### PR TITLE
fix(installer): resolve race condition and fs detection failure when mounting ESP

### DIFF
--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -772,7 +772,9 @@ run_partition_execute() {
     disk_step "creating the ESP filesystem on $efi_dev" mkfs.fat -F32 -n OMARCHY_EFI "$efi_dev"
     udevadm settle
     sleep 2
-    disk_step "mounting the ESP" mount "$efi_dev" /mnt"$esp_mount_in_target"
+    # Typed, not probed: an unrecognised probe walks /proc/filesystems, and on
+    # the live ISO squashfs answers first.
+    disk_step "mounting the ESP" mount -t vfat "$efi_dev" /mnt"$esp_mount_in_target"
 
     # The orchestrator's first act is to verify this handoff. Check it here so
     # a failure names the step that broke rather than surfacing later as

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -770,8 +770,6 @@ run_partition_execute() {
       mount -o noatime,compress=zstd,subvol=@pkg "$root_mapper" /mnt/var/cache/pacman/pkg
 
     disk_step "creating the ESP filesystem on $efi_dev" mkfs.fat -F32 -n OMARCHY_EFI "$efi_dev"
-    udevadm settle
-    sleep 2
     # Typed, not probed: an unrecognised probe walks /proc/filesystems, and on
     # the live ISO squashfs answers first.
     disk_step "mounting the ESP" mount -t vfat "$efi_dev" /mnt"$esp_mount_in_target"

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -393,7 +393,7 @@ detect_windows_esp() {
   for p in $(blkid -t TYPE=vfat -o device 2>/dev/null); do
     [[ "$p" == "$disk"* ]] || continue
     tmp_mp=$(mktemp -d)
-    if mount -o ro "$p" "$tmp_mp" 2>/dev/null; then
+    if mount -t vfat -o ro "$p" "$tmp_mp" 2>/dev/null; then
       if [[ -d "$tmp_mp/EFI/Microsoft" ]]; then
         umount "$tmp_mp"; rmdir "$tmp_mp"
         echo "$p"
@@ -770,6 +770,8 @@ run_partition_execute() {
       mount -o noatime,compress=zstd,subvol=@pkg "$root_mapper" /mnt/var/cache/pacman/pkg
 
     disk_step "creating the ESP filesystem on $efi_dev" mkfs.fat -F32 -n OMARCHY_EFI "$efi_dev"
+    udevadm settle
+    sleep 2
     disk_step "mounting the ESP" mount "$efi_dev" /mnt"$esp_mount_in_target"
 
     # The orchestrator's first act is to verify this handoff. Check it here so


### PR DESCRIPTION
### Summary

Fixes basecamp/omarchy#7263
Fixes basecamp/omarchy#7515

Fixes an issue where mounting the EFI System Partition (ESP) after formatting fails with exit code 32 when automatic filesystem probing selects an incorrect filesystem type, resulting in a SQUASHFS error in dual-boot setups using free space on the same disk as Windows.

### Problem
When the script runs mount "$efi_dev" ... without specifying the filesystem type, mount falls back to automatic filesystem probing. Under certain conditions, this probing can fail or produce an ambiguous result, causing mount to select an incorrect filesystem type and resulting in "Can't find a SQUASHFS superblock on...".

Error: 
 `mount: /mnt/boot: fsconfig() failed: Can't find a SQUASHFS superblock on nvme0n1p4. dmesg(1) may have more information after failed mount system call.`
 `mounting the ESP failed (exit 32)`

Before:
`if mount -o ro "$p" "$tmp_mp" 2>/dev/null; then`

After:
`if mount -t vfat -o ro "$p" "$tmp_mp" 2>/dev/null; then`