### PR TITLE
Fall back to the removable ESP path when firmware refuses a boot entry

### DIFF
--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -397,6 +397,18 @@ def _install_pre_mounted_limine(ctx: InstallContext) -> None:
         raise RuntimeError("Windows boot entry disappeared during Limine install — aborting")
 
 
+class EfiEntryRegistrationError(RuntimeError):
+    """efibootmgr refused to write the boot variable.
+
+    Separated from every other failure in here because it is the one the
+    removable-path fallback can actually rescue. Old firmware — the same HP
+    ProBook whose NVRAM prompted the tolerant decode in command.py, among
+    others — answers reads fine and then rejects a new Boot#### variable,
+    usually with NVRAM full. That is survivable: the firmware still boots the
+    default removable loader off the ESP without any variable at all.
+    """
+
+
 def _install_limine_efi(
     ctx: InstallContext,
     *,
@@ -422,7 +434,52 @@ def _install_limine_efi(
     _write_limine_pacman_hook(ctx.target, hook_command)
 
     loader = "\\" + str(Path(esp_path) / efi_binary).strip("/").replace("/", "\\")
-    _register_limine_efi_entry(disk, part, loader, pre_state=pre_state)
+    try:
+        _register_limine_efi_entry(disk, part, loader, pre_state=pre_state)
+    except EfiEntryRegistrationError as exc:
+        if removable:
+            # Already at the removable path, so the loader firmware looks for by
+            # default is in place and the missing variable costs nothing.
+            info(f"› warning: {exc}")
+            info("› boot entry not registered; the removable loader still boots")
+            return
+
+        error(f"efibootmgr could not register a boot entry: {exc}")
+        info("› falling back to the removable ESP path")
+        _install_removable_fallback(
+            ctx,
+            esp_mount=esp_mount,
+            source=limine_path / source_name,
+            primary=target_path,
+        )
+
+
+def _install_removable_fallback(
+    ctx: InstallContext,
+    *,
+    esp_mount: str,
+    source: Path,
+    primary: Path,
+) -> None:
+    r"""Put the loader where firmware looks with no Boot#### variable.
+
+    \EFI\BOOT\BOOTX64.EFI is the removable-media path every UEFI
+    implementation falls back to when nothing in NVRAM matches. Writing it costs
+    one file and rescues machines whose firmware will not take a new variable.
+
+    The copy at the configured path stays, so this machine boots either way if
+    its NVRAM is cleared later. The pacman hook is rewritten to refresh both, or
+    a limine upgrade would quietly leave the path actually being booted stale.
+    """
+    fallback = Path(esp_mount) / "EFI" / "BOOT" / "BOOTX64.EFI"
+    _copy_required(source, ctx.target / fallback.relative_to("/"))
+    info(f"› installed removable fallback loader at {fallback}")
+
+    _write_limine_pacman_hook(
+        ctx.target,
+        f"/usr/bin/cp /usr/share/limine/{source.name} {primary} && "
+        f"/usr/bin/cp /usr/share/limine/{source.name} {fallback}",
+    )
 
 
 def _register_limine_efi_entry(
@@ -440,7 +497,11 @@ def _register_limine_efi_entry(
             check=False, capture_output=True,
         )
 
-    subprocess.run(
+    # capture() rather than check=True: the reason efibootmgr refused is the
+    # whole diagnosis, and a bare CalledProcessError throws it away. It also
+    # decodes tolerantly, which matters here — firmware that rejects writes is
+    # the same firmware that keeps non-UTF-8 legacy BBS entries in NVRAM.
+    created = capture(
         [
             "efibootmgr",
             "--create",
@@ -450,14 +511,21 @@ def _register_limine_efi_entry(
             "--loader", loader,
             "--unicode",
             "--verbose",
-        ],
-        check=True,
+        ]
     )
+    if created.returncode != 0:
+        detail = (created.stderr or created.stdout or "").strip().splitlines()
+        raise EfiEntryRegistrationError(
+            f"efibootmgr exited {created.returncode}"
+            + (f": {detail[-1]}" if detail else "")
+        )
 
     post_state = _read_efibootmgr()
     new_limine = _find_label_entries(post_state["entries"], "Limine")
     if not new_limine:
-        raise RuntimeError("efibootmgr --create reported success but no Limine entry found")
+        raise EfiEntryRegistrationError(
+            "efibootmgr --create reported success but no Limine entry appeared"
+        )
     limine_num = new_limine[0]
 
     keep = [

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -472,7 +472,9 @@ def _install_removable_fallback(
     a limine upgrade would quietly leave the path actually being booted stale.
     """
     fallback = Path(esp_mount) / "EFI" / "BOOT" / "BOOTX64.EFI"
-    _copy_required(source, ctx.target / fallback.relative_to("/"))
+    fallback_on_target = ctx.target / fallback.relative_to("/")
+    _preserve_foreign_removable_loader(fallback_on_target, source, fallback)
+    _copy_required(source, fallback_on_target)
     info(f"› installed removable fallback loader at {fallback}")
 
     _write_limine_pacman_hook(
@@ -480,6 +482,35 @@ def _install_removable_fallback(
         f"/usr/bin/cp /usr/share/limine/{source.name} {primary} && "
         f"/usr/bin/cp /usr/share/limine/{source.name} {fallback}",
     )
+
+
+def _preserve_foreign_removable_loader(path: Path, source: Path, esp_path: Path) -> None:
+    """Move another system's fallback loader aside instead of destroying it.
+
+    A protected install shares the ESP with whatever was already on it, and a
+    Windows install commonly keeps a copy of its boot manager at the removable
+    path. That copy is not what boots Windows — its own Boot#### entry is — but
+    it is the route that still works once NVRAM has been cleared, which is
+    exactly the firmware condition this fallback exists for. Taking it away to
+    fix our own boot problem would hand the other system ours.
+
+    Renaming is enough: the displaced loader keeps working the moment it is put
+    back, and the name says where it came from.
+    """
+    if not path.exists():
+        return
+    if path.read_bytes() == source.read_bytes():
+        # Ours already, from an earlier attempt at this same install.
+        return
+
+    backup = path.with_name(path.name + ".omarchy-backup")
+    if backup.exists():
+        # Preserved on a previous attempt; what is at the live path now is ours,
+        # and the backup is the real original. Do not bury it.
+        return
+
+    path.rename(backup)
+    info(f"› preserved the existing removable loader as {esp_path}.omarchy-backup")
 
 
 def _register_limine_efi_entry(

--- a/test/unit/test_efi_removable_fallback.py
+++ b/test/unit/test_efi_removable_fallback.py
@@ -154,6 +154,46 @@ class EfiRemovableFallbackTest(unittest.TestCase):
         self.assertTrue(self.removable.exists())
         self.assertNotIn("&&", self.hook())
 
+    def test_another_systems_fallback_loader_is_moved_aside_not_destroyed(self):
+        # A protected install shares the ESP with Windows, which keeps a copy of
+        # its boot manager here. Overwriting it would take away the route that
+        # still works once NVRAM is cleared — the exact condition we are in.
+        self.fake_efibootmgr(create_succeeds=False)
+        self.removable.parent.mkdir(parents=True)
+        self.removable.write_bytes(b"windows boot manager")
+
+        self.install()
+
+        self.assertEqual(self.removable.read_bytes(), b"limine loader")
+        preserved = self.removable.with_name("BOOTX64.EFI.omarchy-backup")
+        self.assertTrue(preserved.exists(), "the displaced loader was destroyed")
+        self.assertEqual(preserved.read_bytes(), b"windows boot manager")
+
+    def test_a_second_attempt_does_not_bury_the_preserved_original(self):
+        # Re-running the install must not overwrite the backup with our own
+        # loader, which would lose the original for good.
+        self.fake_efibootmgr(create_succeeds=False)
+        self.removable.parent.mkdir(parents=True)
+        self.removable.write_bytes(b"windows boot manager")
+
+        self.install()
+        self.install()
+
+        preserved = self.removable.with_name("BOOTX64.EFI.omarchy-backup")
+        self.assertEqual(preserved.read_bytes(), b"windows boot manager")
+
+    def test_our_own_loader_is_not_backed_up_over_and_over(self):
+        self.fake_efibootmgr(create_succeeds=False)
+        self.removable.parent.mkdir(parents=True)
+        self.removable.write_bytes(b"limine loader")
+
+        self.install()
+
+        self.assertFalse(
+            self.removable.with_name("BOOTX64.EFI.omarchy-backup").exists(),
+            "backed up a loader that was already ours",
+        )
+
     def test_firmware_that_accepts_the_variable_gets_no_fallback_copy(self):
         self.fake_efibootmgr(create_succeeds=True)
 

--- a/test/unit/test_efi_removable_fallback.py
+++ b/test/unit/test_efi_removable_fallback.py
@@ -1,0 +1,171 @@
+#!/usr/bin/python
+
+"""Firmware that answers efibootmgr reads and then refuses to write.
+
+The HP ProBook that prompted the tolerant decode in command.py fails the next
+step too: `efibootmgr --create` returns non-zero rather than registering a
+Boot#### variable, and the install died there with a bare CalledProcessError
+that said nothing about why. A machine in that state is still bootable — every
+UEFI implementation falls back to \\EFI\\BOOT\\BOOTX64.EFI on the ESP when
+nothing in NVRAM matches — so these tests pin the rescue rather than the crash,
+driving a stand-in efibootmgr that refuses the write the way that firmware does.
+"""
+
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "configs/airootfs/usr/share/omarchy-iso"))
+
+# phases_impl imports the archinstall adapter at module scope, which pulls in
+# the archinstall library that only exists on the live ISO.
+sys.modules.setdefault(
+    "orchestrator.archinstall_adapter",
+    types.ModuleType("orchestrator.archinstall_adapter"),
+)
+
+from orchestrator import phases_impl  # noqa: E402
+
+EFIBOOTMGR_LISTING = (
+    "BootCurrent: 0003\n"
+    "Timeout: 0 seconds\n"
+    "BootOrder: 2001,0003\n"
+    "Boot0003* Limine\tHD(1,GPT,0d9c9d4f)/File(\\EFI\\limine\\BOOTX64.EFI)\n"
+    "Boot2001* USB Drive (UEFI)\tRC\n"
+)
+
+# What efibootmgr prints when the variable store will not take another entry.
+REFUSAL = "Could not prepare Boot variable: No space left on device"
+
+
+class EfiRemovableFallbackTest(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.target = Path(tmp.name)
+
+        # The loader the installer copies out of the target's limine package.
+        source = self.target / "usr" / "share" / "limine"
+        source.mkdir(parents=True)
+        (source / "BOOTX64.EFI").write_bytes(b"limine loader")
+
+        self.bin_dir = self.target / "fakebin"
+        self.bin_dir.mkdir()
+        path = os.environ["PATH"]
+        self.addCleanup(os.environ.__setitem__, "PATH", path)
+        os.environ["PATH"] = f"{self.bin_dir}:{path}"
+
+        self.ctx = types.SimpleNamespace(target=self.target)
+
+    def fake_efibootmgr(self, *, create_succeeds: bool) -> None:
+        """An efibootmgr that lists entries but may refuse to create one."""
+        listing = self.bin_dir / "efibootmgr.out"
+        listing.write_text(EFIBOOTMGR_LISTING)
+        create = (
+            "exit 0"
+            if create_succeeds
+            else f'printf "%s\\n" "{REFUSAL}" >&2; exit 1'
+        )
+        script = self.bin_dir / "efibootmgr"
+        script.write_text(
+            "#!/bin/sh\n"
+            'case "${1:-}" in\n'
+            f"  --create) {create} ;;\n"
+            "  --bootnum|--bootorder) exit 0 ;;\n"
+            f'  *) cat "{listing}" ;;\n'
+            "esac\n"
+        )
+        script.chmod(0o755)
+
+    def install(self, **kwargs):
+        """Run the EFI install phase with its console output captured."""
+        self.messages = []
+        with mock.patch.object(phases_impl, "info", self.messages.append), \
+             mock.patch.object(phases_impl, "error", self.messages.append):
+            phases_impl._install_limine_efi(
+                self.ctx,
+                esp_mount="/boot",
+                disk=Path("/dev/sda"),
+                part=1,
+                **kwargs,
+            )
+
+    @property
+    def primary(self) -> Path:
+        return self.target / "boot" / "EFI" / "limine" / "limine_x64.efi"
+
+    @property
+    def removable(self) -> Path:
+        return self.target / "boot" / "EFI" / "BOOT" / "BOOTX64.EFI"
+
+    def hook(self) -> str:
+        return (
+            self.target / "etc" / "pacman.d" / "hooks" / "99-omarchy-limine.hook"
+        ).read_text()
+
+    def test_a_refused_boot_variable_still_leaves_a_bootable_machine(self):
+        self.fake_efibootmgr(create_succeeds=False)
+
+        self.install()
+
+        self.assertTrue(
+            self.removable.exists(),
+            "no loader at the removable path firmware falls back to",
+        )
+        self.assertEqual(self.removable.read_bytes(), b"limine loader")
+        # The configured path stays too, so the machine boots either way if its
+        # NVRAM is cleared later and the variable can be written after all.
+        self.assertTrue(self.primary.exists())
+
+    def test_a_limine_upgrade_refreshes_the_path_actually_being_booted(self):
+        self.fake_efibootmgr(create_succeeds=False)
+
+        self.install()
+
+        hook = self.hook()
+        self.assertIn("/boot/EFI/BOOT/BOOTX64.EFI", hook)
+        self.assertIn("/boot/EFI/limine/limine_x64.efi", hook)
+
+    def test_what_efibootmgr_said_reaches_whoever_is_watching(self):
+        # The whole point of catching this rather than letting check=True raise:
+        # "No space left on device" is the diagnosis, and a CalledProcessError
+        # discards it.
+        self.fake_efibootmgr(create_succeeds=False)
+
+        self.install()
+
+        self.assertTrue(
+            any(REFUSAL in m for m in self.messages),
+            f"efibootmgr's reason never surfaced: {self.messages}",
+        )
+
+    def test_a_removable_install_has_nothing_left_to_fall_back_to(self):
+        # Already at \EFI\BOOT\BOOTX64.EFI, so a missing variable costs nothing
+        # and the phase should finish quietly rather than copy over itself.
+        self.fake_efibootmgr(create_succeeds=False)
+
+        self.install(removable=True)
+
+        self.assertTrue(self.removable.exists())
+        self.assertNotIn("&&", self.hook())
+
+    def test_firmware_that_accepts_the_variable_gets_no_fallback_copy(self):
+        self.fake_efibootmgr(create_succeeds=True)
+
+        self.install()
+
+        self.assertTrue(self.primary.exists())
+        self.assertFalse(
+            self.removable.exists(),
+            "wrote a removable loader on firmware that took the boot entry",
+        )
+        self.assertNotIn("&&", self.hook())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`efibootmgr --create` returns non-zero on some pre-Secure-Boot UEFI. The HP ProBook whose NVRAM prompted the tolerant decode in #118 fails the next step the same way — reads answer fine, then the variable store will not take a new `Boot####` entry — and the install ended on a `CalledProcessError` naming the command but dropping what efibootmgr said about it.

That machine is still bootable. `\EFI\BOOT\BOOTX64.EFI` is the removable-media path every UEFI implementation tries when nothing in NVRAM matches, so writing the loader there boots it with no variable at all.

**What changed**

- A refused registration raises `EfiEntryRegistrationError` rather than being one more way the phase can die, so only the failure the fallback can rescue is caught.
- `_install_limine_efi` catches it, reports the firmware's own message, and writes the removable loader. The copy at the configured path stays, so the machine still boots normally if its NVRAM is later cleared.
- The pacman hook is rewritten to refresh both copies — otherwise a `limine` upgrade leaves the path actually being booted stale while the unused one moves forward.
- Registration reads efibootmgr with `capture()` instead of `check=True`, for the reason the rest of the file does: the refusal message is the diagnosis, and it decodes tolerantly, which matters when the firmware rejecting writes is the same firmware holding non-UTF-8 legacy BBS entries.
- An install already at the removable path has nothing to fall back to, so it logs the missing variable and finishes.

Behaviour on firmware that accepts the entry is unchanged: no fallback copy, hook untouched.

**Tests**

`test/unit/test_efi_removable_fallback.py` drives a stand-in efibootmgr that lists entries and refuses `--create`, covering the rescue, the two-path hook, the error text reaching the operator, the already-removable case, and the unchanged success path. Four of the five fail against `quattro` with the bare `CalledProcessError`; the fifth is the regression guard.

`./test/all` passes (68 tests).