### PR TITLE
Install from a prebuilt rootfs image instead of pacstrapping 925 packages

### DIFF
--- a/bin/omarchy-iso-make
+++ b/bin/omarchy-iso-make
@@ -50,6 +50,10 @@ while [[ $# -gt 0 ]]; do
     OMARCHY_MIRROR=edge
     shift
     ;;
+  --no-rootfs-image)
+    OMARCHY_ROOTFS_IMAGE=0
+    shift
+    ;;
   --rc)
     OMARCHY_ISO_REF=rc
     OMARCHY_MIRROR=rc
@@ -57,7 +61,7 @@ while [[ $# -gt 0 ]]; do
     ;;
   *)
     echo "Unknown option: $1"
-    echo "Usage: $0 [--no-cache] [--keep-pkg-cache] [--no-boot-offer] [--debug] [--edge] [--dev|--rc] [--local-source <omarchy-checkout> <pkgs-checkout>]"
+    echo "Usage: $0 [--no-cache] [--keep-pkg-cache] [--no-boot-offer] [--debug] [--edge] [--dev|--rc] [--no-rootfs-image] [--local-source <omarchy-checkout> <pkgs-checkout>]"
     exit 1
     ;;
   esac
@@ -119,6 +123,7 @@ mkdir -p "$BUILD_RELEASE_PATH"
 
 OMARCHY_ISO_REF="${OMARCHY_ISO_REF:-quattro}"
 OMARCHY_MIRROR="${OMARCHY_MIRROR:-stable}"
+OMARCHY_ROOTFS_IMAGE="${OMARCHY_ROOTFS_IMAGE:-1}"
 
 DOCKER_ARGS=(
   --rm
@@ -126,6 +131,7 @@ DOCKER_ARGS=(
   -e "OMARCHY_ISO_REF=$OMARCHY_ISO_REF"
   -e "OMARCHY_MIRROR=$OMARCHY_MIRROR"
   -e "OMARCHY_INSTALL_DEBUG=${OMARCHY_INSTALL_DEBUG:-}"
+  -e "OMARCHY_ROOTFS_IMAGE=$OMARCHY_ROOTFS_IMAGE"
   -e "HOST_UID=$(id -u)"
   -e "HOST_GID=$(id -g)"
   -v "$BUILD_RELEASE_PATH/:/out/"
@@ -148,10 +154,16 @@ fi
 
 # Mount the build cache directory where packages are downloaded. Channels use
 # different package snapshots and must never share an offline mirror cache.
+#
+# Mounted at a neutral path, NOT at the profile's airootfs mirror path
+# (/var/cache/airootfs/var/cache/omarchy): the shipped mirror is pruned to the
+# hardware-conditional closure before mkarchiso runs, and pruning a mount of
+# the host cache would prune the host cache. The host dir keeps its historical
+# name so existing caches stay warm.
 if [[ -z "$NO_CACHE" ]]; then
   OFFLINE_REPO_BUILD_CACHE_DIR="$HOME/.cache/omarchy/iso_${OMARCHY_MIRROR}/airootfs/var/cache/omarchy"
   mkdir -p "$OFFLINE_REPO_BUILD_CACHE_DIR"
-  DOCKER_ARGS+=(-v "$OFFLINE_REPO_BUILD_CACHE_DIR:/var/cache/airootfs/var/cache/omarchy")
+  DOCKER_ARGS+=(-v "$OFFLINE_REPO_BUILD_CACHE_DIR:/var/cache/omarchy-build")
 else
   # The locally cached :latest image is a cache too — docker run never
   # re-checks the registry for it, so refresh it when building cold.

--- a/builder/build-iso.sh
+++ b/builder/build-iso.sh
@@ -524,6 +524,12 @@ build_rootfs_image() {
     echo "Rootfs image carries $package_count packages."
   fi
 
+  # Variant stamp the orchestrator keys install-mode decisions off. Distinct
+  # from the image file itself so a missing image on an image ISO fails before
+  # any disk write instead of falling back to a pacstrap the pruned mirror
+  # cannot feed.
+  echo omarchy-rootfs.sfs >"$iso_share_dir/rootfs-image-build"
+
   # ── Pruned shipped mirror: only what install time can still ask for. ──
   # Resolve with the resolver that answers the question at install time — the
   # image's own pacman db: the hardware-conditional pool omarchy-apply-system

--- a/builder/build-iso.sh
+++ b/builder/build-iso.sh
@@ -493,8 +493,10 @@ build_rootfs_image() {
 
   # The outer airootfs squashfs stores this file uncompressed (see
   # profiledef.sh), so this is the only compression pass it gets.
+  # -exit-on-error because source-read and metadata failures otherwise only
+  # warn, and a silently degraded image would ship.
   mksquashfs "$rootfs_dir" "$rootfs_sfs_dir/omarchy-rootfs.sfs" \
-    -comp zstd -Xcompression-level 19 -b 1M -noappend -xattrs
+    -comp zstd -Xcompression-level 19 -b 1M -noappend -xattrs -exit-on-error
 
   pacman --root "$rootfs_dir" --dbpath "$rootfs_dir/var/lib/pacman" -Q |
     LC_ALL=C sort >"$iso_share_dir/rootfs-manifest"

--- a/builder/build-iso.sh
+++ b/builder/build-iso.sh
@@ -351,8 +351,9 @@ resolve_expected_packages() {
 # build time, ship it as a zstd squashfs, and let the installer restore it with
 # multithreaded unsquashfs instead of replaying ~925 pacman extractions. The
 # shipped mirror then only carries the hardware-conditional closure
-# (omarchy-other.packages ∪ {linux-t2, tailscale}) that install time can still
-# ask for. Everything here runs after repo-add so the full mirror is indexed.
+# (omarchy-other.packages ∪ {linux-t2, tailscale, brltty, espeakup,
+# alsa-utils}) that install time can still ask for. Everything here runs after
+# repo-add so the full mirror is indexed.
 # ─────────────────────────────────────────────────────────────────────────────
 build_rootfs_image() {
   local rootfs_dir=/tmp/omarchy-target-rootfs
@@ -533,8 +534,10 @@ build_rootfs_image() {
   # ── Pruned shipped mirror: only what install time can still ask for. ──
   # Resolve with the resolver that answers the question at install time — the
   # image's own pacman db: the hardware-conditional pool omarchy-apply-system
-  # draws from (omarchy-other.packages) plus the two orchestrator-side
-  # conditionals, with their not-yet-installed dependency closure.
+  # draws from (omarchy-other.packages) plus the orchestrator-side
+  # conditionals — linux-t2/tailscale, and the screen-reader stack the
+  # accessibility=on boot entry needs — with their not-yet-installed
+  # dependency closure.
   #
   # Deliberately NOT --needed: pool members already baked into the image
   # (e.g. sof-firmware, also in archinstall.packages) must KEEP their db
@@ -545,7 +548,7 @@ build_rootfs_image() {
   mapfile -t conditional_targets < <(
     {
       grep -hv '^#\|^$' "$iso_share_dir/omarchy-other.packages"
-      printf '%s\n' linux-t2 tailscale
+      printf '%s\n' linux-t2 tailscale brltty espeakup alsa-utils
     } | sort -u
   )
   if ! resolved_conditionals="$(

--- a/builder/build-iso.sh
+++ b/builder/build-iso.sh
@@ -4,6 +4,10 @@ set -e
 
 OMARCHY_ISO_REF="${OMARCHY_ISO_REF:-quattro}"
 OMARCHY_MIRROR="${OMARCHY_MIRROR:-stable}"
+# 1 (default): bake the target system into a prebuilt rootfs squashfs and ship
+# a mirror pruned to the hardware-conditional closure. 0: legacy-equivalent ISO
+# (full mirror, no image) for A/B comparison and same-day escape.
+OMARCHY_ROOTFS_IMAGE="${OMARCHY_ROOTFS_IMAGE:-1}"
 
 # Edge, dev, and local-source ISOs install the dev packages explicitly. Those
 # package recipes track the quattro branch. This avoids relying on pacman's
@@ -48,9 +52,14 @@ if ! grep -q '^\[omarchy\]' /etc/pacman.conf; then
   awk '/^\[omarchy\]/,/^$/' /configs/pacman-online-${OMARCHY_MIRROR}.conf >> /etc/pacman.conf
 fi
 
-# Build locations
+# Build locations. $build_cache_dir is the mkarchiso profile dir. Package
+# downloads land in $download_cache_dir (host-mounted by omarchy-iso-make at a
+# neutral path), NOT inside the profile's airootfs: the shipped mirror is
+# pruned to the hardware-conditional closure before mkarchiso runs, and pruning
+# a mount of the host cache would prune the host cache.
 build_cache_dir=/var/cache
-offline_mirror_dir="$build_cache_dir/airootfs/var/cache/omarchy/mirror/offline"
+download_cache_dir=/var/cache/omarchy-build
+offline_mirror_dir="$download_cache_dir/mirror/offline"
 mkdir -p "$build_cache_dir" "$offline_mirror_dir"
 
 # Seed from the official Arch releng profile.
@@ -120,6 +129,14 @@ cp "/tmp/$NODE_FILENAME" "$build_cache_dir/airootfs/opt/packages/"
 # live initramfs.
 arch_packages=(linux-t2 git gum jq openssl plymouth ttfx tzupdate omarchy-keyring "$OMARCHY_SETTINGS_PACKAGE" lvm2 cryptsetup parted)
 printf '%s\n' "${arch_packages[@]}" >> "$build_cache_dir/packages.x86_64"
+
+# The installer restores the prebuilt rootfs image with unsquashfs. releng has
+# shipped squashfs-tools for years, but the archiso submodule isn't checked out
+# on the host, so assert rather than assume: a live environment without
+# unsquashfs could only pacstrap. Appended before the offline-mirror package
+# collection below so the live pacstrap can actually resolve it.
+grep -qx 'squashfs-tools' "$build_cache_dir/packages.x86_64" ||
+  echo 'squashfs-tools' >> "$build_cache_dir/packages.x86_64"
 
 # The live ISO boots linux-t2 (see airootfs/etc/mkinitcpio.d/linux-t2.preset), so
 # stock linux is a second kernel nobody boots: ~147MB of ISO, plus its own archiso
@@ -274,15 +291,21 @@ printf '%s\n' "${required_package_files[@]}" |
 rm -f "$offline_mirror_dir"/offline.db* "$offline_mirror_dir"/offline.files*
 repo-add "$offline_mirror_dir/offline.db.tar.gz" "$offline_mirror_dir/"*.pkg.tar.zst
 
-# mkarchiso expects the mirror at /var/cache/omarchy/mirror/offline inside the
-# container (the airootfs path); symlink rather than duplicate.
+# pacman-offline.conf resolves [offline] at /var/cache/omarchy/mirror/offline.
+# Everything that runs against it at BUILD time — the rootfs pacstrap, the
+# expected-package resolvers, and mkarchiso's live-environment pacstrap — must
+# see the FULL mirror in the download cache; symlink rather than duplicate.
+# What ships in the ISO's airootfs at that same path is a separate, real
+# directory (pruned conditional closure, or a full copy for the legacy build).
 mkdir -p /var/cache/omarchy/mirror
 ln -sf "$offline_mirror_dir" /var/cache/omarchy/mirror/offline
 
-# Denominator for the install dashboard's progress bar. Resolving the mirror's
-# own package lists against the mirror we just indexed, with an empty local db,
-# is the question pacstrap asks at install time — same resolver, same repo, same
-# lists — so no hand-kept constant can drift.
+# Denominator for the install dashboard's progress bar, LEGACY VARIANT ONLY
+# (the rootfs-image build counts its local db directly — see
+# build_rootfs_image). Resolving the mirror's own package lists against the
+# mirror we just indexed, with an empty local db, is the question pacstrap asks
+# at install time — same resolver, same repo, same lists — so no hand-kept
+# constant can drift.
 #
 # It over-counts by ~1 in 925: archinstall.packages lists both amd-ucode and
 # intel-ucode because the mirror must contain either. phases.py records expected
@@ -323,24 +346,270 @@ resolve_expected_packages() {
   printf '%s\n' "$resolved" | sort -u | grep -c .
 }
 
-# Worth failing the build over: -S --print only aborts when a target is missing
-# from the offline repo, which would fail pacstrap the same way. A count that
-# merely looks wrong is not — the dashboard falls back without the file.
-if ! expected_packages="$(resolve_expected_packages)"; then
-  echo "ERROR: could not resolve the target package count from the offline mirror." >&2
-  echo "       pacman -S --print aborts the whole transaction if any single target" >&2
-  echo "       is missing, so this almost certainly means pacstrap would fail the" >&2
-  echo "       same way at install time." >&2
-  exit 1
-fi
-if (( expected_packages < 600 || expected_packages > 2000 )); then
-  echo "WARNING: resolved target package count $expected_packages is outside the" >&2
-  echo "         expected 600-2000 range; shipping no denominator so the install" >&2
-  echo "         dashboard falls back to its time-based curve." >&2
+# ─────────────────────────────────────────────────────────────────────────────
+# Prebuilt target rootfs image: pacstrap the full target package set NOW, at
+# build time, ship it as a zstd squashfs, and let the installer restore it with
+# multithreaded unsquashfs instead of replaying ~925 pacman extractions. The
+# shipped mirror then only carries the hardware-conditional closure
+# (omarchy-other.packages ∪ {linux-t2, tailscale}) that install time can still
+# ask for. Everything here runs after repo-add so the full mirror is indexed.
+# ─────────────────────────────────────────────────────────────────────────────
+build_rootfs_image() {
+  local rootfs_dir=/tmp/omarchy-target-rootfs
+  local rootfs_sfs_dir="$build_cache_dir/airootfs/var/cache/omarchy/rootfs"
+  local rootfs_pacman_conf=/tmp/pacman-rootfs.conf
+  local iso_share_dir="$build_cache_dir/airootfs/usr/share/omarchy-iso"
+  local -a rootfs_packages deferred_boot_hooks conditional_targets
+  local hook resolved_conditionals filename package_count hardlink_conflicts
+  local phases_impl
+  local copied=0
+
+  rm -rf "$rootfs_dir"
+  mkdir -p "$rootfs_dir" "$rootfs_sfs_dir"
+
+  # Target package set: what the legacy install-time flow ends up with, minus
+  # the two install-time conditionals. tailscale is in archinstall.packages so
+  # the MIRROR carries it, but it is only ever installed when an autoinstall
+  # drive stages an auth key — it must never be baked into the image. linux
+  # stays baked; the T2 kernel swap happens at install time against the pruned
+  # mirror. rootfs-extra.packages covers what archinstall used to add at
+  # install time (early bootstrap extras, LuaRocks split, zram-generator,
+  # the PipeWire application set).
+  mapfile -t rootfs_packages < <(
+    {
+      grep -hv '^#\|^$' /builder/archinstall.packages | grep -vx 'tailscale'
+      grep -hv '^#\|^$' "$iso_share_dir/omarchy-base.packages"
+      grep -hv '^#\|^$' /builder/rootfs-extra.packages
+      printf '%s\n' "$OMARCHY_RUNTIME_PACKAGE" "$OMARCHY_SETTINGS_PACKAGE" \
+        "$OMARCHY_NVIM_PACKAGE"
+    } | sort -u
+  )
+
+  # Point pacman's CacheDir at the mirror itself so pacstrap -c consumes the
+  # package files in place instead of copying ~3GB through the container's
+  # /var/cache/pacman/pkg — the same trick _mount_offline_package_cache plays
+  # at install time. Nothing is ever downloaded INTO it: every resolved file
+  # is already there.
+  sed '/^\[options\]/a CacheDir = /var/cache/omarchy/mirror/offline/' \
+    "$build_cache_dir/pacman-offline.conf" >"$rootfs_pacman_conf"
+
+  # Mask the same hooks the installer masks around its pacstrap: no initramfs
+  # or UKI is built into the image, leaving the identical end state to the
+  # legacy masked pacstrap — finalize_limine_boot's limine-update builds the
+  # UKI from exactly this state at install time. Masks go in the CONTAINER's
+  # /etc/pacman.d/hooks (config-dir hooks override same-named hooks from the
+  # target's /usr/share/libalpm/hooks) and MUST come off before mkarchiso: the
+  # live environment's initramfs is built by these very hooks during
+  # mkarchiso's own pacstrap.
+  #
+  # The single source of truth is DEFERRED_BOOT_HOOKS in
+  # orchestrator/phases_impl.py — extracted, not copied, so a hook added there
+  # cannot silently bake a boot artifact into the image that the install-time
+  # flow defers. The count guard turns a format change into a build failure
+  # instead of an empty mask list.
+  phases_impl="$build_cache_dir/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py"
+  mapfile -t deferred_boot_hooks < <(
+    sed -n '/^DEFERRED_BOOT_HOOKS = (/,/^)/p' "$phases_impl" |
+      grep -oE '"[^"]+\.hook"' | tr -d '"'
+  )
+  if (( ${#deferred_boot_hooks[@]} < 5 )); then
+    echo "ERROR: extracted only ${#deferred_boot_hooks[@]} entries of DEFERRED_BOOT_HOOKS" >&2
+    echo "       from $phases_impl; expected at least 5. Fix the extraction in" >&2
+    echo "       build-iso.sh to match the tuple's current formatting." >&2
+    exit 1
+  fi
+  mkdir -p /etc/pacman.d/hooks
+  for hook in "${deferred_boot_hooks[@]}"; do
+    ln -sf /dev/null "/etc/pacman.d/hooks/$hook"
+  done
+
+  echo "Building target rootfs image (${#rootfs_packages[@]} package targets)..."
+  # -G: never copy the container keyring (installs init a per-machine one);
+  # -M: target keeps the stock mirrorlist (set_mirrors rewrites it on target).
+  pacstrap -C "$rootfs_pacman_conf" -c -G -M "$rootfs_dir" "${rootfs_packages[@]}"
+
+  for hook in "${deferred_boot_hooks[@]}"; do
+    rm -f "/etc/pacman.d/hooks/$hook"
+  done
+
+  # ── Scrub/normalize: nothing machine-specific may ship in the image. ──
+
+  # Empty machine-id; the installer writes a fresh one per machine with
+  # systemd-machine-id-setup right after the restore.
+  : >"$rootfs_dir/etc/machine-id"
+  if [[ -f "$rootfs_dir/var/lib/dbus/machine-id" && ! -L "$rootfs_dir/var/lib/dbus/machine-id" ]]; then
+    rm -f "$rootfs_dir/var/lib/dbus/machine-id"
+  fi
+
+  # Never ship a shared pacman keyring key. pacstrap -G already skipped the
+  # copy; remove whatever a scriptlet may have seeded anyway.
+  rm -rf "$rootfs_dir/etc/pacman.d/gnupg"
+
+  # sshd host keys are generated at first boot by sshdgenkeys, never at
+  # pacstrap. If any show up here, something fundamental changed — every
+  # install would ship the same private host keys. Stop the build.
+  if compgen -G "$rootfs_dir/etc/ssh/ssh_host_*" >/dev/null; then
+    echo "ERROR: rootfs image contains SSH host keys; refusing to ship them" >&2
+    exit 1
+  fi
+
+  # Locale is baked: both configurator JSONs hardcode en_US.UTF-8, and
+  # archinstall's minimal_installation wrote locale.gen AND locale.conf — do
+  # both for parity. The keymap stays install-time (configure_keyboard).
+  sed -i 's/^#\(en_US\.UTF-8 UTF-8\)/\1/' "$rootfs_dir/etc/locale.gen"
+  arch-chroot "$rootfs_dir" locale-gen
+  echo 'LANG=en_US.UTF-8' >"$rootfs_dir/etc/locale.conf"
+
+  # CacheDir pointed at the mirror, so nothing may have landed here: cached
+  # packages inside the image would be dead weight in every install.
+  if [[ -n $(find "$rootfs_dir/var/cache/pacman/pkg" -mindepth 1 -print -quit 2>/dev/null) ]]; then
+    echo "ERROR: rootfs image has a non-empty /var/cache/pacman/pkg" >&2
+    exit 1
+  fi
+
+  # unsquashfs recreates hardlinks with link(2), and the restore target splits
+  # /home, /var/log and /var/cache/pacman/pkg into separate btrfs subvolumes —
+  # a hardlink pair crossing one of those boundaries would EXDEV mid-restore.
+  # No package is expected to do this; fail loudly if one starts to.
+  hardlink_conflicts=$(
+    cd "$rootfs_dir" && find . -type f -links +1 -printf '%i\t%p\n' |
+      LC_ALL=C sort -n | awk -F'\t' '
+        {
+          zone = "root"
+          if (index($2, "./home/") == 1) zone = "home"
+          else if (index($2, "./var/log/") == 1) zone = "log"
+          else if (index($2, "./var/cache/pacman/pkg/") == 1) zone = "pkg"
+          if ($1 == prev_inode && zone != prev_zone) print $2
+          prev_inode = $1; prev_zone = zone
+        }'
+  )
+  if [[ -n $hardlink_conflicts ]]; then
+    echo "ERROR: rootfs image has hardlinks crossing subvolume boundaries:" >&2
+    printf '%s\n' "$hardlink_conflicts" | sed 's/^/  /' >&2
+    exit 1
+  fi
+
+  # ── Image + metadata ──
+
+  # The outer airootfs squashfs stores this file uncompressed (see
+  # profiledef.sh), so this is the only compression pass it gets.
+  mksquashfs "$rootfs_dir" "$rootfs_sfs_dir/omarchy-rootfs.sfs" \
+    -comp zstd -Xcompression-level 19 -b 1M -noappend -xattrs
+
+  pacman --root "$rootfs_dir" --dbpath "$rootfs_dir/var/lib/pacman" -Q |
+    LC_ALL=C sort >"$iso_share_dir/rootfs-manifest"
+  if grep -q '^tailscale ' "$iso_share_dir/rootfs-manifest"; then
+    echo "ERROR: tailscale leaked into the rootfs image; it must stay an" >&2
+    echo "       install-time conditional (autoinstall auth key only)." >&2
+    exit 1
+  fi
+  if ! grep -q '^linux ' "$iso_share_dir/rootfs-manifest"; then
+    echo "ERROR: the rootfs image does not contain the linux kernel" >&2
+    exit 1
+  fi
+
+  # Denominator for the install dashboard: the restored image IS the installed
+  # set, so count its local db entries (one directory per package). Same
+  # 600-2000 sanity gate as the legacy resolver: a wrong denominator is worse
+  # than none, because it never triggers the dashboard's fallback.
+  package_count=$(find "$rootfs_dir/var/lib/pacman/local" -mindepth 1 -maxdepth 1 -type d | wc -l)
+  if (( package_count < 600 || package_count > 2000 )); then
+    echo "WARNING: rootfs image package count $package_count is outside the" >&2
+    echo "         expected 600-2000 range; shipping no denominator so the install" >&2
+    echo "         dashboard falls back to its time-based curve." >&2
+  else
+    printf '%s\n' "$package_count" >"$iso_share_dir/expected-packages"
+    echo "Rootfs image carries $package_count packages."
+  fi
+
+  # ── Pruned shipped mirror: only what install time can still ask for. ──
+  # Resolve with the resolver that answers the question at install time — the
+  # image's own pacman db: the hardware-conditional pool omarchy-apply-system
+  # draws from (omarchy-other.packages) plus the two orchestrator-side
+  # conditionals, with their not-yet-installed dependency closure.
+  #
+  # Deliberately NOT --needed: pool members already baked into the image
+  # (e.g. sof-firmware, also in archinstall.packages) must KEEP their db
+  # entries and files in the shipped repo. After the install-time resync,
+  # apply-system may run `pacman -S --needed <member>` — pacman resolves
+  # against the sync db before --needed can no-op, so a pruned-out name fails
+  # "target not found" even though the package is already installed.
+  mapfile -t conditional_targets < <(
+    {
+      grep -hv '^#\|^$' "$iso_share_dir/omarchy-other.packages"
+      printf '%s\n' linux-t2 tailscale
+    } | sort -u
+  )
+  if ! resolved_conditionals="$(
+    pacman --config "$build_cache_dir/pacman-offline.conf" \
+      --root "$rootfs_dir" --dbpath "$rootfs_dir/var/lib/pacman" \
+      --noconfirm -S --print --print-format '%f' \
+      "${conditional_targets[@]}"
+  )"; then
+    echo "ERROR: could not resolve the hardware-conditional package closure" >&2
+    echo "       against the rootfs image. omarchy-apply-system would fail to" >&2
+    echo "       install from the pruned mirror the same way at install time." >&2
+    exit 1
+  fi
+
+  while IFS= read -r filename; do
+    [[ -n $filename ]] || continue
+    if [[ ! -f "$offline_mirror_dir/$filename" ]]; then
+      echo "ERROR: resolved conditional package missing from the mirror: $filename" >&2
+      exit 1
+    fi
+    cp "$offline_mirror_dir/$filename" "$shipped_mirror_dir/"
+    if [[ -f "$offline_mirror_dir/$filename.sig" ]]; then
+      cp "$offline_mirror_dir/$filename.sig" "$shipped_mirror_dir/"
+    fi
+    copied=$((copied + 1))
+  done < <(printf '%s\n' "$resolved_conditionals" | sort -u)
+  if (( copied == 0 )); then
+    echo "ERROR: pruned mirror selection is empty; refusing to ship a mirror" >&2
+    echo "       with no packages (linux-t2 alone should always resolve)" >&2
+    exit 1
+  fi
+  echo "Pruned shipped mirror carries $copied conditional package files."
+
+  # Fresh db over exactly the shipped files, same as the full-mirror repo-add.
+  repo-add "$shipped_mirror_dir/offline.db.tar.gz" "$shipped_mirror_dir/"*.pkg.tar.zst
+
+  # Free the Docker VM disk before mkarchiso doubles the airootfs into work/.
+  rm -rf "$rootfs_dir" "$rootfs_pacman_conf"
+}
+
+# What ships at the airootfs mirror path is now always a real directory built
+# per-variant: the pruned conditional closure (image builds) or a full copy of
+# the download cache (legacy builds — the cache is no longer mounted at this
+# path, so shipping the full mirror is an explicit ~3GB copy).
+shipped_mirror_dir="$build_cache_dir/airootfs/var/cache/omarchy/mirror/offline"
+mkdir -p "$shipped_mirror_dir"
+
+if [[ $OMARCHY_ROOTFS_IMAGE == "1" ]]; then
+  build_rootfs_image
 else
-  printf '%s\n' "$expected_packages" \
-    >"$build_cache_dir/airootfs/usr/share/omarchy-iso/expected-packages"
-  echo "Target install resolves to $expected_packages packages."
+  echo "OMARCHY_ROOTFS_IMAGE=0: shipping the full offline mirror, no rootfs image."
+  cp -a "$offline_mirror_dir/." "$shipped_mirror_dir/"
+
+  # Worth failing the build over: -S --print only aborts when a target is missing
+  # from the offline repo, which would fail pacstrap the same way. A count that
+  # merely looks wrong is not — the dashboard falls back without the file.
+  if ! expected_packages="$(resolve_expected_packages)"; then
+    echo "ERROR: could not resolve the target package count from the offline mirror." >&2
+    echo "       pacman -S --print aborts the whole transaction if any single target" >&2
+    echo "       is missing, so this almost certainly means pacstrap would fail the" >&2
+    echo "       same way at install time." >&2
+    exit 1
+  fi
+  if (( expected_packages < 600 || expected_packages > 2000 )); then
+    echo "WARNING: resolved target package count $expected_packages is outside the" >&2
+    echo "         expected 600-2000 range; shipping no denominator so the install" >&2
+    echo "         dashboard falls back to its time-based curve." >&2
+  else
+    printf '%s\n' "$expected_packages" \
+      >"$build_cache_dir/airootfs/usr/share/omarchy-iso/expected-packages"
+    echo "Target install resolves to $expected_packages packages."
+  fi
 fi
 
 # Live ISO uses the same offline pacman.conf.

--- a/builder/rootfs-extra.packages
+++ b/builder/rootfs-extra.packages
@@ -1,0 +1,27 @@
+# Packages the legacy install-time flow added on top of archinstall.packages +
+# omarchy-base.packages, baked into the prebuilt rootfs image instead.
+# base-devel, omarchy-keyring, limine and efibootmgr are NOT restated here —
+# archinstall.packages already carries them.
+
+# EARLY_BOOTSTRAP_BASE_PACKAGES (orchestrator/phases_impl.py)
+git
+
+# EARLY_LUAROCKS_PACKAGES: baking both in one transaction is safe — the
+# ordering hazard the legacy split avoided only exists when lua51-lpeg lands
+# before luarocks, and pacman orders by dependency within a transaction.
+lua51
+luarocks
+
+# installer.setup_swap used to install this; omarchy-settings ships the tuning
+# as a vendor drop-in, so no /etc config is needed.
+zram-generator
+
+# archinstall's PipeWire application set (ApplicationHandler). Verify against
+# the archinstall release on the ISO when bumping the archiso submodule.
+pipewire
+pipewire-alsa
+pipewire-pulse
+pipewire-jack
+wireplumber
+gst-plugin-pipewire
+libpulse

--- a/configs/airootfs/root/.automated_script.sh
+++ b/configs/airootfs/root/.automated_script.sh
@@ -57,28 +57,47 @@ if [[ ${OMARCHY_INSTALL_DEBUG:-} == "1" ]]; then
   echo "================================"
 fi
 
-# Warm the page cache for the bundled packages while the user works through the
-# wizard. The install reads ~3GB out of the offline mirror, and pacman consumes
-# it at only ~33MB/s, so on media slower than that the install is read-bound and
-# every byte cached here is a byte it never waits for. On faster media this costs
-# nothing but otherwise-idle bandwidth: the medium is untouched while the user
-# types, and the target disk it writes to later is a different device.
+# Warm the page cache for the bundled install payload while the user works
+# through the wizard. On rootfs-image ISOs the dominant read is the ~3GB
+# rootfs squashfs (restored sequentially by unsquashfs); on legacy ISOs it is
+# the offline mirror, which pacman consumes at only ~33MB/s. On media slower
+# than the consumer the install is read-bound and every byte cached here is a
+# byte it never waits for. On faster media this costs nothing but
+# otherwise-idle bandwidth: the medium is untouched while the user types, and
+# the target disk it writes to later is a different device.
 #
 # Clean page cache only, so the kernel reclaims it under pressure instead of
 # OOMing, and a budget so small machines never evict what was just warmed.
 # Set OMARCHY_NO_PREFETCH=1 to A/B the same ISO with this disabled.
 warm_offline_mirror() {
   local mirror=/var/cache/omarchy/mirror/offline
-  local budget_kb spent_kb=0 size_kb path
+  local rootfs_image=/var/cache/omarchy/rootfs/omarchy-rootfs.sfs
+  local budget_kb spent_kb=0 size_kb read_kb path
 
   [[ ${OMARCHY_NO_PREFETCH:-} == 1 ]] && return 0
-  [[ -d $mirror ]] || return 0
+  [[ -d $mirror || -f $rootfs_image ]] || return 0
 
   budget_kb=$(($(awk '/^MemAvailable:/ { print $2 }' /proc/meminfo) / 2))
   ((budget_kb > 262144)) || return 0
 
-  # Largest first: the install reads most of the mirror, so when the budget
-  # cannot cover all of it this still front-loads the bytes that dominate.
+  # The rootfs image first — it is the dominant read of the whole install,
+  # and unsquashfs consumes it front-to-back, so on a machine whose budget
+  # cannot hold the whole image a head-warm of whatever DOES fit still beats
+  # spending the budget on hardware-conditional packages most machines never
+  # read. Never skip it outright.
+  if [[ -f $rootfs_image ]]; then
+    size_kb=$(du -k "$rootfs_image" | awk '{print $1}')
+    read_kb=$((budget_kb - spent_kb))
+    ((read_kb > size_kb)) && read_kb=$size_kb
+    if ((read_kb > 0)); then
+      head -c "$((read_kb * 1024))" "$rootfs_image" >/dev/null 2>&1 || true
+      spent_kb=$((spent_kb + read_kb))
+    fi
+  fi
+
+  # Then the (pruned) mirror packages, largest first: when the remaining
+  # budget cannot cover all of them this still front-loads the bytes that
+  # dominate.
   while read -r size_kb path; do
     ((spent_kb + size_kb > budget_kb)) && continue
     cat -- "$path" >/dev/null 2>&1 || true
@@ -115,7 +134,10 @@ fi
 # the actual installer as a non-interactive child, logs child output, waits for
 # completion, then renders the final installed-time/reboot prompt itself.
 export OMARCHY_DASHBOARD_TTY="$(tty)"
-rm -f /run/omarchy-install/state.json
+# restore-progress too: the dashboard trusts that file from phase entry, so a
+# retry after a failed attempt must not inherit the previous attempt's
+# terminal percentage and pin the bar there.
+rm -f /run/omarchy-install/state.json /run/omarchy-install/restore-progress
 /usr/local/bin/omarchy-install-dashboard \
   "$OMARCHY_INSTALL_LOG_FILE" \
   /run/omarchy-install/state.json \

--- a/configs/airootfs/usr/local/bin/omarchy-install-dashboard
+++ b/configs/airootfs/usr/local/bin/omarchy-install-dashboard
@@ -171,8 +171,13 @@ FINISH_TOP_ROW=2
 #   floor  lo + (span-1) * t / (t+tau), on time since this process saw the
 #          phase. Asymptotic, so it approaches the band end without reaching it.
 #          tau is a shape constant, not a duration prediction.
-#   work   packages installed / PKG_TOTAL, for the package phase only (~85% of
-#          the install). libalpm makes one directory per package under
+#   work   for the package phase only. On rootfs-image ISOs the orchestrator
+#          streams unsquashfs -percentage into RESTORE_PROGRESS_FILE and that
+#          percentage IS the work signal — preferred whenever the file exists,
+#          because on image ISOs BOTH signals are present (expected-packages
+#          still ships for phases.py accounting) and the package count only
+#          moves once unsquashfs reaches var/lib/. Otherwise: packages
+#          installed / PKG_TOTAL. libalpm makes one directory per package under
 #          <target>/var/lib/pacman/local; the denominator comes from
 #          build-iso.sh, so there is no second package list to drift.
 #
@@ -181,6 +186,10 @@ FINISH_TOP_ROW=2
 # curves behind a monotonic clamp freeze. With no signal the floor alone still
 # finishes the band.
 EXPECTED_PACKAGES_FILE="${OMARCHY_EXPECTED_PACKAGES_FILE:-/usr/share/omarchy-iso/expected-packages}"
+RESTORE_PROGRESS_FILE="${OMARCHY_RESTORE_PROGRESS_FILE:-/run/omarchy-install/restore-progress}"
+# Presence of the shipped image is what tells this ISO apart from a legacy
+# (full-mirror pacstrap) build; the bands are rebalanced off it below.
+ROOTFS_IMAGE_FILE=/var/cache/omarchy/rootfs/omarchy-rootfs.sfs
 PKG_TOTAL=0
 if [[ -r $EXPECTED_PACKAGES_FILE ]]; then
   read -r PKG_TOTAL _ <"$EXPECTED_PACKAGES_FILE" 2>/dev/null || PKG_TOTAL=0
@@ -207,6 +216,7 @@ PKG_BASE=-1            # package count when the phase started
 PKG_SEEN=0             # running max of packages since PKG_BASE
 PKG_LAST_CHANGE=0
 PKG_BONUS=0
+RESTORE_SEEN=0         # running max of the unsquashfs restore percentage
 
 # Monotonic clock: tzupdate and systemd-timesyncd can step the wall clock
 # mid-install, which would jump every time-driven band to its ceiling.
@@ -293,7 +303,7 @@ count_packages() {
 # here would land on the TTY between the cursor escape and the bar.
 install_progress() {
   local phase finished index total target
-  local lo hi tau span t pos work gap n pkg_signal=0
+  local lo hi tau span t pos work gap n pct pkg_signal=0 restore_signal=0
   local -a state
 
   PROGRESS_PM=$POS
@@ -327,6 +337,7 @@ install_progress() {
     PKG_SEEN=0
     PKG_BONUS=0
     PKG_LAST_CHANGE=$NOW
+    RESTORE_SEEN=0
   fi
 
   # Bands in per-mille, plus tau. The tail bands are wide relative to what they
@@ -362,8 +373,33 @@ install_progress() {
       ;;
   esac
 
+  # Rootfs-image ISOs restore a prebuilt squashfs instead of replaying ~925
+  # pacman transactions, so the package phase shrinks from ~64-85% of the
+  # install to roughly a third, and the tail phases dominate. Rebalance the
+  # named bands; unknown phases keep the index-derived fallback above.
+  # First cut per plan — recalibrate from timing JSON of real runs.
+  if [[ -f $ROOTFS_IMAGE_FILE ]]; then
+    case "$phase" in
+      "Installing Arch + Omarchy")  lo=65  hi=500  tau=150 ;;
+      "Configuring hibernation")    lo=500 hi=520  tau=10  ;;
+      "Configuring system")         lo=520 hi=780  tau=120 ;;
+      "Staging provisioning")       lo=780 hi=785  tau=5   ;;
+      "Finalizing Limine boot")     lo=785 hi=930  tau=90  ;;
+      "Finalizing user")            lo=930 hi=970  tau=30  ;;
+      "Configuring login")          lo=970 hi=985  tau=5   ;;
+    esac
+  fi
+
+  # Prefer the restore percentage whenever the orchestrator is streaming it:
+  # on image ISOs both signal sources exist (expected-packages still ships for
+  # phases.py accounting), so file existence alone is not a valid gate for the
+  # package-count path.
+  if (( pkg_signal )) && [[ -f $RESTORE_PROGRESS_FILE ]]; then
+    restore_signal=1
+    pkg_signal=0
+  fi
   (( pkg_signal && PKG_TOTAL > 0 )) || pkg_signal=0
-  (( pkg_signal )) && tau=$PKG_FLOOR_TAU
+  (( pkg_signal || restore_signal )) && tau=$PKG_FLOOR_TAU
 
   t=$(( NOW - PHASE_T0 ))
   (( t < 0 )) && t=0
@@ -373,7 +409,19 @@ install_progress() {
 
   pos=$(( lo + (span - 1) * t / (t + tau) ))
 
-  if (( pkg_signal )); then
+  if (( restore_signal )); then
+    # The orchestrator rewrites the file atomically with the latest unsquashfs
+    # percentage. Running max, same reasoning as PKG_SEEN, and the same
+    # PKG_TAIL_PM holdback so the band never pins before the phase ends. No
+    # bonus machinery: the percentage is continuous, not bursty.
+    read -r pct _ <"$RESTORE_PROGRESS_FILE" 2>/dev/null || pct=""
+    if [[ $pct =~ ^[0-9]+$ ]]; then
+      (( pct > 100 )) && pct=100
+      (( pct > RESTORE_SEEN )) && RESTORE_SEEN=$pct
+      work=$(( lo + (span - 1 - PKG_TAIL_PM) * RESTORE_SEEN / 100 ))
+      (( work > pos )) && pos=$work
+    fi
+  elif (( pkg_signal )); then
     PKG_DB_DIR="$target/var/lib/pacman/local"
     count_packages
     # Baseline on first sight: a target that already holds packages would

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/archinstall_adapter.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/archinstall_adapter.py
@@ -25,6 +25,8 @@ The canonical call sequence (mirrored from archinstall.scripts.guided.py) is:
         inst.activate_time_synchronization()
         inst.set_user_password(root_user)
         inst.enable_service(services)
+        if accessibility_tools_in_use():              # live espeakup running
+            inst.enable_espeakup()
         inst.genfstab()
 
 Our orchestrator installs Omarchy's Limine files directly instead of invoking
@@ -46,7 +48,7 @@ from archinstall.lib.authentication.authentication_handler import Authentication
 from archinstall.lib.disk.filesystem import FilesystemHandler
 from archinstall.lib.disk.utils import get_parent_device_path, get_unique_path_for_device, udev_sync
 from archinstall.lib.hardware import SysInfo
-from archinstall.lib.installer import Installer
+from archinstall.lib.installer import Installer, accessibility_tools_in_use  # noqa: F401
 from archinstall.lib.mirror.mirror_handler import MirrorListHandler
 from archinstall.lib.models import Bootloader
 from archinstall.lib.models.device import DiskLayoutType, EncryptionType

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/main.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/main.py
@@ -10,10 +10,21 @@ archinstall's import-time CLI parsing from seeing Omarchy-specific flags.
 
 from __future__ import annotations
 
+import signal
 import sys
 from .context import InstallContext
 from .phases import PhaseError, run
 from .ui import error, info
+
+
+def _raise_on_sigterm(signum, frame):
+    # The dashboard stops an install by SIGTERMing this process group and
+    # escalates to SIGKILL only after a grace period. Python's default
+    # disposition would exit without unwinding, skipping main()'s
+    # finally-cleanups and the phases' own except paths (e.g. killing the
+    # detached keyring init, which start_new_session puts outside the group
+    # the dashboard kills); raising turns the stop into a normal unwind.
+    raise SystemExit(128 + signum)
 
 
 def build_phases(ctx: InstallContext):
@@ -66,6 +77,7 @@ def build_phases(ctx: InstallContext):
 
 
 def main() -> int:
+    signal.signal(signal.SIGTERM, _raise_on_sigterm)
     try:
         ctx = InstallContext.from_env()
     except RuntimeError as e:

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases.py
@@ -68,7 +68,11 @@ def run(ctx: InstallContext, phases: list[tuple[str, PhaseFn]]) -> None:
     state["current_phase"] = "Installation complete"
     state["finished_at"] = time.time()
     # Expected vs actual for the bar's denominator, so drift is visible in
-    # acceptance runs rather than only by watching a bar creep.
+    # acceptance runs rather than only by watching a bar creep. On rootfs-image
+    # ISOs the expected count is the image's own local-db size (the restore
+    # carries var/lib/pacman/local verbatim) and installed = image count plus
+    # install-time conditionals (tailscale, kernel swap); on legacy ISOs it is
+    # the build-time resolver count as before.
     state["installed_packages"] = _installed_package_count(ctx.target)
     state["expected_packages"] = _expected_package_count()
     _write_state(state_path, state)

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -301,6 +301,11 @@ def arch_install_system(ctx: InstallContext) -> None:
             installer.set_timezone(config.timezone)
         if config.ntp:
             installer.activate_time_synchronization()
+        # guided.py enables this post-install, not minimal_installation, so
+        # BOTH paths need it here (packages: baked set via minimal_installation
+        # on legacy, pruned-mirror install in _rootfs_image_configure on image).
+        if arch.accessibility_tools_in_use():
+            installer.enable_espeakup()
         if root := arch.root_user(config):
             installer.set_user_password(root)
 
@@ -480,9 +485,24 @@ def _rootfs_image_configure(ctx: InstallContext, installer, config, mirror_handl
             info("› installing tailscale (auth key staged for first boot)")
             installer.add_additional_packages(["tailscale"])
             ctx.state["target_db_synced"] = True
+
+        _install_accessibility_tools(ctx, installer)
     finally:
         _unmask_mkinitcpio_pacman_hooks(ctx)
         _unmount_offline_package_cache(ctx)
+
+
+def _install_accessibility_tools(ctx: InstallContext, installer) -> None:
+    """The legacy path gets these from minimal_installation, which extends its
+    base set when the live session runs a screen reader (the accessibility=on
+    boot entry). The image bakes none of them, so install from the pruned
+    mirror while it is still bind-mounted; the shared finishers in
+    arch_install_system enable espeakup on both paths."""
+    if not arch.accessibility_tools_in_use():
+        return
+    info("› installing accessibility stack (brltty espeakup alsa-utils)")
+    installer.add_additional_packages(["brltty", "espeakup", "alsa-utils"])
+    ctx.state["target_db_synced"] = True
 
 
 def _assert_rootfs_image_supported_config(config) -> None:

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -259,9 +259,6 @@ def arch_install_system(ctx: InstallContext) -> None:
             skip_wkd=True,
         )
 
-        if not pre_mounted and arch.is_encrypted(config):
-            installer.generate_key_files()
-
         if config.mirror_config:
             installer.set_mirrors(mirror_handler, config.mirror_config, on_target=False)
 
@@ -286,6 +283,8 @@ def arch_install_system(ctx: InstallContext) -> None:
 
 def _install_via_pacstrap(ctx: InstallContext, installer, config, mirror_handler) -> None:
     """Legacy package-by-package install from the full offline mirror."""
+    if not arch.is_pre_mount(config) and arch.is_encrypted(config):
+        installer.generate_key_files()
     _mount_offline_package_cache(ctx)
     _mask_mkinitcpio_pacman_hooks(ctx)
     try:
@@ -369,6 +368,13 @@ def _install_via_rootfs_image(ctx: InstallContext, installer, config, mirror_han
     """
     _assert_rootfs_image_supported_config(config)
     _restore_rootfs_image(ctx)
+
+    # After the restore, never before: generate_key_files appends non-root
+    # volumes to the target's /etc/crypttab, which the filesystem package owns,
+    # so unsquashfs -f would overwrite it (pacstrap preserves it as a backup=
+    # file, hence the legacy path has no such constraint).
+    if not arch.is_pre_mount(config) and arch.is_encrypted(config):
+        installer.generate_key_files()
 
     info("› writing per-machine identity")
     subprocess.run(["systemd-machine-id-setup", f"--root={ctx.target}"], check=True)

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -418,19 +418,29 @@ def _install_via_rootfs_image(ctx: InstallContext, installer, config, mirror_han
 
     info("› writing per-machine identity")
     subprocess.run(["systemd-machine-id-setup", f"--root={ctx.target}"], check=True)
-    # Backgrounded: nothing during the install consumes the keyring (the
-    # offline repo is SigLevel = Never) and the init is chroot-free, so there
-    # is no mount teardown to race the chroots below. Killed and joined on
-    # every exit path so a failure cannot leak the process, and the original
-    # error always wins over a keyring one.
-    keyring_proc = _start_target_keyring_init(ctx)
+    # Backgrounded: SigLevel = Never means nothing READS the keyring during
+    # the install, and the init is chroot-free, so there is no mount teardown
+    # to race the chroots below. pacstrap -K WRITES the same gnupg dir though
+    # (it runs its own pacman-key --init), so every pacstrap-semantics site
+    # joins via _await_target_keyring_init before touching the target db.
+    # Killed and joined on every exit path so a failure cannot leak the
+    # process, and the original error always wins over a keyring one. The
+    # SIGTERM handler is what makes "every exit path" true under a dashboard
+    # stop: start_new_session puts the init outside the process group the
+    # dashboard kills, and Python's default SIGTERM disposition would end the
+    # orchestrator without unwinding the except path below.
+    prev_sigterm = signal.signal(signal.SIGTERM, _raise_on_sigterm)
     try:
-        _rootfs_image_configure(ctx, installer, config, mirror_handler)
-    except BaseException:
-        _kill_target_keyring_init(keyring_proc)
-        _finish_target_keyring_init(ctx, keyring_proc, raise_on_error=False)
-        raise
-    _finish_target_keyring_init(ctx, keyring_proc, raise_on_error=True)
+        try:
+            _start_target_keyring_init(ctx)
+            _rootfs_image_configure(ctx, installer, config, mirror_handler)
+            _await_target_keyring_init(ctx, raise_on_error=True)
+        except BaseException:
+            _kill_target_keyring_init(ctx)
+            _await_target_keyring_init(ctx, raise_on_error=False)
+            raise
+    finally:
+        signal.signal(signal.SIGTERM, prev_sigterm)
 
 
 def _rootfs_image_configure(ctx: InstallContext, installer, config, mirror_handler) -> None:
@@ -490,6 +500,7 @@ def _rootfs_image_configure(ctx: InstallContext, installer, config, mirror_handl
         # configures the join.
         if ctx.tailscale_authkey_path is not None:
             info("› installing tailscale (auth key staged for first boot)")
+            _await_target_keyring_init(ctx)
             installer.add_additional_packages(["tailscale"])
             ctx.state["target_db_synced"] = True
 
@@ -508,6 +519,7 @@ def _install_accessibility_tools(ctx: InstallContext, installer) -> None:
     if not arch.accessibility_tools_in_use():
         return
     info("› installing accessibility stack (brltty espeakup alsa-utils)")
+    _await_target_keyring_init(ctx)
     installer.add_additional_packages(["brltty", "espeakup", "alsa-utils"])
     ctx.state["target_db_synced"] = True
 
@@ -674,12 +686,21 @@ def _target_gpgdir(ctx: InstallContext) -> Path:
     return ctx.target / "etc" / "pacman.d" / "gnupg"
 
 
-def _start_target_keyring_init(ctx: InstallContext) -> subprocess.Popen:
+def _raise_on_sigterm(signum, frame) -> None:
+    """Installed for the duration of the background keyring init: turns the
+    dashboard's group SIGTERM (its stop escalates to SIGKILL only after a
+    grace period) into an exception so the except-BaseException path kills
+    and joins the detached keyring session instead of leaking it."""
+    raise SystemExit(128 + signum)
+
+
+def _start_target_keyring_init(ctx: InstallContext) -> None:
     """Recreate the per-machine pacman keyring a legacy pacstrap left behind.
 
     The image ships no /etc/pacman.d/gnupg (a shared keyring key must never be
-    distributed). Nothing during the install needs the keyring — the offline
-    repo is SigLevel = Never — but the installed system does.
+    distributed). Nothing during the install READS the keyring — the offline
+    repo is SigLevel = Never — but the installed system does, and pacstrap -K
+    WRITES it (see _await_target_keyring_init).
 
     Chroot-free on purpose: pacman-key --gpgdir writes the target's keyring
     directory directly, reading the live environment's
@@ -697,7 +718,7 @@ def _start_target_keyring_init(ctx: InstallContext) -> subprocess.Popen:
     # start_new_session makes the shell a process-group leader, so
     # _kill_target_keyring_init reaches pacman-key and its gpg children —
     # killing just the sh wrapper would leave them mutating the target keyring.
-    return subprocess.Popen(
+    ctx.state["target_keyring_proc"] = subprocess.Popen(
         ["sh", "-c", script],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -706,11 +727,42 @@ def _start_target_keyring_init(ctx: InstallContext) -> subprocess.Popen:
     )
 
 
-def _kill_target_keyring_init(proc: subprocess.Popen) -> None:
+def _kill_target_keyring_init(ctx: InstallContext) -> None:
+    proc = ctx.state.get("target_keyring_proc")
+    if proc is None:
+        return
     try:
         os.killpg(proc.pid, signal.SIGKILL)
     except ProcessLookupError:
         pass
+
+
+def _await_target_keyring_init(ctx: InstallContext, *, raise_on_error: bool = True) -> None:
+    """Join the background keyring init if it is still pending; no-op after.
+
+    Every pacstrap-semantics install (installer.add_additional_packages) must
+    call this first: pacstrap -K unconditionally runs its own pacman-key
+    --init on the target's gnupg dir — the very directory the background init
+    is writing — and two concurrent inits on one gpg homedir can generate
+    competing master keys or trip over gpg's keybox/trustdb locks. SigLevel =
+    Never only skips keyring reads, not pacstrap's writes. Installs that never
+    pacstrap (default kernel, no tailscale key, no screen reader) keep the
+    full overlap and join at the end of _install_via_rootfs_image."""
+    proc = ctx.state.get("target_keyring_proc")
+    if proc is None:
+        return
+    try:
+        _finish_target_keyring_init(ctx, proc, raise_on_error=raise_on_error)
+    except RuntimeError:
+        # The join completed and the init failed: nothing is left running, so
+        # drop the proc before the error unwinds into the kill path.
+        ctx.state.pop("target_keyring_proc", None)
+        raise
+    # Popped only after a completed join: an interrupting SIGTERM/SIGINT mid
+    # communicate() must leave the proc in state so the exception path in
+    # _install_via_rootfs_image can still kill and re-join it (a joined proc
+    # must never be joined twice — communicate() raises on closed pipes).
+    ctx.state.pop("target_keyring_proc", None)
 
 
 def _finish_target_keyring_init(
@@ -839,6 +891,7 @@ def _reconcile_target_kernel(ctx: InstallContext, installer, config) -> None:
     _mask_mkinitcpio_pacman_hooks(ctx, ctx.target, TARGET_DEFERRED_BOOT_HOOKS)
     try:
         if missing:
+            _await_target_keyring_init(ctx)
             installer.add_additional_packages(missing)
             ctx.state["target_db_synced"] = True
         if drop_linux:

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -830,7 +830,7 @@ def _ensure_target_locale(ctx: InstallContext, config) -> None:
     locale_gen = ctx.target / "etc" / "locale.gen"
     entry = f"{lang} {encoding}\n"
     existing = locale_gen.read_text() if locale_gen.exists() else ""
-    if entry not in existing:
+    if entry.rstrip("\n") not in existing.splitlines():
         with locale_gen.open("a", encoding="utf-8") as f:
             f.write(entry)
     subprocess.run(["arch-chroot", str(ctx.target), "locale-gen"], check=True)

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -371,11 +371,22 @@ def _install_via_rootfs_image(ctx: InstallContext, installer, config, mirror_han
 
     info("› writing per-machine identity")
     subprocess.run(["systemd-machine-id-setup", f"--root={ctx.target}"], check=True)
-    # Synchronous on purpose: the init takes a few seconds and overlapping it
-    # with the rest of the install buys little for the lifecycle bookkeeping
-    # (kill/join on every exit path) it would demand.
-    _init_target_keyring(ctx)
+    # Backgrounded: nothing during the install consumes the keyring (the
+    # offline repo is SigLevel = Never) and the init is chroot-free, so there
+    # is no mount teardown to race the chroots below. Killed and joined on
+    # every exit path so a failure cannot leak the process, and the original
+    # error always wins over a keyring one.
+    keyring_proc = _start_target_keyring_init(ctx)
+    try:
+        _rootfs_image_configure(ctx, installer, config, mirror_handler)
+    except BaseException:
+        keyring_proc.kill()
+        _finish_target_keyring_init(ctx, keyring_proc, raise_on_error=False)
+        raise
+    _finish_target_keyring_init(ctx, keyring_proc, raise_on_error=True)
 
+
+def _rootfs_image_configure(ctx: InstallContext, installer, config, mirror_handler) -> None:
     # Config side-effects minimal_installation used to perform. Locale is
     # baked (en_US.UTF-8 in locale.gen + locale.conf at build time);
     # hostname is ours to write. archinstall's application handler
@@ -561,7 +572,11 @@ def _write_restore_progress(value: str) -> None:
         pass
 
 
-def _init_target_keyring(ctx: InstallContext) -> None:
+def _target_gpgdir(ctx: InstallContext) -> Path:
+    return ctx.target / "etc" / "pacman.d" / "gnupg"
+
+
+def _start_target_keyring_init(ctx: InstallContext) -> subprocess.Popen:
     """Recreate the per-machine pacman keyring a legacy pacstrap left behind.
 
     The image ships no /etc/pacman.d/gnupg (a shared keyring key must never be
@@ -570,34 +585,46 @@ def _init_target_keyring(ctx: InstallContext) -> None:
 
     Chroot-free on purpose: pacman-key --gpgdir writes the target's keyring
     directory directly, reading the live environment's
-    /usr/share/pacman/keyrings (same package snapshot as the target's), so no
-    API mounts are held or torn down. The trailing gpgconf --kill matters:
-    pacman-key leaves gpg-agent/dirmngr holding sockets under the target's
-    gnupg dir, which would keep the target busy at umount time — pacstrap
-    kills them for the same reason.
+    /usr/share/pacman/keyrings (same package snapshot as the target's). With
+    no chroot there are no API mounts to hold or tear down, which is what
+    makes running this in the background safe — an arch-chroot's exit-time
+    teardown unmounts by path and can pop a concurrent chroot's mounts.
     """
-    info("› initializing per-machine pacman keyring")
-    gpgdir = ctx.target / "etc" / "pacman.d" / "gnupg"
-    quoted = shlex.quote(str(gpgdir))
+    info("› initializing per-machine pacman keyring (background)")
+    gpgdir = shlex.quote(str(_target_gpgdir(ctx)))
     script = (
-        f"pacman-key --gpgdir {quoted} --init && "
-        f"pacman-key --gpgdir {quoted} --populate archlinux omarchy"
+        f"pacman-key --gpgdir {gpgdir} --init && "
+        f"pacman-key --gpgdir {gpgdir} --populate archlinux omarchy"
     )
-    res = subprocess.run(
+    return subprocess.Popen(
         ["sh", "-c", script],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
     )
+
+
+def _finish_target_keyring_init(
+    ctx: InstallContext,
+    proc: subprocess.Popen,
+    *,
+    raise_on_error: bool,
+) -> None:
+    """Join the keyring init and always kill its gpg daemons: gpg-agent and
+    dirmngr hold sockets under the target's gnupg dir and would keep the
+    target busy at umount time — pacstrap kills them for the same reason.
+    raise_on_error=False is the exception path, where the original error must
+    not be masked by a keyring failure."""
+    out, _ = proc.communicate()
     subprocess.run(
-        ["gpgconf", "--homedir", str(gpgdir), "--kill", "all"],
+        ["gpgconf", "--homedir", str(_target_gpgdir(ctx)), "--kill", "all"],
         check=False,
         capture_output=True,
     )
-    if res.returncode != 0:
+    if raise_on_error and proc.returncode != 0:
         raise RuntimeError(
             "per-machine pacman keyring init failed "
-            f"(exit {res.returncode}):\n{(res.stdout or '').strip()}"
+            f"(exit {proc.returncode}):\n{(out or '').strip()}"
         )
 
 

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -492,8 +492,12 @@ def _assert_rootfs_image_supported_config(config) -> None:
 def _restore_rootfs_image(ctx: InstallContext) -> None:
     """unsquashfs the image over the mounted target layout.
 
-    Runs as root, so ownership, modes, xattrs/capabilities, ACLs and hardlinks
-    are restored by default. -f because the mounted subvolume layout already
+    Runs as root, so ownership, modes, xattrs/capabilities and hardlinks are
+    restored by default. POSIX ACLs are not: mksquashfs drops the
+    system.posix_acl_* xattrs at build. Harmless today — the only ACL carriers
+    on an installed system are tmpfiles.d a+ lines reapplied at boot — but a
+    package that ships an ACL directly would lose it.
+    -f because the mounted subvolume layout already
     created the top-level directories; writes pass through the mounted
     @home/@log/@pkg subvolumes, and the ESP mountpoint is untouched (the
     image's /boot is empty — boot hooks were masked at build).

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -8,8 +8,9 @@ Phase ordering (full-disk and protected/pre-mounted):
     prepare_install_target → verify pre-mounted target/ESP when the JSON uses
                              pre_mounted_config; no-op for full-disk installs
     arch_install_system    → one archinstall flow for partition/mount-or-use,
-                             base install, early Omarchy packages, Limine setup,
-                             useradd, runtime Omarchy packages, fstab
+                             system payload (prebuilt rootfs image restore, or
+                             legacy pacstrap from the full mirror), Limine
+                             setup, useradd, fstab
     configure_hibernation  → root-owned swap/resume drop-ins
     run_system_finalizer   → arch-chroot root omarchy-apply-system, including Snapper
     finalize_limine_boot   → final Limine config/UKI build after hardware drop-ins
@@ -25,6 +26,7 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import textwrap
@@ -202,10 +204,25 @@ def _install_disk(ctx: InstallContext) -> str | None:
 
 # ─────────────────────────────────────────────────────────────────────────────
 # arch_install_system: everything inside a single Installer context manager.
-# Reorders guided.py's perform_installation() so early Omarchy packages install
-# before user creation and before our Omarchy-owned Limine setup copies files
-# from the target's limine package.
+# One shipped artifact decides how the system lands on disk:
+#
+#   _install_via_rootfs_image  the ISO carries a prebuilt rootfs squashfs
+#                              (build_rootfs_image in builder/build-iso.sh):
+#                              restore it with multithreaded unsquashfs, then
+#                              reconcile the install-time conditionals (kernel,
+#                              tailscale) against the pruned offline mirror.
+#   _install_via_pacstrap      legacy flow (ISO built with
+#                              OMARCHY_ROOTFS_IMAGE=0): reorders guided.py's
+#                              perform_installation() so early Omarchy packages
+#                              install before user creation and before our
+#                              Omarchy-owned Limine setup copies files from the
+#                              target's limine package. Kept for at least one
+#                              release as the fallback.
 # ─────────────────────────────────────────────────────────────────────────────
+
+ROOTFS_IMAGE_PATH = Path("/var/cache/omarchy/rootfs/omarchy-rootfs.sfs")
+RESTORE_PROGRESS_PATH = Path("/run/omarchy-install/restore-progress")
+
 
 def prepare_install_target(ctx: InstallContext) -> None:
     if ctx.is_protected:
@@ -218,7 +235,8 @@ def arch_install_system(ctx: InstallContext) -> None:
     The phase sequence is the same for full-disk and protected installs. The
     JSON decides whether archinstall should create/mount a disk layout or use
     a pre-mounted target, and Omarchy derives boot/fstab details from that same
-    input.
+    input. The prologue and the finishers are shared; only the way packages
+    land on disk differs between the image-restore and pacstrap paths.
     """
     handler = ctx.state["arch_config_handler"]
     mirror_handler = ctx.state["mirror_handler"]
@@ -246,62 +264,10 @@ def arch_install_system(ctx: InstallContext) -> None:
         if config.mirror_config:
             installer.set_mirrors(mirror_handler, config.mirror_config, on_target=False)
 
-        _mount_offline_package_cache(ctx)
-        _mask_mkinitcpio_pacman_hooks(ctx)
-        try:
-            info("› installing base system (mkinitcpio deferred to final Limine UKI build)")
-            # An empty kb_layout makes archinstall's set_keyboard_language skip
-            # booting the target in a container just to run localectl; the
-            # keymap is configured offline right after instead.
-            kb_layout = config.locale_config.kb_layout if config.locale_config else ""
-            installer.minimal_installation(
-                optional_repositories=(
-                    config.mirror_config.optional_repositories
-                    if config.mirror_config else []
-                ),
-                mkinitcpio=False,
-                hostname=config.hostname,
-                locale_config=(
-                    replace(config.locale_config, kb_layout="")
-                    if config.locale_config else None
-                ),
-                pacman_config=config.pacman_config,
-            )
-
-            if not configure_keyboard(installer.target, kb_layout):
-                error(f"Invalid keyboard language specified: {kb_layout}")
-
-            if config.mirror_config:
-                installer.set_mirrors(mirror_handler, config.mirror_config, on_target=True)
-
-            if config.swap and config.swap.enabled:
-                installer.setup_swap(algo=config.swap.algorithm)
-                _drop_archinstall_zram_conf(ctx)
-
-            _install_early_packages(installer)
-            _configure_limine_boot(ctx, installer, config)
-
-            info("› creating user (with /etc/skel populated)")
-            if config.auth_config and config.auth_config.users:
-                installer.create_users(config.auth_config.users)
-
-            if config.app_config:
-                info("› installing archinstall application selections")
-                arch.install_applications(installer, config)
-
-            info("› installing Omarchy runtime + omarchy-base.packages")
-            installer.add_additional_packages(_runtime_package_list(ctx))
-
-            # Tailscale is bundled in the offline mirror but only installed
-            # when an autoinstall drive staged an auth key; must happen here,
-            # while the mirror is still bind-mounted, not in the phase that
-            # configures the join.
-            if ctx.tailscale_authkey_path is not None:
-                info("› installing tailscale (auth key staged for first boot)")
-                installer.add_additional_packages(["tailscale"])
-        finally:
-            _unmask_mkinitcpio_pacman_hooks(ctx)
-            _unmount_offline_package_cache(ctx)
+        if ROOTFS_IMAGE_PATH.exists():
+            _install_via_rootfs_image(ctx, installer, config, mirror_handler)
+        else:
+            _install_via_pacstrap(ctx, installer, config, mirror_handler)
 
         # Standard arch finishers.
         if config.timezone:
@@ -315,6 +281,436 @@ def arch_install_system(ctx: InstallContext) -> None:
             _write_pre_mounted_fstab(ctx)
         else:
             installer.genfstab()
+
+
+def _install_via_pacstrap(ctx: InstallContext, installer, config, mirror_handler) -> None:
+    """Legacy package-by-package install from the full offline mirror."""
+    _mount_offline_package_cache(ctx)
+    _mask_mkinitcpio_pacman_hooks(ctx)
+    try:
+        info("› installing base system (mkinitcpio deferred to final Limine UKI build)")
+        # An empty kb_layout makes archinstall's set_keyboard_language skip
+        # booting the target in a container just to run localectl; the
+        # keymap is configured offline right after instead.
+        kb_layout = config.locale_config.kb_layout if config.locale_config else ""
+        installer.minimal_installation(
+            optional_repositories=(
+                config.mirror_config.optional_repositories
+                if config.mirror_config else []
+            ),
+            mkinitcpio=False,
+            hostname=config.hostname,
+            locale_config=(
+                replace(config.locale_config, kb_layout="")
+                if config.locale_config else None
+            ),
+            pacman_config=config.pacman_config,
+        )
+
+        if not configure_keyboard(installer.target, kb_layout):
+            error(f"Invalid keyboard language specified: {kb_layout}")
+
+        if config.mirror_config:
+            installer.set_mirrors(mirror_handler, config.mirror_config, on_target=True)
+
+        if config.swap and config.swap.enabled:
+            installer.setup_swap(algo=config.swap.algorithm)
+            _drop_archinstall_zram_conf(ctx)
+
+        _install_early_packages(installer)
+        _configure_limine_boot(ctx, installer, config)
+
+        info("› creating user (with /etc/skel populated)")
+        if config.auth_config and config.auth_config.users:
+            installer.create_users(config.auth_config.users)
+
+        if config.app_config:
+            info("› installing archinstall application selections")
+            arch.install_applications(installer, config)
+
+        info("› installing Omarchy runtime + omarchy-base.packages")
+        installer.add_additional_packages(_runtime_package_list(ctx))
+
+        # Tailscale is bundled in the offline mirror but only installed
+        # when an autoinstall drive staged an auth key; must happen here,
+        # while the mirror is still bind-mounted, not in the phase that
+        # configures the join.
+        if ctx.tailscale_authkey_path is not None:
+            info("› installing tailscale (auth key staged for first boot)")
+            installer.add_additional_packages(["tailscale"])
+    finally:
+        _unmask_mkinitcpio_pacman_hooks(ctx)
+        _unmount_offline_package_cache(ctx)
+
+
+def _install_via_rootfs_image(ctx: InstallContext, installer, config, mirror_handler) -> None:
+    """Restore the prebuilt rootfs image, then reconcile install-time
+    conditionals.
+
+    The image is the legacy flow's package end state (built by
+    build_rootfs_image with the same DEFERRED_BOOT_HOOKS masked, locale baked,
+    machine identity scrubbed), so every phase after this one is unchanged.
+
+    Ordering constraints:
+      - restore BEFORE _mount_offline_package_cache: unsquashfs -f would write
+        the image's empty var/cache/pacman/pkg through the bind onto the
+        mirror.
+      - kernel reconcile BEFORE _configure_limine_boot so the boot config and
+        every later phase see the final kernel set.
+
+    Residual package work goes through installer.add_additional_packages
+    (pacstrap semantics: LIVE pacman.conf + --root). The restored target's own
+    /etc/pacman.conf is the stock pacman default with no [offline] repo, and
+    the mirror path does not exist inside the chroot, so `arch-chroot pacman
+    -S` cannot resolve anything here — only _prepare_target_setup later gives
+    the chroot that view (and it resyncs the target db then, see
+    ctx.state["target_db_synced"]).
+    """
+    _assert_rootfs_image_supported_config(config)
+    _restore_rootfs_image(ctx)
+
+    info("› writing per-machine identity")
+    subprocess.run(["systemd-machine-id-setup", f"--root={ctx.target}"], check=True)
+    # Synchronous on purpose: the init takes a few seconds and overlapping it
+    # with the rest of the install buys little for the lifecycle bookkeeping
+    # (kill/join on every exit path) it would demand.
+    _init_target_keyring(ctx)
+
+    # Config side-effects minimal_installation used to perform. Locale is
+    # baked (en_US.UTF-8 in locale.gen + locale.conf at build time);
+    # hostname is ours to write. archinstall's application handler
+    # (PipeWire) is intentionally NOT invoked: its package set is baked
+    # via builder/rootfs-extra.packages, and every other application
+    # selection is rejected up front by _assert_rootfs_image_supported_config
+    # — if a future archinstall handler grows per-user side effects, they
+    # belong in omarchy-provision-user, not here.
+    _write_target_hostname(ctx, config)
+    _ensure_target_locale(ctx, config)
+
+    # Same contract as the legacy path: an empty kb_layout skips
+    # archinstall's localectl-in-container dance; the keymap is configured
+    # offline right after.
+    kb_layout = config.locale_config.kb_layout if config.locale_config else ""
+    if not configure_keyboard(installer.target, kb_layout):
+        error(f"Invalid keyboard language specified: {kb_layout}")
+
+    if config.mirror_config:
+        installer.set_mirrors(mirror_handler, config.mirror_config, on_target=True)
+
+    # No setup_swap: zram-generator is baked and omarchy-settings ships the
+    # vendor drop-in (see _drop_archinstall_zram_conf for why an /etc copy
+    # decides nothing). Deliberate behavior change vs the legacy path: a
+    # config with swap.enabled=false still gets zram.
+    #
+    # config.pacman_config is likewise deliberately ignored: it only tuned
+    # ParallelDownloads/repo toggles in the target's pacman.conf, which is
+    # meaningless offline and overwritten by _prepare_target_setup (and later
+    # by omarchy-apply-system) on every install anyway.
+
+    # archinstall gates some Installer methods on flags its own
+    # minimal_installation sets; the image restore IS our minimal
+    # installation. Precedent: the ["bootloader"] poke in
+    # _install_limine_omarchy. Both spellings are set because the key
+    # changed names across archinstall releases.
+    installer._helper_flags["base"] = True
+    installer._helper_flags["base-strapped"] = True
+
+    _mount_offline_package_cache(ctx)
+    _mask_mkinitcpio_pacman_hooks(ctx)
+    try:
+        _reconcile_target_kernel(ctx, installer, config)
+        _configure_limine_boot(ctx, installer, config)
+
+        info("› creating user (with /etc/skel populated)")
+        if config.auth_config and config.auth_config.users:
+            installer.create_users(config.auth_config.users)
+            _enable_pipewire_pulse_for_users(ctx, config)
+
+        # Tailscale is bundled in the pruned mirror but only installed
+        # when an autoinstall drive staged an auth key; must happen here,
+        # while the mirror is still bind-mounted, not in the phase that
+        # configures the join.
+        if ctx.tailscale_authkey_path is not None:
+            info("› installing tailscale (auth key staged for first boot)")
+            installer.add_additional_packages(["tailscale"])
+            ctx.state["target_db_synced"] = True
+    finally:
+        _unmask_mkinitcpio_pacman_hooks(ctx)
+        _unmount_offline_package_cache(ctx)
+
+
+def _assert_rootfs_image_supported_config(config) -> None:
+    """Refuse loudly what the image path would otherwise silently ignore.
+
+    The legacy path feeds app_config through archinstall's application
+    handler and optional_repositories through minimal_installation. The image
+    bakes PipeWire and nothing else, and the pruned mirror cannot supply
+    packages for other selections afterward — an autoinstall author must find
+    out here, not weeks later on the installed machine. Such configs still
+    work on an ISO built with OMARCHY_ROOTFS_IMAGE=0.
+    """
+    app_config = getattr(config, "app_config", None)
+
+    audio = getattr(app_config, "audio_config", None) if app_config else None
+    audio_kind = str(getattr(audio, "audio", "") or "").lower()
+    if audio_kind and "pipewire" not in audio_kind and "no_audio" not in audio_kind:
+        raise RuntimeError(
+            f"rootfs-image install bakes PipeWire; audio selection {audio_kind!r} "
+            "is not supported (build with OMARCHY_ROOTFS_IMAGE=0 for raw "
+            "archinstall behavior)"
+        )
+
+    bluetooth = getattr(app_config, "bluetooth_config", None) if app_config else None
+    if bluetooth is not None and bool(getattr(bluetooth, "enabled", True)):
+        raise RuntimeError(
+            "rootfs-image install does not support archinstall bluetooth_config "
+            "(Omarchy configures bluetooth via omarchy-apply-system; build with "
+            "OMARCHY_ROOTFS_IMAGE=0 for raw archinstall behavior)"
+        )
+
+    mirror_config = getattr(config, "mirror_config", None)
+    optional = list(getattr(mirror_config, "optional_repositories", None) or [])
+    if optional:
+        raise RuntimeError(
+            f"rootfs-image install cannot enable optional_repositories {optional!r}: "
+            "minimal_installation does not write the target's pacman.conf on this "
+            "path (build with OMARCHY_ROOTFS_IMAGE=0)"
+        )
+
+
+def _restore_rootfs_image(ctx: InstallContext) -> None:
+    """unsquashfs the image over the mounted target layout.
+
+    Runs as root, so ownership, modes, xattrs/capabilities, ACLs and hardlinks
+    are restored by default. -f because the mounted subvolume layout already
+    created the top-level directories; writes pass through the mounted
+    @home/@log/@pkg subvolumes, and the ESP mountpoint is untouched (the
+    image's /boot is empty — boot hooks were masked at build).
+
+    The exit code is checked hard: a partial restore must abort the install,
+    not continue into user creation on a half-written root.
+    """
+    info("› restoring prebuilt system image (unsquashfs)")
+
+    # A retried install in the same live session must not start from the
+    # previous attempt's terminal "100".
+    RESTORE_PROGRESS_PATH.unlink(missing_ok=True)
+    _write_restore_progress("0")
+
+    cmd = [
+        "unsquashfs",
+        "-f",
+        "-p",
+        str(_unsquashfs_processors()),
+        "-d",
+        str(ctx.target),
+    ]
+    if _unsquashfs_supports_percentage():
+        proc = subprocess.Popen(
+            [*cmd, "-percentage", str(ROOTFS_IMAGE_PATH)],
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            value = line.strip()
+            if value.isdigit():
+                _write_restore_progress(value)
+        returncode = proc.wait()
+    else:
+        returncode = subprocess.run(
+            [*cmd, "-no-progress", str(ROOTFS_IMAGE_PATH)],
+        ).returncode
+
+    if returncode != 0:
+        raise RuntimeError(
+            f"unsquashfs failed with exit code {returncode}; refusing to "
+            "continue on a partially restored target"
+        )
+    _write_restore_progress("100")
+
+
+def _unsquashfs_processors() -> int:
+    count = getattr(os, "process_cpu_count", os.cpu_count)()
+    return count or 1
+
+
+def _unsquashfs_supports_percentage() -> bool:
+    """-percentage shipped with squashfs-tools 4.6 (2023); probe rather than
+    assume so an older live environment degrades to the dashboard's time
+    curve instead of failing the restore."""
+    res = subprocess.run(
+        ["unsquashfs", "-help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return "-percentage" in f"{res.stdout}{res.stderr}"
+
+
+def _write_restore_progress(value: str) -> None:
+    """Latest restore percentage for the dashboard. Same atomic-replace dance
+    as the phase state file so the twice-a-second reader never sees a torn
+    write. Best effort — progress display must never fail an install."""
+    try:
+        RESTORE_PROGRESS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        tmp = RESTORE_PROGRESS_PATH.with_name(f".{RESTORE_PROGRESS_PATH.name}.tmp")
+        tmp.write_text(f"{value}\n")
+        tmp.replace(RESTORE_PROGRESS_PATH)
+    except OSError:
+        pass
+
+
+def _init_target_keyring(ctx: InstallContext) -> None:
+    """Recreate the per-machine pacman keyring a legacy pacstrap left behind.
+
+    The image ships no /etc/pacman.d/gnupg (a shared keyring key must never be
+    distributed). Nothing during the install needs the keyring — the offline
+    repo is SigLevel = Never — but the installed system does.
+
+    Chroot-free on purpose: pacman-key --gpgdir writes the target's keyring
+    directory directly, reading the live environment's
+    /usr/share/pacman/keyrings (same package snapshot as the target's), so no
+    API mounts are held or torn down. The trailing gpgconf --kill matters:
+    pacman-key leaves gpg-agent/dirmngr holding sockets under the target's
+    gnupg dir, which would keep the target busy at umount time — pacstrap
+    kills them for the same reason.
+    """
+    info("› initializing per-machine pacman keyring")
+    gpgdir = ctx.target / "etc" / "pacman.d" / "gnupg"
+    quoted = shlex.quote(str(gpgdir))
+    script = (
+        f"pacman-key --gpgdir {quoted} --init && "
+        f"pacman-key --gpgdir {quoted} --populate archlinux omarchy"
+    )
+    res = subprocess.run(
+        ["sh", "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    subprocess.run(
+        ["gpgconf", "--homedir", str(gpgdir), "--kill", "all"],
+        check=False,
+        capture_output=True,
+    )
+    if res.returncode != 0:
+        raise RuntimeError(
+            "per-machine pacman keyring init failed "
+            f"(exit {res.returncode}):\n{(res.stdout or '').strip()}"
+        )
+
+
+def _write_target_hostname(ctx: InstallContext, config) -> None:
+    # Same default archinstall's minimal_installation(hostname=...) applies
+    # when the JSON carries none.
+    hostname = getattr(config, "hostname", None) or "archinstall"
+    hostname_path = ctx.target / "etc" / "hostname"
+    hostname_path.parent.mkdir(parents=True, exist_ok=True)
+    hostname_path.write_text(f"{hostname}\n")
+
+
+def _ensure_target_locale(ctx: InstallContext, config) -> None:
+    """en_US.UTF-8 is baked into the image (locale.gen entry, generated data,
+    locale.conf). Both configurator JSONs hardcode it; this escape hatch only
+    exists for a hand-written cidata config that asks for something else."""
+    locale_config = getattr(config, "locale_config", None)
+    if locale_config is None:
+        return
+
+    lang = (getattr(locale_config, "sys_lang", "") or "").strip()
+    if not lang or lang.split(".")[0] == "en_US":
+        return
+
+    encoding = (getattr(locale_config, "sys_enc", "") or "UTF-8").strip()
+    info(f"› generating non-default locale {lang}")
+    locale_gen = ctx.target / "etc" / "locale.gen"
+    entry = f"{lang} {encoding}\n"
+    existing = locale_gen.read_text() if locale_gen.exists() else ""
+    if entry not in existing:
+        with locale_gen.open("a", encoding="utf-8") as f:
+            f.write(entry)
+    subprocess.run(["arch-chroot", str(ctx.target), "locale-gen"], check=True)
+    (ctx.target / "etc" / "locale.conf").write_text(f"LANG={lang}\n")
+
+
+def _enable_pipewire_pulse_for_users(ctx: InstallContext, config) -> None:
+    """Replicate the one per-user side effect of archinstall's audio handler.
+
+    AudioApp._enable_pipewire (archinstall 4.4, applications/audio.py) links
+    pipewire-pulse.service/.socket into each user's default.target.wants.
+    That is the only audio state the legacy handler creates that baking the
+    package set cannot: no preset or package enables pipewire-pulse for the
+    user (the fresh-install manifests carry exactly these two symlinks and
+    nothing else), so without them PulseAudio-API clients on an image install
+    would find no socket. The handler's hardware conditionals (sof-firmware,
+    alsa-firmware) are already baked via archinstall.packages.
+    """
+    audio = getattr(getattr(config, "app_config", None), "audio_config", None)
+    if "pipewire" not in str(getattr(audio, "audio", "") or "").lower():
+        return
+
+    for user in config.auth_config.users:
+        username = getattr(user, "username", None)
+        if not username:
+            continue
+        info(f"› enabling pipewire-pulse for {username}")
+        wants_dir = (
+            ctx.target / "home" / username / ".config" / "systemd" / "user"
+            / "default.target.wants"
+        )
+        wants_dir.mkdir(parents=True, exist_ok=True)
+        for unit in ("pipewire-pulse.service", "pipewire-pulse.socket"):
+            link = wants_dir / unit
+            link.unlink(missing_ok=True)
+            link.symlink_to(f"/usr/lib/systemd/user/{unit}")
+        # The dirs above were made as root; hand the subtree to the user the
+        # way the archinstall handler's chown does.
+        subprocess.run(
+            ["arch-chroot", str(ctx.target), "chown", "-R",
+             f"{username}:{username}", f"/home/{username}/.config"],
+            check=True,
+        )
+
+
+def _reconcile_target_kernel(ctx: InstallContext, installer, config) -> None:
+    """The image bakes exactly one kernel: linux. Bring the target to the
+    configured kernel set (T2 Macs install with kernels=["linux-t2"], the only
+    non-default kernel the pruned mirror is guaranteed to carry).
+
+    The install goes through pacstrap semantics, whose implicit -Sy also
+    rewrites the target's sync db — baked from the FULL build-time mirror —
+    against the pruned shipped repo, so later resolution matches what the ISO
+    actually carries.
+
+    The target's own boot hooks are live in the image (limine-entry-tool ships
+    90-mkinitcpio-install.hook) and neither /etc/default/limine nor
+    /etc/kernel/cmdline exists yet, so mask the install hook inside the target
+    for the duration — the live-root masks around this phase do nothing for
+    hooks pacman reads out of the target root (see _mask_mkinitcpio_pacman_hooks).
+    The kernel-removal hooks stay live, same rationale as
+    TARGET_DEFERRED_BOOT_HOOKS: pruning Limine entries is exactly what
+    removing the stock kernel needs, and with no limine.conf yet they no-op.
+    """
+    kernels = list(getattr(config, "kernels", None) or ["linux"])
+    missing = [k for k in kernels if k != "linux"]
+    drop_linux = "linux" not in kernels
+    if not missing and not drop_linux:
+        return
+
+    info(f"› reconciling kernels: baked [linux] → configured {kernels}")
+    _mask_mkinitcpio_pacman_hooks(ctx, ctx.target, TARGET_DEFERRED_BOOT_HOOKS)
+    try:
+        if missing:
+            installer.add_additional_packages(missing)
+            ctx.state["target_db_synced"] = True
+        if drop_linux:
+            subprocess.run(
+                ["arch-chroot", str(ctx.target), "pacman", "-Rdd", "--noconfirm", "linux"],
+                check=True,
+            )
+    finally:
+        _unmask_mkinitcpio_pacman_hooks(ctx, ctx.target, TARGET_DEFERRED_BOOT_HOOKS)
 
 
 def _configure_limine_boot(ctx: InstallContext, installer, config) -> None:
@@ -1034,6 +1430,16 @@ def _prepare_target_setup(ctx: InstallContext) -> None:
             subprocess.run(["mount", "--bind", src, str(target_dst)], check=True)
             ctx.state["bind_mounts"].append(str(target_dst))
             mounted.add(str(target_dst))
+
+    # Rootfs-image installs: the image's sync db was populated from the FULL
+    # build-time mirror. If no residual install has resynced it yet (their
+    # pacstrap semantics rewrite it in passing), refresh it against the pruned
+    # shipped repo — the conf copy and bind mounts above are exactly what a
+    # chroot pacman needs for that — so apply-system's hardware installs
+    # resolve against what the ISO actually carries.
+    if ROOTFS_IMAGE_PATH.exists() and not ctx.state.get("target_db_synced"):
+        subprocess.run(["arch-chroot", str(ctx.target), "pacman", "-Sy"], check=True)
+        ctx.state["target_db_synced"] = True
 
     ctx.state["target_setup_prepared"] = True
 

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -28,6 +28,7 @@ import os
 import re
 import shlex
 import shutil
+import signal
 import subprocess
 import textwrap
 import time
@@ -380,7 +381,7 @@ def _install_via_rootfs_image(ctx: InstallContext, installer, config, mirror_han
     try:
         _rootfs_image_configure(ctx, installer, config, mirror_handler)
     except BaseException:
-        keyring_proc.kill()
+        _kill_target_keyring_init(keyring_proc)
         _finish_target_keyring_init(ctx, keyring_proc, raise_on_error=False)
         raise
     _finish_target_keyring_init(ctx, keyring_proc, raise_on_error=True)
@@ -600,12 +601,23 @@ def _start_target_keyring_init(ctx: InstallContext) -> subprocess.Popen:
         f"pacman-key --gpgdir {gpgdir} --init && "
         f"pacman-key --gpgdir {gpgdir} --populate archlinux omarchy"
     )
+    # start_new_session makes the shell a process-group leader, so
+    # _kill_target_keyring_init reaches pacman-key and its gpg children —
+    # killing just the sh wrapper would leave them mutating the target keyring.
     return subprocess.Popen(
         ["sh", "-c", script],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        start_new_session=True,
     )
+
+
+def _kill_target_keyring_init(proc: subprocess.Popen) -> None:
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
 
 
 def _finish_target_keyring_init(

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -228,6 +228,11 @@ ROOTFS_IMAGE_BUILD_MARKER = Path("/usr/share/omarchy-iso/rootfs-image-build")
 # would fail mid-install in _reconcile_target_kernel, so the config assert
 # rejects it before the disk is touched.
 ROOTFS_IMAGE_SUPPORTED_KERNELS = {"linux", "linux-t2"}
+# What minimal_installation adds on the legacy path when the live session runs
+# a screen reader (archinstall's own list is private). build-iso.sh's
+# conditional_targets must carry the same names so the pruned mirror can serve
+# them at install time.
+ACCESSIBILITY_PACKAGES = ["brltty", "espeakup", "alsa-utils"]
 # Filesystems whose userspace archinstall's legacy minimal_installation would
 # have pacstrapped for the config (FilesystemType.installation_pkg: xfsprogs,
 # f2fs-tools) but that neither the baked image nor the pruned mirror carries
@@ -236,6 +241,14 @@ ROOTFS_IMAGE_SUPPORTED_KERNELS = {"linux", "linux-t2"}
 # the disk is touched — same contract as ROOTFS_IMAGE_SUPPORTED_KERNELS.
 ROOTFS_IMAGE_UNSUPPORTED_FS_TYPES = {"xfs", "f2fs"}
 RESTORE_PROGRESS_PATH = Path("/run/omarchy-install/restore-progress")
+
+
+def _configured_kernels(config) -> list[str]:
+    """The configured kernel set with archinstall's default. The contract pair
+    _assert_rootfs_image_supported_config / _reconcile_target_kernel must
+    parse config.kernels identically — the assert's pre-format guarantee
+    holds only as long as both go through here."""
+    return list(getattr(config, "kernels", None) or ["linux"])
 
 
 def _is_rootfs_image_install() -> bool:
@@ -322,10 +335,18 @@ def arch_install_system(ctx: InstallContext) -> None:
             installer.genfstab()
 
 
-def _install_via_pacstrap(ctx: InstallContext, installer, config, mirror_handler) -> None:
-    """Legacy package-by-package install from the full offline mirror."""
+def _generate_key_files_if_needed(installer, config) -> None:
+    """Key files (and the crypttab entries referencing them) are only wanted
+    when this install created the encrypted layout itself; each install path
+    calls this at its own deliberately different point (see the ordering
+    comment in _install_via_rootfs_image)."""
     if not arch.is_pre_mount(config) and arch.is_encrypted(config):
         installer.generate_key_files()
+
+
+def _install_via_pacstrap(ctx: InstallContext, installer, config, mirror_handler) -> None:
+    """Legacy package-by-package install from the full offline mirror."""
+    _generate_key_files_if_needed(installer, config)
     _mount_offline_package_cache(ctx)
     _mask_mkinitcpio_pacman_hooks(ctx)
     try:
@@ -413,34 +434,27 @@ def _install_via_rootfs_image(ctx: InstallContext, installer, config, mirror_han
     # volumes to the target's /etc/crypttab, which the filesystem package owns,
     # so unsquashfs -f would overwrite it (pacstrap preserves it as a backup=
     # file, hence the legacy path has no such constraint).
-    if not arch.is_pre_mount(config) and arch.is_encrypted(config):
-        installer.generate_key_files()
+    _generate_key_files_if_needed(installer, config)
 
     info("› writing per-machine identity")
     subprocess.run(["systemd-machine-id-setup", f"--root={ctx.target}"], check=True)
     # Backgrounded: SigLevel = Never means nothing READS the keyring during
     # the install, and the init is chroot-free, so there is no mount teardown
     # to race the chroots below. pacstrap -K WRITES the same gnupg dir though
-    # (it runs its own pacman-key --init), so every pacstrap-semantics site
-    # joins via _await_target_keyring_init before touching the target db.
-    # Killed and joined on every exit path so a failure cannot leak the
-    # process, and the original error always wins over a keyring one. The
-    # SIGTERM handler is what makes "every exit path" true under a dashboard
-    # stop: start_new_session puts the init outside the process group the
-    # dashboard kills, and Python's default SIGTERM disposition would end the
-    # orchestrator without unwinding the except path below.
-    prev_sigterm = signal.signal(signal.SIGTERM, _raise_on_sigterm)
+    # (it runs its own pacman-key --init), so _install_target_packages joins
+    # the init before any pacstrap-semantics install. Killed and joined on
+    # every exit path so a failure cannot leak the process, and the original
+    # error always wins over a keyring one — "every exit path" includes a
+    # dashboard stop because main() turns SIGTERM into an exception (the
+    # detached init sits outside the process group the dashboard kills).
     try:
-        try:
-            _start_target_keyring_init(ctx)
-            _rootfs_image_configure(ctx, installer, config, mirror_handler)
-            _await_target_keyring_init(ctx, raise_on_error=True)
-        except BaseException:
-            _kill_target_keyring_init(ctx)
-            _await_target_keyring_init(ctx, raise_on_error=False)
-            raise
-    finally:
-        signal.signal(signal.SIGTERM, prev_sigterm)
+        _start_target_keyring_init(ctx)
+        _rootfs_image_configure(ctx, installer, config, mirror_handler)
+        _await_target_keyring_init(ctx, raise_on_error=True)
+    except BaseException:
+        _kill_target_keyring_init(ctx)
+        _await_target_keyring_init(ctx, raise_on_error=False)
+        raise
 
 
 def _rootfs_image_configure(ctx: InstallContext, installer, config, mirror_handler) -> None:
@@ -494,33 +508,42 @@ def _rootfs_image_configure(ctx: InstallContext, installer, config, mirror_handl
             installer.create_users(config.auth_config.users)
             _enable_pipewire_pulse_for_users(ctx, config)
 
-        # Tailscale is bundled in the pruned mirror but only installed
-        # when an autoinstall drive staged an auth key; must happen here,
-        # while the mirror is still bind-mounted, not in the phase that
-        # configures the join.
+        # Conditional packages are bundled in the pruned mirror and must be
+        # installed here, while it is still bind-mounted — tailscale not in
+        # the phase that configures the join. One batched call: each install
+        # is a full pacstrap run with its own -Sy rewrite of the target db.
+        packages = []
         if ctx.tailscale_authkey_path is not None:
             info("› installing tailscale (auth key staged for first boot)")
-            _await_target_keyring_init(ctx)
-            installer.add_additional_packages(["tailscale"])
-            ctx.state["target_db_synced"] = True
-
-        _install_accessibility_tools(ctx, installer)
+            packages.append("tailscale")
+        packages += _accessibility_packages()
+        if packages:
+            _install_target_packages(ctx, installer, packages)
     finally:
         _unmask_mkinitcpio_pacman_hooks(ctx)
         _unmount_offline_package_cache(ctx)
 
 
-def _install_accessibility_tools(ctx: InstallContext, installer) -> None:
+def _accessibility_packages() -> list[str]:
     """The legacy path gets these from minimal_installation, which extends its
     base set when the live session runs a screen reader (the accessibility=on
-    boot entry). The image bakes none of them, so install from the pruned
-    mirror while it is still bind-mounted; the shared finishers in
+    boot entry). The image bakes none of them, so they ride the conditional
+    package install from the pruned mirror; the shared finishers in
     arch_install_system enable espeakup on both paths."""
     if not arch.accessibility_tools_in_use():
-        return
-    info("› installing accessibility stack (brltty espeakup alsa-utils)")
+        return []
+    info(f"› installing accessibility stack ({' '.join(ACCESSIBILITY_PACKAGES)})")
+    return list(ACCESSIBILITY_PACKAGES)
+
+
+def _install_target_packages(ctx: InstallContext, installer, packages: list[str]) -> None:
+    """Pacstrap-semantics install from the pruned mirror (LIVE pacman.conf +
+    --root, see the _install_via_rootfs_image docstring). Owns the two
+    obligations every such install carries: joining the background keyring
+    init first (pacstrap -K writes the target's gnupg dir) and recording that
+    pacstrap's implicit -Sy already rewrote the target's sync db."""
     _await_target_keyring_init(ctx)
-    installer.add_additional_packages(["brltty", "espeakup", "alsa-utils"])
+    installer.add_additional_packages(packages)
     ctx.state["target_db_synced"] = True
 
 
@@ -570,12 +593,12 @@ def _assert_rootfs_image_supported_config(config) -> None:
             "would have added (build with OMARCHY_ROOTFS_IMAGE=0)"
         )
 
-    fs_types = set()
-    for mod in list(getattr(disk_config, "device_modifications", None) or []):
-        for part in list(getattr(mod, "partitions", None) or []):
-            fs_type = getattr(part, "fs_type", None)
-            if fs_type is not None:
-                fs_types.add(str(getattr(fs_type, "value", fs_type)).lower())
+    fs_types = {
+        part.fs_type.value.lower()
+        for mod in (getattr(disk_config, "device_modifications", None) or [])
+        for part in mod.partitions
+        if part.fs_type is not None
+    }
     unsupported_fs = sorted(fs_types & ROOTFS_IMAGE_UNSUPPORTED_FS_TYPES)
     if unsupported_fs:
         raise RuntimeError(
@@ -585,8 +608,7 @@ def _assert_rootfs_image_supported_config(config) -> None:
             "mirror cannot supply the rest (build with OMARCHY_ROOTFS_IMAGE=0)"
         )
 
-    kernels = list(getattr(config, "kernels", None) or ["linux"])
-    unsupported = sorted(set(kernels) - ROOTFS_IMAGE_SUPPORTED_KERNELS)
+    unsupported = sorted(set(_configured_kernels(config)) - ROOTFS_IMAGE_SUPPORTED_KERNELS)
     if unsupported:
         raise RuntimeError(
             f"rootfs-image install cannot provide kernels {unsupported!r}: the "
@@ -686,14 +708,6 @@ def _target_gpgdir(ctx: InstallContext) -> Path:
     return ctx.target / "etc" / "pacman.d" / "gnupg"
 
 
-def _raise_on_sigterm(signum, frame) -> None:
-    """Installed for the duration of the background keyring init: turns the
-    dashboard's group SIGTERM (its stop escalates to SIGKILL only after a
-    grace period) into an exception so the except-BaseException path kills
-    and joins the detached keyring session instead of leaking it."""
-    raise SystemExit(128 + signum)
-
-
 def _start_target_keyring_init(ctx: InstallContext) -> None:
     """Recreate the per-machine pacman keyring a legacy pacstrap left behind.
 
@@ -740,14 +754,15 @@ def _kill_target_keyring_init(ctx: InstallContext) -> None:
 def _await_target_keyring_init(ctx: InstallContext, *, raise_on_error: bool = True) -> None:
     """Join the background keyring init if it is still pending; no-op after.
 
-    Every pacstrap-semantics install (installer.add_additional_packages) must
-    call this first: pacstrap -K unconditionally runs its own pacman-key
-    --init on the target's gnupg dir — the very directory the background init
-    is writing — and two concurrent inits on one gpg homedir can generate
-    competing master keys or trip over gpg's keybox/trustdb locks. SigLevel =
-    Never only skips keyring reads, not pacstrap's writes. Installs that never
-    pacstrap (default kernel, no tailscale key, no screen reader) keep the
-    full overlap and join at the end of _install_via_rootfs_image."""
+    Every pacstrap-semantics install must run behind this join — enforced by
+    routing them through _install_target_packages: pacstrap -K
+    unconditionally runs its own pacman-key --init on the target's gnupg dir
+    — the very directory the background init is writing — and two concurrent
+    inits on one gpg homedir can generate competing master keys or trip over
+    gpg's keybox/trustdb locks. SigLevel = Never only skips keyring reads,
+    not pacstrap's writes. Installs that never pacstrap (default kernel, no
+    tailscale key, no screen reader) keep the full overlap and join at the
+    end of _install_via_rootfs_image."""
     proc = ctx.state.get("target_keyring_proc")
     if proc is None:
         return
@@ -881,7 +896,7 @@ def _reconcile_target_kernel(ctx: InstallContext, installer, config) -> None:
     TARGET_DEFERRED_BOOT_HOOKS: pruning Limine entries is exactly what
     removing the stock kernel needs, and with no limine.conf yet they no-op.
     """
-    kernels = list(getattr(config, "kernels", None) or ["linux"])
+    kernels = _configured_kernels(config)
     missing = [k for k in kernels if k != "linux"]
     drop_linux = "linux" not in kernels
     if not missing and not drop_linux:
@@ -891,9 +906,7 @@ def _reconcile_target_kernel(ctx: InstallContext, installer, config) -> None:
     _mask_mkinitcpio_pacman_hooks(ctx, ctx.target, TARGET_DEFERRED_BOOT_HOOKS)
     try:
         if missing:
-            _await_target_keyring_init(ctx)
-            installer.add_additional_packages(missing)
-            ctx.state["target_db_synced"] = True
+            _install_target_packages(ctx, installer, missing)
         if drop_linux:
             subprocess.run(
                 ["arch-chroot", str(ctx.target), "pacman", "-Rdd", "--noconfirm", "linux"],

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -222,7 +222,24 @@ def _install_disk(ctx: InstallContext) -> str | None:
 # ─────────────────────────────────────────────────────────────────────────────
 
 ROOTFS_IMAGE_PATH = Path("/var/cache/omarchy/rootfs/omarchy-rootfs.sfs")
+ROOTFS_IMAGE_BUILD_MARKER = Path("/usr/share/omarchy-iso/rootfs-image-build")
 RESTORE_PROGRESS_PATH = Path("/run/omarchy-install/restore-progress")
+
+
+def _is_rootfs_image_install() -> bool:
+    """Build-time variant decision, not runtime file presence: an image ISO
+    whose image file is missing must abort (see _assert_rootfs_image_available),
+    never quietly fall back to pacstrapping against the pruned mirror."""
+    return ROOTFS_IMAGE_BUILD_MARKER.exists()
+
+
+def _assert_rootfs_image_available() -> None:
+    if not ROOTFS_IMAGE_PATH.exists():
+        raise RuntimeError(
+            f"this ISO was built around a rootfs image but {ROOTFS_IMAGE_PATH} "
+            "is missing; refusing to touch the disk (the pruned mirror cannot "
+            "feed a pacstrap fallback)"
+        )
 
 
 def prepare_install_target(ctx: InstallContext) -> None:
@@ -244,6 +261,13 @@ def arch_install_system(ctx: InstallContext) -> None:
     config = handler.config
     pre_mounted = arch.is_pre_mount(config)
 
+    # Both checks must precede any disk write: a broken or unsupported image
+    # install has no pacstrap fallback to save it after formatting.
+    use_rootfs_image = _is_rootfs_image_install()
+    if use_rootfs_image:
+        _assert_rootfs_image_available()
+        _assert_rootfs_image_supported_config(config)
+
     if not pre_mounted:
         info("› partitioning + formatting + encrypting")
         arch.perform_filesystem_operations(config)
@@ -262,7 +286,7 @@ def arch_install_system(ctx: InstallContext) -> None:
         if config.mirror_config:
             installer.set_mirrors(mirror_handler, config.mirror_config, on_target=False)
 
-        if ROOTFS_IMAGE_PATH.exists():
+        if use_rootfs_image:
             _install_via_rootfs_image(ctx, installer, config, mirror_handler)
         else:
             _install_via_pacstrap(ctx, installer, config, mirror_handler)
@@ -366,7 +390,6 @@ def _install_via_rootfs_image(ctx: InstallContext, installer, config, mirror_han
     the chroot that view (and it resyncs the target db then, see
     ctx.state["target_db_synced"]).
     """
-    _assert_rootfs_image_supported_config(config)
     _restore_rootfs_image(ctx)
 
     # After the restore, never before: generate_key_files appends non-root
@@ -1486,7 +1509,7 @@ def _prepare_target_setup(ctx: InstallContext) -> None:
     # shipped repo — the conf copy and bind mounts above are exactly what a
     # chroot pacman needs for that — so apply-system's hardware installs
     # resolve against what the ISO actually carries.
-    if ROOTFS_IMAGE_PATH.exists() and not ctx.state.get("target_db_synced"):
+    if _is_rootfs_image_install() and not ctx.state.get("target_db_synced"):
         subprocess.run(["arch-chroot", str(ctx.target), "pacman", "-Sy"], check=True)
         ctx.state["target_db_synced"] = True
 

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -228,6 +228,13 @@ ROOTFS_IMAGE_BUILD_MARKER = Path("/usr/share/omarchy-iso/rootfs-image-build")
 # would fail mid-install in _reconcile_target_kernel, so the config assert
 # rejects it before the disk is touched.
 ROOTFS_IMAGE_SUPPORTED_KERNELS = {"linux", "linux-t2"}
+# Filesystems whose userspace archinstall's legacy minimal_installation would
+# have pacstrapped for the config (FilesystemType.installation_pkg: xfsprogs,
+# f2fs-tools) but that neither the baked image nor the pruned mirror carries
+# (btrfs-progs alone is baked, via snapper). Such a config would format fine
+# and boot without fsck/repair tools, so the config assert rejects it before
+# the disk is touched — same contract as ROOTFS_IMAGE_SUPPORTED_KERNELS.
+ROOTFS_IMAGE_UNSUPPORTED_FS_TYPES = {"xfs", "f2fs"}
 RESTORE_PROGRESS_PATH = Path("/run/omarchy-install/restore-progress")
 
 
@@ -549,6 +556,21 @@ def _assert_rootfs_image_supported_config(config) -> None:
             "rootfs-image install does not support lvm_config: the image bakes "
             "neither lvm2 nor its mkinitcpio hook, which minimal_installation "
             "would have added (build with OMARCHY_ROOTFS_IMAGE=0)"
+        )
+
+    fs_types = set()
+    for mod in list(getattr(disk_config, "device_modifications", None) or []):
+        for part in list(getattr(mod, "partitions", None) or []):
+            fs_type = getattr(part, "fs_type", None)
+            if fs_type is not None:
+                fs_types.add(str(getattr(fs_type, "value", fs_type)).lower())
+    unsupported_fs = sorted(fs_types & ROOTFS_IMAGE_UNSUPPORTED_FS_TYPES)
+    if unsupported_fs:
+        raise RuntimeError(
+            f"rootfs-image install cannot provide filesystem tools for "
+            f"{unsupported_fs!r}: minimal_installation would have installed "
+            "them, but the image bakes only the btrfs userspace and the pruned "
+            "mirror cannot supply the rest (build with OMARCHY_ROOTFS_IMAGE=0)"
         )
 
     kernels = list(getattr(config, "kernels", None) or ["linux"])

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -223,6 +223,11 @@ def _install_disk(ctx: InstallContext) -> str | None:
 
 ROOTFS_IMAGE_PATH = Path("/var/cache/omarchy/rootfs/omarchy-rootfs.sfs")
 ROOTFS_IMAGE_BUILD_MARKER = Path("/usr/share/omarchy-iso/rootfs-image-build")
+# linux is baked into the image; linux-t2 is the only other kernel the pruned
+# shipped mirror guarantees (build-iso.sh conditional_targets). Anything else
+# would fail mid-install in _reconcile_target_kernel, so the config assert
+# rejects it before the disk is touched.
+ROOTFS_IMAGE_SUPPORTED_KERNELS = {"linux", "linux-t2"}
 RESTORE_PROGRESS_PATH = Path("/run/omarchy-install/restore-progress")
 
 
@@ -518,6 +523,23 @@ def _assert_rootfs_image_supported_config(config) -> None:
             "path (build with OMARCHY_ROOTFS_IMAGE=0)"
         )
 
+    disk_config = getattr(config, "disk_config", None)
+    if getattr(disk_config, "lvm_config", None):
+        raise RuntimeError(
+            "rootfs-image install does not support lvm_config: the image bakes "
+            "neither lvm2 nor its mkinitcpio hook, which minimal_installation "
+            "would have added (build with OMARCHY_ROOTFS_IMAGE=0)"
+        )
+
+    kernels = list(getattr(config, "kernels", None) or ["linux"])
+    unsupported = sorted(set(kernels) - ROOTFS_IMAGE_SUPPORTED_KERNELS)
+    if unsupported:
+        raise RuntimeError(
+            f"rootfs-image install cannot provide kernels {unsupported!r}: the "
+            f"pruned mirror only carries {sorted(ROOTFS_IMAGE_SUPPORTED_KERNELS)} "
+            "(build with OMARCHY_ROOTFS_IMAGE=0)"
+        )
+
 
 def _restore_rootfs_image(ctx: InstallContext) -> None:
     """unsquashfs the image over the mounted target layout.
@@ -748,7 +770,8 @@ def _enable_pipewire_pulse_for_users(ctx: InstallContext, config) -> None:
 def _reconcile_target_kernel(ctx: InstallContext, installer, config) -> None:
     """The image bakes exactly one kernel: linux. Bring the target to the
     configured kernel set (T2 Macs install with kernels=["linux-t2"], the only
-    non-default kernel the pruned mirror is guaranteed to carry).
+    non-default kernel the pruned mirror is guaranteed to carry — any other
+    name was rejected pre-format via ROOTFS_IMAGE_SUPPORTED_KERNELS).
 
     The install goes through pacstrap semantics, whose implicit -Sy also
     rewrites the target's sync db — baked from the FULL build-time mirror —

--- a/configs/profiledef.sh
+++ b/configs/profiledef.sh
@@ -27,6 +27,11 @@ airootfs_image_tool_options=(
   '-Xcompression-level' '19'
   '-b' '1M'
   '-action' 'uncompressed@subpathname(var/cache/omarchy/mirror/offline)'
+  # The prebuilt rootfs image is itself a zstd squashfs (built by
+  # build_rootfs_image in builder/build-iso.sh); recompressing it here would
+  # cost build time and make the installer decompress two layers on the
+  # dominant read of the whole install.
+  '-action' 'uncompressed@pathname(var/cache/omarchy/rootfs/omarchy-rootfs.sfs)'
 )
 bootstrap_tarball_compression=('zstd' '-c' '-T0' '--auto-threads=logical' '--long' '-19')
 file_permissions=(

--- a/test/test_rootfs_restore.py
+++ b/test/test_rootfs_restore.py
@@ -127,5 +127,61 @@ class RestoreRootfsImageTest(unittest.TestCase):
         self.assertEqual([int(v) for v in self.progress], [0, 100])
 
 
+class FakeKeyringProc:
+    def __init__(self, returncode, output="keyring output"):
+        self.returncode = returncode
+        self._output = output
+
+    def communicate(self):
+        return self._output, None
+
+
+class FinishTargetKeyringInitTest(unittest.TestCase):
+    def setUp(self):
+        self.run_cmds = []
+
+        info_patch = mock.patch.object(phases_impl, "info")
+        info_patch.start()
+        self.addCleanup(info_patch.stop)
+
+        run_patch = mock.patch.object(
+            phases_impl.subprocess, "run", side_effect=self.fake_run
+        )
+        run_patch.start()
+        self.addCleanup(run_patch.stop)
+
+    def fake_run(self, cmd, **kwargs):
+        self.run_cmds.append(cmd)
+        return types.SimpleNamespace(returncode=0)
+
+    def ctx(self):
+        return types.SimpleNamespace(target=Path("/mnt/target"))
+
+    def assert_gpg_daemons_killed(self):
+        self.assertEqual(self.run_cmds, [[
+            "gpgconf", "--homedir", "/mnt/target/etc/pacman.d/gnupg",
+            "--kill", "all",
+        ]])
+
+    def test_failure_raises_with_output_and_kills_gpg_daemons(self):
+        with self.assertRaisesRegex(RuntimeError, "keyring output"):
+            phases_impl._finish_target_keyring_init(
+                self.ctx(), FakeKeyringProc(returncode=1), raise_on_error=True
+            )
+        self.assert_gpg_daemons_killed()
+
+    def test_failure_is_swallowed_on_the_exception_path(self):
+        phases_impl._finish_target_keyring_init(
+            self.ctx(), FakeKeyringProc(returncode=1), raise_on_error=False
+        )
+        self.assert_gpg_daemons_killed()
+
+    def test_success_does_not_raise(self):
+        phases_impl._finish_target_keyring_init(
+            self.ctx(), FakeKeyringProc(returncode=0), raise_on_error=True
+        )
+        self.assert_gpg_daemons_killed()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_rootfs_restore.py
+++ b/test/test_rootfs_restore.py
@@ -1,0 +1,131 @@
+"""Unit tests for rootfs-image restore via multithreaded unsquashfs."""
+
+import io
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "configs/airootfs/usr/share/omarchy-iso"))
+
+sys.modules["orchestrator.archinstall_adapter"] = types.ModuleType("orchestrator.archinstall_adapter")
+
+from orchestrator import phases_impl  # noqa: E402
+
+
+class FakeProc:
+    def __init__(self, lines, returncode=0):
+        self.stdout = io.StringIO("".join(f"{line}\n" for line in lines))
+        self._returncode = returncode
+
+    def wait(self):
+        return self._returncode
+
+
+class RestoreRootfsImageTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        root = Path(self.tmp.name)
+        self.target = root / "mnt"
+        self.target.mkdir()
+        self.image = root / "omarchy-rootfs.sfs"
+        self.image.write_bytes(b"squashfs-image\n")
+        self.progress_path = root / "restore-progress"
+
+        self.progress = []
+        self.popen_cmds = []
+
+        info_patch = mock.patch.object(phases_impl, "info")
+        info_patch.start()
+        self.addCleanup(info_patch.stop)
+
+        image_patch = mock.patch.object(phases_impl, "ROOTFS_IMAGE_PATH", self.image)
+        image_patch.start()
+        self.addCleanup(image_patch.stop)
+
+        progress_path_patch = mock.patch.object(
+            phases_impl, "RESTORE_PROGRESS_PATH", self.progress_path
+        )
+        progress_path_patch.start()
+        self.addCleanup(progress_path_patch.stop)
+
+        write_patch = mock.patch.object(
+            phases_impl, "_write_restore_progress", side_effect=self.progress.append
+        )
+        write_patch.start()
+        self.addCleanup(write_patch.stop)
+
+        pct_patch = mock.patch.object(
+            phases_impl, "_unsquashfs_supports_percentage", return_value=True
+        )
+        pct_patch.start()
+        self.addCleanup(pct_patch.stop)
+
+        cpu_patch = mock.patch.object(phases_impl, "_unsquashfs_processors", return_value=8)
+        cpu_patch.start()
+        self.addCleanup(cpu_patch.stop)
+
+        popen_patch = mock.patch.object(
+            phases_impl.subprocess, "Popen", side_effect=self.fake_popen
+        )
+        popen_patch.start()
+        self.addCleanup(popen_patch.stop)
+
+    def ctx(self):
+        return types.SimpleNamespace(target=self.target, state={})
+
+    def fake_popen(self, cmd, **kwargs):
+        self.popen_cmds.append(cmd)
+        return FakeProc(["0", "50", "100"])
+
+    def test_unsquashfs_command_shape(self):
+        phases_impl._restore_rootfs_image(self.ctx())
+        self.assertEqual(len(self.popen_cmds), 1)
+        self.assertEqual(self.popen_cmds[0], [
+            "unsquashfs", "-f", "-p", "8", "-d", str(self.target),
+            "-percentage", str(self.image),
+        ])
+
+    def test_nonzero_exit_raises(self):
+        def failing_popen(cmd, **kwargs):
+            self.popen_cmds.append(cmd)
+            return FakeProc(["0"], returncode=1)
+
+        with mock.patch.object(phases_impl.subprocess, "Popen", side_effect=failing_popen):
+            with self.assertRaisesRegex(RuntimeError, "unsquashfs failed"):
+                phases_impl._restore_rootfs_image(self.ctx())
+
+    def test_progress_is_passed_through_and_monotonic(self):
+        phases_impl._restore_rootfs_image(self.ctx())
+        values = [int(v) for v in self.progress]
+        self.assertEqual(values, [0, 0, 50, 100, 100])
+        self.assertEqual(values, sorted(values))
+
+    def test_falls_back_to_no_progress_without_percentage_support(self):
+        run_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            run_cmds.append(cmd)
+            return types.SimpleNamespace(returncode=0)
+
+        with (
+            mock.patch.object(
+                phases_impl, "_unsquashfs_supports_percentage", return_value=False
+            ),
+            mock.patch.object(phases_impl.subprocess, "run", side_effect=fake_run),
+        ):
+            phases_impl._restore_rootfs_image(self.ctx())
+        self.assertEqual(self.popen_cmds, [])
+        self.assertEqual(run_cmds, [[
+            "unsquashfs", "-f", "-p", "8", "-d", str(self.target),
+            "-no-progress", str(self.image),
+        ]])
+        # No streamed percentages, but the terminal states still land.
+        self.assertEqual([int(v) for v in self.progress], [0, 100])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_rootfs_restore.py
+++ b/test/unit/test_rootfs_restore.py
@@ -136,6 +136,70 @@ class FakeKeyringProc:
         return self._output, None
 
 
+class AssertRootfsImageSupportedConfigTest(unittest.TestCase):
+    def config(self, **overrides):
+        base = dict(
+            app_config=None, mirror_config=None, disk_config=None, kernels=None
+        )
+        base.update(overrides)
+        return types.SimpleNamespace(**base)
+
+    def assert_rejected(self, pattern, **overrides):
+        with self.assertRaisesRegex(RuntimeError, pattern):
+            phases_impl._assert_rootfs_image_supported_config(
+                self.config(**overrides)
+            )
+
+    def test_default_config_is_supported(self):
+        phases_impl._assert_rootfs_image_supported_config(self.config())
+
+    def test_non_pipewire_audio_is_rejected(self):
+        self.assert_rejected(
+            "bakes PipeWire",
+            app_config=types.SimpleNamespace(
+                audio_config=types.SimpleNamespace(audio="pulseaudio"),
+                bluetooth_config=None,
+            ),
+        )
+
+    def test_bluetooth_is_rejected(self):
+        self.assert_rejected(
+            "bluetooth_config",
+            app_config=types.SimpleNamespace(
+                audio_config=None,
+                bluetooth_config=types.SimpleNamespace(enabled=True),
+            ),
+        )
+
+    def test_optional_repositories_are_rejected(self):
+        self.assert_rejected(
+            "optional_repositories",
+            mirror_config=types.SimpleNamespace(
+                optional_repositories=["multilib"]
+            ),
+        )
+
+    def test_lvm_is_rejected(self):
+        self.assert_rejected(
+            "lvm_config",
+            disk_config=types.SimpleNamespace(lvm_config=object()),
+        )
+
+    def test_lvm_free_disk_config_is_supported(self):
+        phases_impl._assert_rootfs_image_supported_config(
+            self.config(disk_config=types.SimpleNamespace(lvm_config=None))
+        )
+
+    def test_unsupported_kernel_is_rejected(self):
+        self.assert_rejected("linux-zen", kernels=["linux", "linux-zen"])
+
+    def test_supported_kernels_pass(self):
+        for kernels in (None, ["linux"], ["linux-t2"], ["linux", "linux-t2"]):
+            phases_impl._assert_rootfs_image_supported_config(
+                self.config(kernels=kernels)
+            )
+
+
 class RootfsImageMarkerTest(unittest.TestCase):
     """The install-mode decision is the build-time marker, never the image
     file: an image ISO with a missing image must abort pre-format instead of

--- a/test/unit/test_rootfs_restore.py
+++ b/test/unit/test_rootfs_restore.py
@@ -136,6 +136,59 @@ class FakeKeyringProc:
         return self._output, None
 
 
+class InstallViaRootfsImageKeyFilesTest(unittest.TestCase):
+    """generate_key_files must follow the restore: it appends to the target's
+    /etc/crypttab, which unsquashfs -f would otherwise overwrite."""
+
+    def run_install(self, *, encrypted, pre_mounted=False):
+        calls = []
+        installer = mock.Mock()
+        installer.generate_key_files.side_effect = (
+            lambda: calls.append("generate_key_files")
+        )
+        patches = [
+            mock.patch.object(phases_impl, "info"),
+            mock.patch.object(phases_impl.subprocess, "run"),
+            mock.patch.object(
+                phases_impl, "_assert_rootfs_image_supported_config"
+            ),
+            mock.patch.object(
+                phases_impl, "_restore_rootfs_image",
+                side_effect=lambda ctx: calls.append("restore"),
+            ),
+            mock.patch.object(phases_impl, "_rootfs_image_configure"),
+            mock.patch.object(phases_impl, "_start_target_keyring_init"),
+            mock.patch.object(phases_impl, "_finish_target_keyring_init"),
+            mock.patch.object(
+                phases_impl.arch, "is_pre_mount",
+                lambda config: pre_mounted, create=True,
+            ),
+            mock.patch.object(
+                phases_impl.arch, "is_encrypted",
+                lambda config: encrypted, create=True,
+            ),
+        ]
+        for patch in patches:
+            patch.start()
+            self.addCleanup(patch.stop)
+        ctx = types.SimpleNamespace(target=Path("/mnt/target"))
+        phases_impl._install_via_rootfs_image(ctx, installer, object(), object())
+        return calls
+
+    def test_encrypted_generates_key_files_after_the_restore(self):
+        self.assertEqual(
+            self.run_install(encrypted=True), ["restore", "generate_key_files"]
+        )
+
+    def test_unencrypted_skips_key_files(self):
+        self.assertEqual(self.run_install(encrypted=False), ["restore"])
+
+    def test_pre_mounted_skips_key_files(self):
+        self.assertEqual(
+            self.run_install(encrypted=True, pre_mounted=True), ["restore"]
+        )
+
+
 class StartTargetKeyringInitTest(unittest.TestCase):
     def test_shell_leads_its_own_process_group(self):
         with mock.patch.object(phases_impl, "info"), \

--- a/test/unit/test_rootfs_restore.py
+++ b/test/unit/test_rootfs_restore.py
@@ -1,6 +1,7 @@
 """Unit tests for rootfs-image restore via multithreaded unsquashfs."""
 
 import io
+import signal
 import sys
 import tempfile
 import types
@@ -322,7 +323,7 @@ class InstallViaRootfsImageKeyFilesTest(unittest.TestCase):
         for patch in patches:
             patch.start()
             self.addCleanup(patch.stop)
-        ctx = types.SimpleNamespace(target=Path("/mnt/target"))
+        ctx = types.SimpleNamespace(target=Path("/mnt/target"), state={})
         phases_impl._install_via_rootfs_image(ctx, installer, object(), object())
         return calls
 
@@ -340,27 +341,149 @@ class InstallViaRootfsImageKeyFilesTest(unittest.TestCase):
         )
 
 
+class KeyringSigtermWindowTest(unittest.TestCase):
+    """A dashboard stop SIGTERMs the orchestrator's process group, which the
+    detached (start_new_session) keyring init survives. While the init runs,
+    SIGTERM must raise so the except-BaseException path kills and joins it,
+    and the previous disposition must come back afterwards."""
+
+    def run_install(self, *, configure_side_effect):
+        seen = {}
+
+        def configure(ctx, installer, config, mirror_handler):
+            seen["handler"] = signal.getsignal(signal.SIGTERM)
+            if configure_side_effect is not None:
+                raise configure_side_effect
+
+        def start_keyring(ctx):
+            ctx.state["target_keyring_proc"] = FakeKeyringProc(returncode=0)
+            ctx.state["target_keyring_proc"].pid = 1234
+
+        patches = [
+            mock.patch.object(phases_impl, "info"),
+            mock.patch.object(phases_impl.subprocess, "run"),
+            mock.patch.object(phases_impl.os, "killpg"),
+            mock.patch.object(
+                phases_impl, "_assert_rootfs_image_supported_config"
+            ),
+            mock.patch.object(phases_impl, "_restore_rootfs_image"),
+            mock.patch.object(
+                phases_impl, "_rootfs_image_configure", side_effect=configure
+            ),
+            mock.patch.object(
+                phases_impl, "_start_target_keyring_init",
+                side_effect=start_keyring,
+            ),
+            mock.patch.object(
+                phases_impl.arch, "is_pre_mount",
+                lambda config: False, create=True,
+            ),
+            mock.patch.object(
+                phases_impl.arch, "is_encrypted",
+                lambda config: False, create=True,
+            ),
+        ]
+        for patch in patches:
+            patch.start()
+            self.addCleanup(patch.stop)
+        ctx = types.SimpleNamespace(target=Path("/mnt/target"), state={})
+        phases_impl._install_via_rootfs_image(ctx, installer=mock.Mock(),
+                                             config=object(),
+                                             mirror_handler=object())
+        return ctx, seen
+
+    def test_sigterm_raises_inside_the_keyring_window(self):
+        before = signal.getsignal(signal.SIGTERM)
+        _, seen = self.run_install(configure_side_effect=None)
+        self.assertIs(seen["handler"], phases_impl._raise_on_sigterm)
+        with self.assertRaises(SystemExit):
+            seen["handler"](signal.SIGTERM, None)
+        self.assertIs(signal.getsignal(signal.SIGTERM), before)
+
+    def test_exception_path_kills_and_joins_the_init(self):
+        boom = RuntimeError("configure failed")
+        with self.assertRaises(RuntimeError) as raised:
+            self.run_install(configure_side_effect=boom)
+        self.assertIs(raised.exception, boom)
+        phases_impl.os.killpg.assert_called_once_with(
+            1234, phases_impl.signal.SIGKILL
+        )
+
+
 class StartTargetKeyringInitTest(unittest.TestCase):
     def test_shell_leads_its_own_process_group(self):
+        ctx = types.SimpleNamespace(target=Path("/mnt/target"), state={})
         with mock.patch.object(phases_impl, "info"), \
                 mock.patch.object(phases_impl.subprocess, "Popen") as popen:
-            phases_impl._start_target_keyring_init(
-                types.SimpleNamespace(target=Path("/mnt/target"))
-            )
+            phases_impl._start_target_keyring_init(ctx)
         self.assertTrue(popen.call_args.kwargs["start_new_session"])
+        self.assertIs(ctx.state["target_keyring_proc"], popen.return_value)
 
 
 class KillTargetKeyringInitTest(unittest.TestCase):
+    def ctx(self):
+        return types.SimpleNamespace(
+            state={"target_keyring_proc": types.SimpleNamespace(pid=1234)}
+        )
+
     def test_kills_the_whole_process_group(self):
         with mock.patch.object(phases_impl.os, "killpg") as killpg:
-            phases_impl._kill_target_keyring_init(types.SimpleNamespace(pid=1234))
+            phases_impl._kill_target_keyring_init(self.ctx())
         killpg.assert_called_once_with(1234, phases_impl.signal.SIGKILL)
 
     def test_tolerates_an_already_dead_group(self):
         with mock.patch.object(
             phases_impl.os, "killpg", side_effect=ProcessLookupError
         ):
-            phases_impl._kill_target_keyring_init(types.SimpleNamespace(pid=1234))
+            phases_impl._kill_target_keyring_init(self.ctx())
+
+    def test_noop_without_a_pending_init(self):
+        with mock.patch.object(phases_impl.os, "killpg") as killpg:
+            phases_impl._kill_target_keyring_init(types.SimpleNamespace(state={}))
+        killpg.assert_not_called()
+
+
+class AwaitTargetKeyringInitTest(unittest.TestCase):
+    """pacstrap -K runs its own pacman-key --init on the target's gnupg dir,
+    so every pacstrap-semantics site must join the background init first."""
+
+    def test_joins_the_pending_init_exactly_once(self):
+        ctx = types.SimpleNamespace(
+            target=Path("/mnt/target"),
+            state={"target_keyring_proc": FakeKeyringProc(returncode=0)},
+        )
+        with mock.patch.object(phases_impl, "info"), mock.patch.object(
+            phases_impl, "_finish_target_keyring_init"
+        ) as finish:
+            phases_impl._await_target_keyring_init(ctx)
+            phases_impl._await_target_keyring_init(ctx)
+        finish.assert_called_once()
+        self.assertNotIn("target_keyring_proc", ctx.state)
+
+    def test_noop_without_a_pending_init(self):
+        with mock.patch.object(
+            phases_impl, "_finish_target_keyring_init"
+        ) as finish:
+            phases_impl._await_target_keyring_init(
+                types.SimpleNamespace(state={})
+            )
+        finish.assert_not_called()
+
+    def test_accessibility_install_joins_before_pacstrap(self):
+        ctx = types.SimpleNamespace(
+            target=Path("/mnt/target"),
+            state={"target_keyring_proc": FakeKeyringProc(returncode=0)},
+        )
+        installer = mock.Mock()
+        with mock.patch.object(phases_impl, "info"), \
+                mock.patch.object(phases_impl.subprocess, "run"), \
+                mock.patch.object(
+                    phases_impl.arch, "accessibility_tools_in_use",
+                    lambda: True, create=True,
+                ):
+            phases_impl._install_accessibility_tools(ctx, installer)
+        self.assertNotIn("target_keyring_proc", ctx.state)
+        installer.add_additional_packages.assert_called_once()
 
 
 class FinishTargetKeyringInitTest(unittest.TestCase):

--- a/test/unit/test_rootfs_restore.py
+++ b/test/unit/test_rootfs_restore.py
@@ -8,7 +8,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "configs/airootfs/usr/share/omarchy-iso"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "configs/airootfs/usr/share/omarchy-iso"))
 
 sys.modules["orchestrator.archinstall_adapter"] = types.ModuleType("orchestrator.archinstall_adapter")
 

--- a/test/unit/test_rootfs_restore.py
+++ b/test/unit/test_rootfs_restore.py
@@ -136,6 +136,29 @@ class FakeKeyringProc:
         return self._output, None
 
 
+class StartTargetKeyringInitTest(unittest.TestCase):
+    def test_shell_leads_its_own_process_group(self):
+        with mock.patch.object(phases_impl, "info"), \
+                mock.patch.object(phases_impl.subprocess, "Popen") as popen:
+            phases_impl._start_target_keyring_init(
+                types.SimpleNamespace(target=Path("/mnt/target"))
+            )
+        self.assertTrue(popen.call_args.kwargs["start_new_session"])
+
+
+class KillTargetKeyringInitTest(unittest.TestCase):
+    def test_kills_the_whole_process_group(self):
+        with mock.patch.object(phases_impl.os, "killpg") as killpg:
+            phases_impl._kill_target_keyring_init(types.SimpleNamespace(pid=1234))
+        killpg.assert_called_once_with(1234, phases_impl.signal.SIGKILL)
+
+    def test_tolerates_an_already_dead_group(self):
+        with mock.patch.object(
+            phases_impl.os, "killpg", side_effect=ProcessLookupError
+        ):
+            phases_impl._kill_target_keyring_init(types.SimpleNamespace(pid=1234))
+
+
 class FinishTargetKeyringInitTest(unittest.TestCase):
     def setUp(self):
         self.run_cmds = []

--- a/test/unit/test_rootfs_restore.py
+++ b/test/unit/test_rootfs_restore.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "configs/airootfs/u
 
 sys.modules["orchestrator.archinstall_adapter"] = types.ModuleType("orchestrator.archinstall_adapter")
 
+from orchestrator import main as orchestrator_main  # noqa: E402
 from orchestrator import phases_impl  # noqa: E402
 
 
@@ -232,28 +233,21 @@ class AssertRootfsImageSupportedConfigTest(unittest.TestCase):
             )
 
 
-class InstallAccessibilityToolsTest(unittest.TestCase):
-    def run_helper(self, *, in_use):
-        ctx = types.SimpleNamespace(state={})
-        installer = mock.Mock()
+class AccessibilityPackagesTest(unittest.TestCase):
+    def packages(self, *, in_use):
         with mock.patch.object(phases_impl, "info"), mock.patch.object(
             phases_impl.arch, "accessibility_tools_in_use",
             lambda: in_use, create=True,
         ):
-            phases_impl._install_accessibility_tools(ctx, installer)
-        return ctx, installer
+            return phases_impl._accessibility_packages()
 
-    def test_installs_the_screen_reader_stack_when_live_session_uses_one(self):
-        ctx, installer = self.run_helper(in_use=True)
-        installer.add_additional_packages.assert_called_once_with(
-            ["brltty", "espeakup", "alsa-utils"]
+    def test_screen_reader_session_gets_the_stack(self):
+        self.assertEqual(
+            self.packages(in_use=True), phases_impl.ACCESSIBILITY_PACKAGES
         )
-        self.assertTrue(ctx.state["target_db_synced"])
 
-    def test_noop_without_accessibility_tools(self):
-        ctx, installer = self.run_helper(in_use=False)
-        installer.add_additional_packages.assert_not_called()
-        self.assertEqual(ctx.state, {})
+    def test_empty_without_a_screen_reader(self):
+        self.assertEqual(self.packages(in_use=False), [])
 
 
 class RootfsImageMarkerTest(unittest.TestCase):
@@ -288,29 +282,35 @@ class RootfsImageMarkerTest(unittest.TestCase):
         phases_impl._assert_rootfs_image_available()
 
 
-class InstallViaRootfsImageKeyFilesTest(unittest.TestCase):
-    """generate_key_files must follow the restore: it appends to the target's
-    /etc/crypttab, which unsquashfs -f would otherwise overwrite."""
+class InstallViaRootfsImageTestBase(unittest.TestCase):
+    """Shared harness driving _install_via_rootfs_image with every
+    collaborator patched out; subclasses pass their deltas."""
 
-    def run_install(self, *, encrypted, pre_mounted=False):
-        calls = []
-        installer = mock.Mock()
-        installer.generate_key_files.side_effect = (
-            lambda: calls.append("generate_key_files")
+    def run_install(self, *, encrypted=False, pre_mounted=False,
+                    configure=None, start_keyring=None):
+        self.calls = []
+        self.installer = mock.Mock()
+        self.installer.generate_key_files.side_effect = (
+            lambda: self.calls.append("generate_key_files")
         )
         patches = [
             mock.patch.object(phases_impl, "info"),
             mock.patch.object(phases_impl.subprocess, "run"),
+            mock.patch.object(phases_impl.os, "killpg"),
             mock.patch.object(
                 phases_impl, "_assert_rootfs_image_supported_config"
             ),
             mock.patch.object(
                 phases_impl, "_restore_rootfs_image",
-                side_effect=lambda ctx: calls.append("restore"),
+                side_effect=lambda ctx: self.calls.append("restore"),
             ),
-            mock.patch.object(phases_impl, "_rootfs_image_configure"),
-            mock.patch.object(phases_impl, "_start_target_keyring_init"),
-            mock.patch.object(phases_impl, "_finish_target_keyring_init"),
+            mock.patch.object(
+                phases_impl, "_rootfs_image_configure", side_effect=configure
+            ),
+            mock.patch.object(
+                phases_impl, "_start_target_keyring_init",
+                side_effect=start_keyring,
+            ),
             mock.patch.object(
                 phases_impl.arch, "is_pre_mount",
                 lambda config: pre_mounted, create=True,
@@ -323,9 +323,16 @@ class InstallViaRootfsImageKeyFilesTest(unittest.TestCase):
         for patch in patches:
             patch.start()
             self.addCleanup(patch.stop)
-        ctx = types.SimpleNamespace(target=Path("/mnt/target"), state={})
-        phases_impl._install_via_rootfs_image(ctx, installer, object(), object())
-        return calls
+        self.ctx = types.SimpleNamespace(target=Path("/mnt/target"), state={})
+        phases_impl._install_via_rootfs_image(
+            self.ctx, self.installer, object(), object()
+        )
+        return self.calls
+
+
+class InstallViaRootfsImageKeyFilesTest(InstallViaRootfsImageTestBase):
+    """generate_key_files must follow the restore: it appends to the target's
+    /etc/crypttab, which unsquashfs -f would otherwise overwrite."""
 
     def test_encrypted_generates_key_files_after_the_restore(self):
         self.assertEqual(
@@ -341,73 +348,35 @@ class InstallViaRootfsImageKeyFilesTest(unittest.TestCase):
         )
 
 
-class KeyringSigtermWindowTest(unittest.TestCase):
-    """A dashboard stop SIGTERMs the orchestrator's process group, which the
-    detached (start_new_session) keyring init survives. While the init runs,
-    SIGTERM must raise so the except-BaseException path kills and joins it,
-    and the previous disposition must come back afterwards."""
+class KeyringExceptionPathTest(InstallViaRootfsImageTestBase):
+    """A failure while the detached keyring init runs must kill its process
+    group and join it, and the original error must win. main()'s SIGTERM
+    handler is what routes a dashboard stop through this same path."""
 
-    def run_install(self, *, configure_side_effect):
-        seen = {}
-
-        def configure(ctx, installer, config, mirror_handler):
-            seen["handler"] = signal.getsignal(signal.SIGTERM)
-            if configure_side_effect is not None:
-                raise configure_side_effect
-
-        def start_keyring(ctx):
-            ctx.state["target_keyring_proc"] = FakeKeyringProc(returncode=0)
-            ctx.state["target_keyring_proc"].pid = 1234
-
-        patches = [
-            mock.patch.object(phases_impl, "info"),
-            mock.patch.object(phases_impl.subprocess, "run"),
-            mock.patch.object(phases_impl.os, "killpg"),
-            mock.patch.object(
-                phases_impl, "_assert_rootfs_image_supported_config"
-            ),
-            mock.patch.object(phases_impl, "_restore_rootfs_image"),
-            mock.patch.object(
-                phases_impl, "_rootfs_image_configure", side_effect=configure
-            ),
-            mock.patch.object(
-                phases_impl, "_start_target_keyring_init",
-                side_effect=start_keyring,
-            ),
-            mock.patch.object(
-                phases_impl.arch, "is_pre_mount",
-                lambda config: False, create=True,
-            ),
-            mock.patch.object(
-                phases_impl.arch, "is_encrypted",
-                lambda config: False, create=True,
-            ),
-        ]
-        for patch in patches:
-            patch.start()
-            self.addCleanup(patch.stop)
-        ctx = types.SimpleNamespace(target=Path("/mnt/target"), state={})
-        phases_impl._install_via_rootfs_image(ctx, installer=mock.Mock(),
-                                             config=object(),
-                                             mirror_handler=object())
-        return ctx, seen
-
-    def test_sigterm_raises_inside_the_keyring_window(self):
-        before = signal.getsignal(signal.SIGTERM)
-        _, seen = self.run_install(configure_side_effect=None)
-        self.assertIs(seen["handler"], phases_impl._raise_on_sigterm)
-        with self.assertRaises(SystemExit):
-            seen["handler"](signal.SIGTERM, None)
-        self.assertIs(signal.getsignal(signal.SIGTERM), before)
+    @staticmethod
+    def start_keyring(ctx):
+        proc = FakeKeyringProc(returncode=0)
+        proc.pid = 1234
+        ctx.state["target_keyring_proc"] = proc
 
     def test_exception_path_kills_and_joins_the_init(self):
         boom = RuntimeError("configure failed")
+
+        def configure(ctx, installer, config, mirror_handler):
+            raise boom
+
         with self.assertRaises(RuntimeError) as raised:
-            self.run_install(configure_side_effect=boom)
+            self.run_install(configure=configure,
+                             start_keyring=self.start_keyring)
         self.assertIs(raised.exception, boom)
         phases_impl.os.killpg.assert_called_once_with(
             1234, phases_impl.signal.SIGKILL
         )
+
+    def test_sigterm_converts_to_a_normal_unwind(self):
+        with self.assertRaises(SystemExit) as raised:
+            orchestrator_main._raise_on_sigterm(signal.SIGTERM, None)
+        self.assertEqual(raised.exception.code, 128 + signal.SIGTERM)
 
 
 class StartTargetKeyringInitTest(unittest.TestCase):
@@ -469,21 +438,23 @@ class AwaitTargetKeyringInitTest(unittest.TestCase):
             )
         finish.assert_not_called()
 
-    def test_accessibility_install_joins_before_pacstrap(self):
+class InstallTargetPackagesTest(unittest.TestCase):
+    """Owns the pacstrap-semantics obligations: join the background keyring
+    init before pacstrap -K touches the target's gnupg dir, then record that
+    the implicit -Sy already rewrote the target's sync db."""
+
+    def test_joins_installs_and_records_the_sync(self):
         ctx = types.SimpleNamespace(
             target=Path("/mnt/target"),
             state={"target_keyring_proc": FakeKeyringProc(returncode=0)},
         )
         installer = mock.Mock()
         with mock.patch.object(phases_impl, "info"), \
-                mock.patch.object(phases_impl.subprocess, "run"), \
-                mock.patch.object(
-                    phases_impl.arch, "accessibility_tools_in_use",
-                    lambda: True, create=True,
-                ):
-            phases_impl._install_accessibility_tools(ctx, installer)
+                mock.patch.object(phases_impl.subprocess, "run"):
+            phases_impl._install_target_packages(ctx, installer, ["tailscale"])
         self.assertNotIn("target_keyring_proc", ctx.state)
-        installer.add_additional_packages.assert_called_once()
+        installer.add_additional_packages.assert_called_once_with(["tailscale"])
+        self.assertTrue(ctx.state["target_db_synced"])
 
 
 class FinishTargetKeyringInitTest(unittest.TestCase):

--- a/test/unit/test_rootfs_restore.py
+++ b/test/unit/test_rootfs_restore.py
@@ -136,6 +136,38 @@ class FakeKeyringProc:
         return self._output, None
 
 
+class RootfsImageMarkerTest(unittest.TestCase):
+    """The install-mode decision is the build-time marker, never the image
+    file: an image ISO with a missing image must abort pre-format instead of
+    falling back to a pacstrap the pruned mirror cannot feed."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.marker = Path(self.tmp.name) / "rootfs-image-build"
+        self.image = Path(self.tmp.name) / "omarchy-rootfs.sfs"
+        for attr, value in (
+            ("ROOTFS_IMAGE_BUILD_MARKER", self.marker),
+            ("ROOTFS_IMAGE_PATH", self.image),
+        ):
+            patch = mock.patch.object(phases_impl, attr, value)
+            patch.start()
+            self.addCleanup(patch.stop)
+
+    def test_marker_presence_decides_the_install_mode(self):
+        self.assertFalse(phases_impl._is_rootfs_image_install())
+        self.marker.write_text("omarchy-rootfs.sfs\n")
+        self.assertTrue(phases_impl._is_rootfs_image_install())
+
+    def test_missing_image_refuses_the_install(self):
+        with self.assertRaisesRegex(RuntimeError, "refusing to touch the disk"):
+            phases_impl._assert_rootfs_image_available()
+
+    def test_present_image_passes(self):
+        self.image.write_bytes(b"sfs")
+        phases_impl._assert_rootfs_image_available()
+
+
 class InstallViaRootfsImageKeyFilesTest(unittest.TestCase):
     """generate_key_files must follow the restore: it appends to the target's
     /etc/crypttab, which unsquashfs -f would otherwise overwrite."""

--- a/test/unit/test_rootfs_restore.py
+++ b/test/unit/test_rootfs_restore.py
@@ -190,6 +190,37 @@ class AssertRootfsImageSupportedConfigTest(unittest.TestCase):
             self.config(disk_config=types.SimpleNamespace(lvm_config=None))
         )
 
+    def disk_config_with_fs(self, *fs_values):
+        return types.SimpleNamespace(
+            lvm_config=None,
+            device_modifications=[types.SimpleNamespace(partitions=[
+                types.SimpleNamespace(
+                    fs_type=(
+                        types.SimpleNamespace(value=value)
+                        if value is not None else None
+                    )
+                )
+                for value in fs_values
+            ])],
+        )
+
+    def test_filesystems_without_baked_tools_are_rejected(self):
+        for fs in ("xfs", "f2fs"):
+            self.assert_rejected(
+                "filesystem tools",
+                disk_config=self.disk_config_with_fs("fat32", fs),
+            )
+
+    def test_baked_filesystems_pass(self):
+        phases_impl._assert_rootfs_image_supported_config(self.config(
+            disk_config=self.disk_config_with_fs("fat32", "btrfs", "ext4")
+        ))
+
+    def test_partitions_without_an_fs_type_pass(self):
+        phases_impl._assert_rootfs_image_supported_config(self.config(
+            disk_config=self.disk_config_with_fs(None)
+        ))
+
     def test_unsupported_kernel_is_rejected(self):
         self.assert_rejected("linux-zen", kernels=["linux", "linux-zen"])
 

--- a/test/unit/test_rootfs_restore.py
+++ b/test/unit/test_rootfs_restore.py
@@ -200,6 +200,30 @@ class AssertRootfsImageSupportedConfigTest(unittest.TestCase):
             )
 
 
+class InstallAccessibilityToolsTest(unittest.TestCase):
+    def run_helper(self, *, in_use):
+        ctx = types.SimpleNamespace(state={})
+        installer = mock.Mock()
+        with mock.patch.object(phases_impl, "info"), mock.patch.object(
+            phases_impl.arch, "accessibility_tools_in_use",
+            lambda: in_use, create=True,
+        ):
+            phases_impl._install_accessibility_tools(ctx, installer)
+        return ctx, installer
+
+    def test_installs_the_screen_reader_stack_when_live_session_uses_one(self):
+        ctx, installer = self.run_helper(in_use=True)
+        installer.add_additional_packages.assert_called_once_with(
+            ["brltty", "espeakup", "alsa-utils"]
+        )
+        self.assertTrue(ctx.state["target_db_synced"])
+
+    def test_noop_without_accessibility_tools(self):
+        ctx, installer = self.run_helper(in_use=False)
+        installer.add_additional_packages.assert_not_called()
+        self.assertEqual(ctx.state, {})
+
+
 class RootfsImageMarkerTest(unittest.TestCase):
     """The install-mode decision is the build-time marker, never the image
     file: an image ISO with a missing image must abort pre-format instead of


### PR DESCRIPTION
Thinking about how to speed up installation time, I thought I'd try an image-based approach where we bake the universal packages into a squashfs image at build time, then restore it onto the target disk at install time. The hardware-specific packages/configs are applied afterwards.  On a cheap Intel 120U laptop this dropped the install time from 1m7s to 43s:
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="380" src="https://github.com/user-attachments/assets/d6800aa3-879f-4ee3-87aa-cd4c70199322" /></td>
    <td><img width="380" src="https://github.com/user-attachments/assets/23133934-16f9-482c-9d38-49e23fadc55b" /></td>
  </tr>
</table


Claude's notes below:

Today the installer replays ~925 package installs out of a ~3GB offline mirror — that's most of the install's wall time, spent redoing identical work on every machine. This PR does that work once, at ISO build time, and ships the result.

How it works

- The ISO build pacstraps the full universal package set into a scratch root and ships it as a zstd squashfs (omarchy-rootfs.sfs). The installer restores it with one multithreaded unsquashfs pass instead of ~925 pacman transactions.
- Since the universal set is baked, the shipped mirror shrinks to only what install time can still ask for: the hardware-conditional closure of omarchy-other.packages plus linux-t2 and tailscale. Net: the ISO gets smaller, not larger.

What stays per-machine at install time

- Identity is never baked: machine-id, SSH host keys, and the pacman keyring are scrubbed from the image (guarded by build-time asserts) and generated per install — the keyring init now runs in the background, hidden behind the rest of configuration.
- The install-time conditionals are reconciled after the restore: kernel swap for T2 Macs, tailscale only when an autoinstall auth key is staged.

Safety valve

- omarchy-iso-make --no-rootfs-image builds the legacy full-mirror ISO unchanged, and the installer picks its path by whether the image is present — the pacstrap flow stays intact for A/B and rollback.

🤖 Generated with Claude Code