### PR TITLE
Diagnose the retry that follows a deleted package

### DIFF
--- a/configs/airootfs/usr/local/bin/omarchy-install-diagnose-media
+++ b/configs/airootfs/usr/local/bin/omarchy-install-diagnose-media
@@ -47,6 +47,21 @@ corrupt_package() {
   printf '%s' "$package"
 }
 
+# A retry in the same boot never gets as far as a checksum. The first failure
+# unlinked the package through the bind mount, so pacman now fails opening it,
+# and it names the mirror it read from rather than the cache it writes to.
+deleted_package() {
+  local log match package=""
+
+  for log in "$@"; do
+    [[ -f $log ]] || continue
+    match=$(sed -n "s|.*Could not open file ${OFFLINE_MIRROR}/\([^ ]*\).*|\1|p" "$log" | tail -n 1)
+    [[ -n $match ]] && package="$match"
+  done
+
+  printf '%s' "$package"
+}
+
 expected_checksum() {
   local package="$1" reader
 
@@ -77,7 +92,14 @@ actual_checksum() {
   printf '%s' "${sum%% *}"
 }
 
+# The checksum failure is read first wherever both are in the log: it is the
+# attempt that names the cause, and the open failures after it are its wake.
 package=$(corrupt_package "$@")
+deleted=""
+if [[ -z $package ]]; then
+  package=$(deleted_package "$@")
+  deleted=1
+fi
 if [[ -z $package ]]; then
   exit 1
 fi
@@ -86,6 +108,20 @@ fi
 # backslash that the renderer would read as an escape. Strip anything a package
 # filename has no business containing before printing it.
 display_package="${package//[^A-Za-z0-9._+:@%-]/}"
+
+# Nothing can be weighed here: the bytes that failed are gone, and the copy in
+# the mirror went with them. Say which attempt this is, because the screen
+# otherwise repeats the same unreadable error for every retry and the one that
+# explains it scrolled away with the first.
+if [[ -n $deleted ]]; then
+  echo "An earlier attempt deleted this package"
+  echo "pacman rejected it off this ISO and unlinked it from the mirror:"
+  echo "$display_package"
+  echo
+  echo "Reboot before retrying: the deletion is in RAM, so the ISO's copy returns"
+  echo "The first error after that reboot is the one that names the fault"
+  exit 0
+fi
 
 expected=$(expected_checksum "$package")
 actual=$(actual_checksum "$package")

--- a/test/unit/install-media-diagnosis-test.sh
+++ b/test/unit/install-media-diagnosis-test.sh
@@ -142,6 +142,65 @@ if grep -qF "no longer matches the checksum" <<<"$output"; then
 fi
 pass "a deleted package names the medium without claiming which way it failed"
 
+# Every retry in the same boot fails on the open rather than the checksum, and
+# pacman names the mirror it read from, not the cache it writes to.
+write_retry_log() {
+  local log="$1" path="${2:-$mirror/$PACKAGE}"
+
+  {
+    echo "[dashboard] :: Retrieving packages..."
+    echo "[dashboard] error: failed retrieving file '${path##*/}' from disk : Could not open file $path"
+    echo "[dashboard] error: failed to commit transaction (download library error)"
+    echo "[dashboard] ==> ERROR: Failed to install packages to new root"
+  } >"$log"
+}
+
+write_retry_log "$work/retry.log"
+
+set +e
+output=$(diagnose "$work/retry.log")
+status=$?
+set -e
+
+(( status == 0 )) || fail "a retry after the deletion is diagnosed" "exit status $status"
+[[ $(head -n 1 <<<"$output") == "An earlier attempt deleted this package" ]] ||
+  fail "a retry is diagnosed as a retry" "$output"
+grep -qF "$PACKAGE" <<<"$output" || fail "a retry names the package" "$output"
+grep -qF "Reboot before retrying" <<<"$output" ||
+  fail "a retry says how to get the package back" "$output"
+pass "a retry after the deletion says so instead of going undiagnosed"
+
+# A log holding both attempts must answer with the one that names the cause.
+# The retries come after it and would otherwise win on recency.
+printf 'a package, but damaged\n' >"$mirror/$PACKAGE"
+write_mirror_db "$(printf '0%.0s' {1..64})"
+{
+  cat "$log"
+  cat "$work/retry.log"
+} >"$work/both.log"
+
+set +e
+output=$(diagnose "$work/both.log")
+set -e
+
+[[ $(head -n 1 <<<"$output") == "The install medium is damaged" ]] ||
+  fail "the checksum failure outranks the retries that followed it" "$output"
+pass "the checksum failure outranks the retries that followed it"
+
+# An open failure somewhere other than the mirror was not read off this ISO.
+write_retry_log "$work/retry-elsewhere.log" "/var/tmp/build/$PACKAGE"
+
+set +e
+output=$(diagnose "$work/retry-elsewhere.log")
+status=$?
+set -e
+
+(( status == 1 )) || fail "an open failure outside the mirror is not diagnosed" "exit $status: $output"
+[[ -z $output ]] || fail "an open failure outside the mirror prints nothing" "$output"
+pass "an open failure outside the mirror is not blamed on the medium"
+
+rm "$mirror/$PACKAGE"
+
 # A record with no %SHA256SUM% must not borrow the next record's, which would
 # compare a real file against another package's checksum.
 printf 'a package, but damaged\n' >"$mirror/$PACKAGE"


### PR DESCRIPTION
The failure screen names the install medium when pacman rejects a package off it, but only on the attempt that does the rejecting. Every attempt after that fails on the open instead: pacstrap runs with `--noconfirm`, so pacman answers yes to "delete it?" and unlinks the package through the bind mount that makes the ISO's offline mirror the target's package cache. A retry's log carries no `is corrupted` line, nothing matches, and the screen falls back to the bare pacstrap error with the word USB nowhere on it. That is the state most people are in by the time they read the screen, because the attempt that explained it scrolled away with the first try.

pacman names the repository it read from in that error, not the cache it writes to, so the match keys on the mirror path rather than on the target cache path:

```
error: failed retrieving file 'gst-plugin-gtk-1.28.6-1-x86_64.pkg.tar.zst' from disk : Could not open file /var/cache/omarchy/mirror/offline/gst-plugin-gtk-1.28.6-1-x86_64.pkg.tar.zst
```

Where a log holds both attempts the checksum failure still wins. It is the one that names the cause, and the open failures after it are its wake.

The new verdict sends the reader to reboot rather than offering a remedy for the medium. Nothing can be weighed once the bytes are gone, and the deletion landed in the live session's RAM overlay rather than on the stick, so a reboot brings the ISO's copy back and the first error after that is the one that says what actually failed.

Reported in basecamp/omarchy#7704, where the undiagnosed retry is the exact error two people are stuck on. This does not stop the deletion itself — that is the read-write cache bind in `_mount_offline_package_cache`, which #108 and #113 are both rewriting.

Codex at xhigh reasoning reviewed the failure and confirmed the gap this closes: a retry log holding only the retrieval error produces no diagnosis, while an accumulated log that still carries the first attempt's line is diagnosed as before, which is the precedence kept here. Its independence is not currently guaranteed.