### PR TITLE
Offer safe graphics boot for black-screen installs

### DIFF
--- a/configs/grub/grub.cfg
+++ b/configs/grub/grub.cfg
@@ -46,8 +46,8 @@ fi
 
 # Set default menu entry
 default=archlinux
-timeout=0
-timeout_style=hidden
+timeout=3
+timeout_style=menu
 
 
 # Menu entries
@@ -55,6 +55,12 @@ timeout_style=hidden
 menuentry "Omarchy (%ARCH%, ${archiso_platform})" --class arch --class gnu-linux --class gnu --class os --id 'archlinux' {
     set gfxpayload=keep
     linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux-t2 archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% quiet splash xe.enable_panel_replay=0 initramfs_async=0
+    initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux-t2.img
+}
+
+menuentry "Omarchy with safe graphics (%ARCH%, ${archiso_platform})" --class arch --class gnu-linux --class gnu --class os --id 'archlinux-safe-graphics' {
+    set gfxpayload=keep
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux-t2 archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% quiet splash xe.enable_panel_replay=0 initramfs_async=0 nomodeset
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux-t2.img
 }
 

--- a/configs/grub/grub.cfg
+++ b/configs/grub/grub.cfg
@@ -58,7 +58,7 @@ menuentry "Omarchy (%ARCH%, ${archiso_platform})" --class arch --class gnu-linux
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux-t2.img
 }
 
-menuentry "Omarchy with safe graphics (%ARCH%, ${archiso_platform})" --class arch --class gnu-linux --class gnu --class os --id 'archlinux-safe-graphics' {
+menuentry "Omarchy with safe graphics (%ARCH%, ${archiso_platform})" --hotkey g --class arch --class gnu-linux --class gnu --class os --id 'archlinux-safe-graphics' {
     set gfxpayload=keep
     linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux-t2 archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% quiet splash xe.enable_panel_replay=0 initramfs_async=0 nomodeset
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux-t2.img

--- a/configs/grub/loopback.cfg
+++ b/configs/grub/loopback.cfg
@@ -34,7 +34,7 @@ menuentry "Omarchy (%ARCH%, ${archiso_platform})" --class arch --class gnu-linux
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux-t2.img
 }
 
-menuentry "Omarchy with safe graphics (%ARCH%, ${archiso_platform})" --class arch --class gnu-linux --class gnu --class os --id 'archlinux-safe-graphics' {
+menuentry "Omarchy with safe graphics (%ARCH%, ${archiso_platform})" --hotkey g --class arch --class gnu-linux --class gnu --class os --id 'archlinux-safe-graphics' {
     set gfxpayload=keep
     linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux-t2 archisobasedir=%INSTALL_DIR% img_dev=UUID=${archiso_img_dev_uuid} img_loop="${iso_path}" quiet splash xe.enable_panel_replay=0 initramfs_async=0 nomodeset
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux-t2.img

--- a/configs/grub/loopback.cfg
+++ b/configs/grub/loopback.cfg
@@ -22,8 +22,8 @@ fi
 
 # Set default menu entry
 default=archlinux
-timeout=0
-timeout_style=hidden
+timeout=3
+timeout_style=menu
 
 
 # Menu entries
@@ -31,6 +31,12 @@ timeout_style=hidden
 menuentry "Omarchy (%ARCH%, ${archiso_platform})" --class arch --class gnu-linux --class gnu --class os --id 'archlinux' {
     set gfxpayload=keep
     linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux-t2 archisobasedir=%INSTALL_DIR% img_dev=UUID=${archiso_img_dev_uuid} img_loop="${iso_path}" quiet splash xe.enable_panel_replay=0 initramfs_async=0
+    initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux-t2.img
+}
+
+menuentry "Omarchy with safe graphics (%ARCH%, ${archiso_platform})" --class arch --class gnu-linux --class gnu --class os --id 'archlinux-safe-graphics' {
+    set gfxpayload=keep
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux-t2 archisobasedir=%INSTALL_DIR% img_dev=UUID=${archiso_img_dev_uuid} img_loop="${iso_path}" quiet splash xe.enable_panel_replay=0 initramfs_async=0 nomodeset
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux-t2.img
 }
 

--- a/configs/syslinux/archiso_sys-linux.cfg
+++ b/configs/syslinux/archiso_sys-linux.cfg
@@ -8,6 +8,17 @@ LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-t2
 INITRD /%INSTALL_DIR%/boot/x86_64/initramfs-linux-t2.img
 APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% quiet splash xe.enable_panel_replay=0 initramfs_async=0
 
+# Safe graphics boot option
+LABEL arch64safe
+TEXT HELP
+Boot the Omarchy install medium on BIOS without kernel mode setting.
+Use this when the normal boot leaves the display black.
+ENDTEXT
+MENU LABEL Omarchy install medium (x86_64, BIOS) with safe ^graphics
+LINUX /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux-t2
+INITRD /%INSTALL_DIR%/boot/x86_64/initramfs-linux-t2.img
+APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% quiet splash xe.enable_panel_replay=0 initramfs_async=0 nomodeset
+
 # Accessibility boot option
 LABEL arch64speech
 TEXT HELP

--- a/test/unit/safe-graphics-boot-test.sh
+++ b/test/unit/safe-graphics-boot-test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+grub_entry() {
+  local config="$1" id="$2"
+
+  awk -v id="--id '$id'" '
+    index($0, id) { inside = 1 }
+    inside { print }
+    inside && /^}/ { exit }
+  ' "$config"
+}
+
+syslinux_entry() {
+  local config="$1" label="$2"
+
+  awk -v label="LABEL $label" '
+    $0 == label { inside = 1 }
+    inside && /^LABEL / && $0 != label { exit }
+    inside { print }
+  ' "$config"
+}
+
+for config in "$ROOT/configs/grub/grub.cfg" "$ROOT/configs/grub/loopback.cfg"; do
+  normal=$(grub_entry "$config" archlinux)
+  safe=$(grub_entry "$config" archlinux-safe-graphics)
+  ids=$(sed -n "s/.*--id '\([^']*\)'.*/\1/p" "$config")
+
+  [[ -n $normal ]] || fail "$(basename "$config") keeps the normal boot entry"
+  [[ $normal != *nomodeset* ]] || fail "$(basename "$config") leaves normal boot graphics unchanged"
+  [[ $safe == *nomodeset* ]] || fail "$(basename "$config") gives safe graphics its own kernel mode"
+  [[ $(wc -l <<<"$ids") == $(sort -u <<<"$ids" | wc -l) ]] ||
+    fail "$(basename "$config") gives every menu entry a unique ID"
+  [[ $(grep -ow 'nomodeset' "$config" | wc -l) == 1 ]] ||
+    fail "$(basename "$config") limits nomodeset to safe graphics"
+  grep -Fxq 'default=archlinux' "$config" || fail "$(basename "$config") keeps normal boot as the default"
+  grep -Fxq 'timeout=3' "$config" || fail "$(basename "$config") leaves time to select safe graphics"
+  grep -Fxq 'timeout_style=menu' "$config" || fail "$(basename "$config") shows the safe graphics choice"
+
+  pass "$(basename "$config") offers safe graphics without changing the default"
+done
+
+syslinux="$ROOT/configs/syslinux/archiso_sys-linux.cfg"
+normal=$(syslinux_entry "$syslinux" arch64)
+safe=$(syslinux_entry "$syslinux" arch64safe)
+
+[[ -n $normal ]] || fail "Syslinux keeps the normal boot entry"
+[[ $normal != *nomodeset* ]] || fail "Syslinux leaves normal boot graphics unchanged"
+[[ $safe == *nomodeset* ]] || fail "Syslinux safe graphics disables kernel mode setting"
+[[ $(grep -c '^LABEL arch64safe$' "$syslinux") == 1 ]] || fail "Syslinux has one safe graphics entry"
+pass "Syslinux offers safe graphics without changing the default"

--- a/test/unit/safe-graphics-boot-test.sh
+++ b/test/unit/safe-graphics-boot-test.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+ROOT=${OMARCHY_SAFE_GRAPHICS_TEST_ROOT:-$ROOT}
 
 pass() {
   printf 'ok - %s\n' "$1"
@@ -17,9 +18,9 @@ grub_entry() {
   local config="$1" id="$2"
 
   awk -v id="--id '$id'" '
-    index($0, id) { inside = 1 }
+    /^[[:space:]]*menuentry[[:space:]]/ && index($0, id) { inside = 1 }
     inside { print }
-    inside && /^}/ { exit }
+    inside && /^[[:space:]]*}/ { exit }
   ' "$config"
 }
 
@@ -29,25 +30,49 @@ syslinux_entry() {
   awk -v label="LABEL $label" '
     $0 == label { inside = 1 }
     inside && /^LABEL / && $0 != label { exit }
-    inside { print }
+    /^TEXT HELP$/ { help = 1 }
+    inside && !help { print }
+    /^ENDTEXT$/ { help = 0 }
   ' "$config"
+}
+
+grub_setting() {
+  awk -v key="$2" '
+    $0 ~ "^[[:space:]]*(set[[:space:]]+)?" key "=" {
+      value=$0
+      sub("^[[:space:]]*(set[[:space:]]+)?" key "=", "", value)
+      sub(/[[:space:]]*#.*$/, "", value)
+      gsub(/^[[:space:]\047\042]+|[[:space:]\047\042]+$/, "", value)
+    }
+    END { print value }
+  ' "$1"
+}
+
+kernel_line() {
+  awk -v command="$1" '$1 == command && NF > 1 { print }'
 }
 
 for config in "$ROOT/configs/grub/grub.cfg" "$ROOT/configs/grub/loopback.cfg"; do
   normal=$(grub_entry "$config" archlinux)
   safe=$(grub_entry "$config" archlinux-safe-graphics)
-  ids=$(sed -n "s/.*--id '\([^']*\)'.*/\1/p" "$config")
+  ids=$(sed -n "/^[[:space:]]*menuentry[[:space:]]/s/.*--id '\([^']*\)'.*/\1/p" "$config")
 
   [[ -n $normal ]] || fail "$(basename "$config") keeps the normal boot entry"
-  [[ $normal != *nomodeset* ]] || fail "$(basename "$config") leaves normal boot graphics unchanged"
-  [[ $safe == *nomodeset* ]] || fail "$(basename "$config") gives safe graphics its own kernel mode"
+  normal_linux=$(kernel_line linux <<< "$normal")
+  safe_linux=$(kernel_line linux <<< "$safe")
+  [[ -n $normal_linux && -n $(kernel_line initrd <<< "$normal") ]] || fail "$(basename "$config") has a bootable normal entry"
+  [[ -n $safe_linux && -n $(kernel_line initrd <<< "$safe") ]] || fail "$(basename "$config") has a bootable safe entry"
+  [[ ! $normal_linux =~ (^|[[:space:]])nomodeset([[:space:]]|$) ]] || fail "$(basename "$config") leaves normal boot graphics unchanged"
+  [[ $safe_linux =~ (^|[[:space:]])nomodeset([[:space:]]|$) ]] || fail "$(basename "$config") gives safe graphics its own kernel mode"
   [[ $(wc -l <<<"$ids") == $(sort -u <<<"$ids" | wc -l) ]] ||
     fail "$(basename "$config") gives every menu entry a unique ID"
   [[ $(grep -ow 'nomodeset' "$config" | wc -l) == 1 ]] ||
     fail "$(basename "$config") limits nomodeset to safe graphics"
-  grep -Fxq 'default=archlinux' "$config" || fail "$(basename "$config") keeps normal boot as the default"
-  grep -Fxq 'timeout=3' "$config" || fail "$(basename "$config") leaves time to select safe graphics"
-  grep -Fxq 'timeout_style=menu' "$config" || fail "$(basename "$config") shows the safe graphics choice"
+  [[ $(grub_setting "$config" default) == "archlinux" ]] || fail "$(basename "$config") keeps normal boot as the default"
+  timeout=$(grub_setting "$config" timeout)
+  [[ $timeout =~ ^[0-9]+$ ]] && (( 10#$timeout > 0 )) || fail "$(basename "$config") leaves time to select safe graphics"
+  style=$(grub_setting "$config" timeout_style)
+  [[ $style == "menu" || $style == "hidden" || $style == "countdown" ]] || fail "$(basename "$config") has a supported timeout style"
 
   pass "$(basename "$config") offers safe graphics without changing the default"
 done
@@ -57,7 +82,15 @@ normal=$(syslinux_entry "$syslinux" arch64)
 safe=$(syslinux_entry "$syslinux" arch64safe)
 
 [[ -n $normal ]] || fail "Syslinux keeps the normal boot entry"
-[[ $normal != *nomodeset* ]] || fail "Syslinux leaves normal boot graphics unchanged"
-[[ $safe == *nomodeset* ]] || fail "Syslinux safe graphics disables kernel mode setting"
+for entry in "$normal" "$safe"; do
+  for directive in LINUX INITRD APPEND; do
+    [[ -n $(kernel_line "$directive" <<< "$entry") ]] || fail "Syslinux boot entries require $directive"
+  done
+done
+normal_append=$(kernel_line APPEND <<< "$normal")
+safe_append=$(kernel_line APPEND <<< "$safe")
+[[ ! $normal_append =~ (^|[[:space:]])nomodeset([[:space:]]|$) ]] || fail "Syslinux leaves normal boot graphics unchanged"
+[[ $safe_append =~ (^|[[:space:]])nomodeset([[:space:]]|$) ]] || fail "Syslinux safe graphics disables kernel mode setting"
 [[ $(grep -c '^LABEL arch64safe$' "$syslinux") == 1 ]] || fail "Syslinux has one safe graphics entry"
+[[ $(awk '$1 == "DEFAULT" { value=$2 } END { print value }' "$ROOT/configs/syslinux/archiso_sys.cfg") == "arch64" ]] || fail "Syslinux keeps normal boot as the default"
 pass "Syslinux offers safe graphics without changing the default"

--- a/test/unit/safe-graphics-boot-test.sh
+++ b/test/unit/safe-graphics-boot-test.sh
@@ -64,6 +64,9 @@ for config in "$ROOT/configs/grub/grub.cfg" "$ROOT/configs/grub/loopback.cfg"; d
   [[ -n $safe_linux && -n $(kernel_line initrd <<< "$safe") ]] || fail "$(basename "$config") has a bootable safe entry"
   [[ ! $normal_linux =~ (^|[[:space:]])nomodeset([[:space:]]|$) ]] || fail "$(basename "$config") leaves normal boot graphics unchanged"
   [[ $safe_linux =~ (^|[[:space:]])nomodeset([[:space:]]|$) ]] || fail "$(basename "$config") gives safe graphics its own kernel mode"
+  # The hotkey is the only way in when gfxterm never paints the menu.
+  [[ $(head -1 <<< "$safe") =~ (^|[[:space:]])--hotkey[[:space:]]+g([[:space:]]|$) ]] ||
+    fail "$(basename "$config") gives safe graphics a hotkey"
   [[ $(wc -l <<<"$ids") == $(sort -u <<<"$ids" | wc -l) ]] ||
     fail "$(basename "$config") gives every menu entry a unique ID"
   [[ $(grep -ow 'nomodeset' "$config" | wc -l) == 1 ]] ||

--- a/test/unit/safe-graphics-mutations-test.sh
+++ b/test/unit/safe-graphics-mutations-test.sh
@@ -5,7 +5,19 @@ ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
 test_tmp=$(mktemp -d)
 trap 'rm -rf "$test_tmp"' EXIT
 
-for mutation in comment_only help_only bios_default zero_timeout grub_default missing_initrd; do
+# A harness that only asserts failure goes green when the fixture itself is
+# broken, so prove an untouched copy still passes before trusting a rejection.
+baseline="$test_tmp/baseline"
+mkdir -p "$baseline"
+cp -r "$ROOT/configs" "$baseline/"
+if ! OMARCHY_SAFE_GRAPHICS_TEST_ROOT="$baseline" bash "$ROOT/test/unit/safe-graphics-boot-test.sh" > "$baseline/output" 2>&1; then
+  cat "$baseline/output" >&2
+  printf 'not ok - safe graphics tests accept an unmutated tree\n' >&2
+  exit 1
+fi
+printf 'ok - safe graphics tests accept an unmutated tree\n'
+
+for mutation in comment_only help_only bios_default zero_timeout grub_default missing_initrd no_hotkey; do
   fixture="$test_tmp/$mutation"
   mkdir -p "$fixture"
   cp -r "$ROOT/configs" "$fixture/"
@@ -31,6 +43,9 @@ for mutation in comment_only help_only bios_default zero_timeout grub_default mi
     ;;
   missing_initrd)
     sed -i "/^menuentry .*--id 'archlinux-safe-graphics'/,/^}/ { /^[[:space:]]*initrd /d; }" "$grub"
+    ;;
+  no_hotkey)
+    sed -i "/--id 'archlinux-safe-graphics'/s/ --hotkey g//" "$grub"
     ;;
   esac
   if OMARCHY_SAFE_GRAPHICS_TEST_ROOT="$fixture" bash "$ROOT/test/unit/safe-graphics-boot-test.sh" > "$fixture/output" 2>&1; then

--- a/test/unit/safe-graphics-mutations-test.sh
+++ b/test/unit/safe-graphics-mutations-test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -euo pipefail
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+
+for mutation in comment_only help_only bios_default zero_timeout grub_default missing_initrd; do
+  fixture="$test_tmp/$mutation"
+  mkdir -p "$fixture"
+  cp -r "$ROOT/configs" "$fixture/"
+  grub="$fixture/configs/grub/grub.cfg"
+  syslinux="$fixture/configs/syslinux/archiso_sys-linux.cfg"
+  case "$mutation" in
+  comment_only)
+    sed -i "/^menuentry .*--id 'archlinux-safe-graphics'/,/^}/d" "$grub"
+    printf '%s\n' "# --id 'archlinux-safe-graphics' nomodeset" >> "$grub"
+    ;;
+  help_only)
+    sed -i '/^LABEL arch64safe$/,/^LABEL arch64speech$/ { /^LINUX /d; /^INITRD /d; /^APPEND /d; }' "$syslinux"
+    sed -i '/^TEXT HELP$/a nomodeset' "$syslinux"
+    ;;
+  bios_default)
+    printf '%s\n' 'DEFAULT arch64safe' >> "$fixture/configs/syslinux/archiso_sys.cfg"
+    ;;
+  zero_timeout)
+    printf '%s\n' 'timeout=0' 'timeout_style=hidden' >> "$grub"
+    ;;
+  grub_default)
+    printf '%s\n' 'set default=archlinux-safe-graphics' >> "$grub"
+    ;;
+  missing_initrd)
+    sed -i "/^menuentry .*--id 'archlinux-safe-graphics'/,/^}/ { /^[[:space:]]*initrd /d; }" "$grub"
+    ;;
+  esac
+  if OMARCHY_SAFE_GRAPHICS_TEST_ROOT="$fixture" bash "$ROOT/test/unit/safe-graphics-boot-test.sh" > "$fixture/output" 2>&1; then
+    printf 'not ok - safe graphics tests accepted %s\n' "$mutation" >&2
+    exit 1
+  fi
+  printf 'ok - safe graphics tests reject %s\n' "$mutation"
+done


### PR DESCRIPTION
Some newer GPUs can black-screen before the configurator starts. The reporter in basecamp/omarchy#7045 confirmed the same Quattro ISO boots after adding `nomodeset`.

Keep the normal accelerated entry as the default, but show the boot menu for three seconds and add a separate **safe graphics** entry with `nomodeset`. Mirror the fallback for GRUB loopback and legacy BIOS boot.

The regression test keeps `nomodeset` isolated to the safe entries, checks unique GRUB IDs, and ensures normal boot remains the default.

Fixes basecamp/omarchy#7045.

Tested with:
- `bash test/unit/safe-graphics-boot-test.sh`
- `grub-script-check configs/grub/grub.cfg`
- `grub-script-check configs/grub/loopback.cfg`
- [Full x86 ISO build](https://github.com/yashranaway/omarchy-iso/actions/runs/31927871918)