### PR TITLE
Support Bluetooth keyboards in the live installer

### DIFF
--- a/builder/build-iso.sh
+++ b/builder/build-iso.sh
@@ -118,7 +118,7 @@ cp "/tmp/$NODE_FILENAME" "$build_cache_dir/airootfs/opt/packages/"
 # The selected omarchy-settings package is needed here so its post_install hook
 # drops Omarchy's plymouthd.conf into /etc/plymouth before mkarchiso builds the
 # live initramfs.
-arch_packages=(linux-t2 git gum jq openssl plymouth ttfx tzupdate omarchy-keyring "$OMARCHY_SETTINGS_PACKAGE" lvm2 cryptsetup parted)
+arch_packages=(linux-t2 git gum jq openssl plymouth ttfx tzupdate omarchy-keyring "$OMARCHY_SETTINGS_PACKAGE" lvm2 cryptsetup parted bluez bluez-utils)
 printf '%s\n' "${arch_packages[@]}" >> "$build_cache_dir/packages.x86_64"
 
 # The live ISO boots linux-t2 (see airootfs/etc/mkinitcpio.d/linux-t2.preset), so

--- a/builder/build-iso.sh
+++ b/builder/build-iso.sh
@@ -141,6 +141,7 @@ sed -i -E '/^(linux|broadcom-wl)$/d' "$build_cache_dir/packages.x86_64"
 if [[ -d /omarchy-source ]]; then
   base_pkg_lists=(/omarchy-source/install/omarchy-base.packages /omarchy-source/install/omarchy-other.packages)
   setup_form=/omarchy-source/install/provisioning/setup-form.sh
+  bluetooth_unlock_helper=/omarchy-source/bin/omarchy-setup-security-bluetooth-unlock
 else
   # Pull the same package lists out of the freshly-downloaded Omarchy runtime
   # package so we don't need a local checkout in the non-local-source path.
@@ -162,6 +163,8 @@ else
   # actionable error below.
   bsdtar -xf "$omarchy_pkg" -C /tmp/omarchy-pkglists usr/share/omarchy/install/provisioning/setup-form.sh 2>/dev/null || true
   setup_form=/tmp/omarchy-pkglists/usr/share/omarchy/install/provisioning/setup-form.sh
+  bsdtar -xf "$omarchy_pkg" -C /tmp/omarchy-pkglists usr/share/omarchy/bin/omarchy-setup-security-bluetooth-unlock 2>/dev/null || true
+  bluetooth_unlock_helper=/tmp/omarchy-pkglists/usr/share/omarchy/bin/omarchy-setup-security-bluetooth-unlock
 fi
 
 mkdir -p "$build_cache_dir/airootfs/usr/share/omarchy-iso"
@@ -186,6 +189,14 @@ if [[ ! -f $setup_form ]]; then
   exit 1
 fi
 cp "$setup_form" "$build_cache_dir/airootfs/usr/share/omarchy-iso/setup-form.sh"
+
+# Older bundled runtimes can pair for installation but cannot enable disk unlock.
+# Advertise the option only when this build's runtime includes its setup command.
+bluetooth_unlock_capability="$build_cache_dir/airootfs/usr/share/omarchy-iso/bluetooth-unlock-supported"
+rm -f "$bluetooth_unlock_capability"
+if [[ -x $bluetooth_unlock_helper ]]; then
+  touch "$bluetooth_unlock_capability"
+fi
 
 # Collect every package we want available in the offline mirror.
 declare -a all_packages

--- a/configs/airootfs/root/.automated_script.sh
+++ b/configs/airootfs/root/.automated_script.sh
@@ -128,4 +128,5 @@ rm -f /run/omarchy-install/state.json
     --encrypt-file /root/user_encrypt_installation.txt \
     --authorized-keys-file /root/authorized_keys \
     --tailscale-authkey-file /root/tailscale_authkey \
-    --defer-provisioning-file /root/defer-provisioning
+    --defer-provisioning-file /root/defer-provisioning \
+    --bluetooth-unlock-file /root/bluetooth-unlock.json

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -8,6 +8,8 @@ OMARCHY_RUNTIME_PACKAGE="${OMARCHY_RUNTIME_PACKAGE:-omarchy}"
 OMARCHY_SETTINGS_PACKAGE="${OMARCHY_SETTINGS_PACKAGE:-omarchy-settings}"
 
 LOGO_PATH="$OMARCHY_PATH/logo.txt"
+BLUETOOTH_KEYBOARD_MARKER="${OMARCHY_BLUETOOTH_KEYBOARD_MARKER:-/root/bluetooth-keyboard.json}"
+BLUETOOTH_UNLOCK_MARKER="${OMARCHY_BLUETOOTH_UNLOCK_MARKER:-/root/bluetooth-unlock.json}"
 
 # The setup form — keyboard, account, hostname, and timezone questions, plus the
 # rules their answers are checked against — shared verbatim with the first-boot
@@ -102,20 +104,21 @@ clear_logo() {
 greeter() {
   measure_terminal
 
-  local rows logo_h content_h top cols logo_row tagline_row hint_row
-  local tagline hint tpad hpad anim
+  local rows logo_h content_h top cols logo_row tagline_row hint_row bluetooth_hint_row
+  local tagline hint bluetooth_hint tpad hpad anim
   cols=$TERM_WIDTH
   rows=$(stty size 2>/dev/null </dev/tty | awk '{print $1}')
   [[ $rows =~ ^[0-9]+$ ]] || rows=${LINES:-24}
   logo_h=$(wc -l <"$LOGO_PATH")
 
-  # logo + blank + tagline + blank + hint
-  content_h=$((logo_h + 4))
+  # logo + blank + tagline + blank + two hints
+  content_h=$((logo_h + 5))
   top=$(((rows - content_h) / 2))
   (( top < 0 )) && top=0
   logo_row=$((top + 1))
   tagline_row=$((top + logo_h + 2))
   hint_row=$((top + logo_h + 4))
+  bluetooth_hint_row=$((hint_row + 1))
 
   printf '\033[?25l\033[H\033[2J'
 
@@ -129,6 +132,10 @@ greeter() {
   hint="Press Return to Start Install"
   hpad=$(((cols - ${#hint}) / 2)); (( hpad < 0 )) && hpad=0
   printf '\033[%d;%dH\033[2m%s\033[0m' "$hint_row" "$((hpad + 1))" "$hint"
+
+  bluetooth_hint="Bluetooth keyboard? Put it in pairing mode now"
+  hpad=$(((cols - ${#bluetooth_hint}) / 2)); (( hpad < 0 )) && hpad=0
+  printf '\033[%d;%dH\033[2m%s\033[0m' "$bluetooth_hint_row" "$((hpad + 1))" "$bluetooth_hint"
 
   # ColorShift the logo: a green base (indexed color 2) with a cyan accent (6)
   # drifting through, settling on green. Indexed ANSI colors, not hex — the
@@ -173,6 +180,23 @@ greeter() {
   # Reset the screen so the leftover animation frame doesn't linger under the
   # keyboard step that follows.
   printf '\033[0m\033[H\033[2J\033[?25h'
+}
+
+start_bluetooth_keyboard_pairing() {
+  local helper=/usr/local/bin/omarchy-bluetooth-keyboard-pair
+  bluetooth_pair_pid=""
+  rm -f "$BLUETOOTH_KEYBOARD_MARKER" "$BLUETOOTH_UNLOCK_MARKER"
+  [[ -x $helper ]] || return 0
+
+  "$helper" "$BLUETOOTH_KEYBOARD_MARKER" /dev/tty &
+  bluetooth_pair_pid=$!
+}
+
+stop_bluetooth_keyboard_pairing() {
+  [[ -n ${bluetooth_pair_pid:-} ]] || return 0
+  kill "$bluetooth_pair_pid" 2>/dev/null || true
+  wait "$bluetooth_pair_pid" 2>/dev/null || true
+  bluetooth_pair_pid=""
 }
 
 abort() {
@@ -1030,6 +1054,24 @@ select_installation() {
   done
 }
 
+offer_bluetooth_disk_unlock() {
+  rm -f "$BLUETOOTH_UNLOCK_MARKER"
+  [[ $encrypt_installation == true && $defer_provisioning == false && -s $BLUETOOTH_KEYBOARD_MARKER ]] || return 0
+
+  clear_logo
+  echo
+  say "Use the paired Bluetooth keyboard for encrypted disk unlock?"
+  say --foreground 8 "Its Bluetooth bond key will be copied to the unencrypted boot image."
+  say --foreground 8 "Radio, firmware, or battery trouble can still prevent it connecting."
+  say --foreground 8 "Keep a wired or 2.4ghz keyboard available for recovery."
+  echo
+
+  if gum confirm --affirmative "Yes, enable Bluetooth unlock" --negative "No, installer only" \
+    "Enable Bluetooth keyboard disk unlock?"; then
+    install -m 0600 "$BLUETOOTH_KEYBOARD_MARKER" "$BLUETOOTH_UNLOCK_MARKER"
+  fi
+}
+
 # STEP 1: KEYBOARD (Ctrl+C here arms deferred provisioning and jumps to disk selection)
 
 defer_provisioning=false
@@ -1039,7 +1081,9 @@ install_target="full_disk"
 # isn't measured against the transient 80-column boot console.
 wait_for_stable_terminal
 
+start_bluetooth_keyboard_pairing
 greeter
+stop_bluetooth_keyboard_pairing
 
 keyboard_form
 
@@ -1077,6 +1121,8 @@ else
   disk_form
   select_installation
 fi
+
+offer_bluetooth_disk_unlock
 
 clear
 

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -151,8 +151,7 @@ greeter() {
   printf '\033[%d;1H\0337' "$((logo_row + logo_h))"
   # Run ttfx directly (not inside a `while` subshell) so $anim is ttfx's own
   # PID: killing a wrapping subshell would orphan ttfx, which then keeps
-  # painting the logo over the keyboard step. --cycles is high enough that it
-  # never ends on its own before Return.
+  # painting over pairing passkeys. Stop the intro before pairing starts.
   # Two columns narrower than the console: ttfx centers its text two columns
   # right of plain centering, so a full-width canvas would sit the animated
   # logo a column off the gum-drawn one underneath it.
@@ -170,13 +169,16 @@ greeter() {
     </dev/null >/dev/tty 2>/dev/null &
   anim=$!
 
-  IFS= read -r _ </dev/tty || true
+  sleep 1
   # Tolerate ttfx's kill signal in `wait` so a future `set -e` here can't abort.
   kill "$anim" 2>/dev/null
   wait "$anim" 2>/dev/null || true
   # ttfx leaves the tty in raw/no-echo mode when killed; restore it or the gum
   # prompts in the keyboard step that follows silently die.
   stty sane </dev/tty 2>/dev/null || true
+  # Pairing owns the terminal while the welcome screen waits for Return.
+  start_bluetooth_keyboard_pairing
+  IFS= read -r _ </dev/tty || true
   # Reset the screen so the leftover animation frame doesn't linger under the
   # keyboard step that follows.
   printf '\033[0m\033[H\033[2J\033[?25h'
@@ -1058,6 +1060,17 @@ offer_bluetooth_disk_unlock() {
   rm -f "$BLUETOOTH_UNLOCK_MARKER"
   [[ $encrypt_installation == true && $defer_provisioning == false && -s $BLUETOOTH_KEYBOARD_MARKER ]] || return 0
 
+  if [[ ! -f /usr/share/omarchy-iso/bluetooth-unlock-supported ]]; then
+    clear_logo
+    echo
+    say "This ISO's bundled runtime cannot enable Bluetooth disk unlock."
+    say "After reboot, use a wired or 2.4 GHz keyboard to unlock the encrypted disk."
+    echo
+    gum confirm --affirmative "I have another keyboard" --negative "Abort installation" \
+      "Continue with a recovery keyboard available?" || abort
+    return 0
+  fi
+
   clear_logo
   echo
   say "Use the paired Bluetooth keyboard for encrypted disk unlock?"
@@ -1081,7 +1094,7 @@ install_target="full_disk"
 # isn't measured against the transient 80-column boot console.
 wait_for_stable_terminal
 
-start_bluetooth_keyboard_pairing
+trap stop_bluetooth_keyboard_pairing EXIT
 greeter
 stop_bluetooth_keyboard_pairing
 

--- a/configs/airootfs/usr/local/bin/omarchy-bluetooth-keyboard-pair
+++ b/configs/airootfs/usr/local/bin/omarchy-bluetooth-keyboard-pair
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Pair one nearby keyboard while the live ISO welcome screen is waiting. The
+# remote keyboard's pairing mode is the physical-presence signal; if more than
+# one candidate is visible, pair none rather than guessing.
+
+set -u
+
+marker=${1:-/root/bluetooth-keyboard.json}
+output=${2:-/dev/tty}
+scan_seconds=${OMARCHY_BLUETOOTH_SCAN_SECONDS:-900}
+poll_seconds=${OMARCHY_BLUETOOTH_POLL_SECONDS:-1}
+
+valid_address() {
+  [[ $1 =~ ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$ ]]
+}
+
+device_info() {
+  timeout 3s bluetoothctl info "$1" 2>/dev/null || true
+}
+
+is_keyboard() {
+  local info=$1
+  [[ $info == *"Icon: input-keyboard"* ||
+    $info == *"Appearance: 0x03c"* ||
+    $info == *"00001812-0000-1000-8000-00805f9b34fb"* ||
+    $info == *"00001124-0000-1000-8000-00805f9b34fb"* ]]
+}
+
+cleanup() {
+  timeout 3s bluetoothctl scan off >/dev/null 2>&1 || true
+  [[ -n ${scanner_pid:-} ]] && kill "$scanner_pid" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+systemctl start bluetooth.service >/dev/null 2>&1 || exit 0
+rfkill unblock bluetooth >/dev/null 2>&1 || true
+timeout 5s bluetoothctl power on >/dev/null 2>&1 || exit 0
+
+bluetoothctl --timeout "$scan_seconds" scan on >/dev/null 2>&1 &
+scanner_pid=$!
+deadline=$((SECONDS + scan_seconds))
+declare -A tried=()
+
+while (( SECONDS < deadline )); do
+  candidates=()
+  while read -r address; do
+    valid_address "$address" || continue
+    [[ -z ${tried[$address]:-} ]] || continue
+    info=$(device_info "$address")
+    [[ $info == *"Paired: yes"* ]] && continue
+    is_keyboard "$info" || continue
+    candidates+=("$address")
+  done < <(bluetoothctl devices 2>/dev/null | awk '{print $2}' | sort -u)
+
+  if (( ${#candidates[@]} == 1 )); then
+    address=${candidates[0]}
+    tried[$address]=1
+    info=$(device_info "$address")
+    name=$(sed -n 's/^[[:space:]]*Name: //p' <<<"$info" | head -1 | tr '\t\r\n' '   ' | sed 's/[[:space:]]*$//')
+    name=${name:-Bluetooth keyboard}
+
+    printf '\r\nBluetooth keyboard found: %s\r\n' "$name" >"$output"
+    printf 'If a pairing code appears, type it on that keyboard and press Return.\r\n\r\n' >"$output"
+
+    if bluetoothctl --agent DisplayOnly --timeout 60 pair "$address" >"$output" 2>&1; then
+      bluetoothctl trust "$address" >/dev/null 2>&1 || true
+      bluetoothctl connect "$address" >/dev/null 2>&1 || true
+      info=$(device_info "$address")
+      if [[ $info == *"Paired: yes"* && $info == *"Trusted: yes"* ]]; then
+        controller=$(bluetoothctl show 2>/dev/null | awk '/^Controller / {print $2; exit}')
+        if valid_address "$controller"; then
+          jq -n \
+            --arg controller "${controller^^}" \
+            --arg device "${address^^}" \
+            --arg name "$name" \
+            '{controller: $controller, device: $device, name: $name}' >"$marker"
+          chmod 0600 "$marker"
+          printf '\r\nBluetooth keyboard connected. Press Return to start the install.\r\n' >"$output"
+          exit 0
+        fi
+      fi
+    fi
+
+    printf '\r\nCould not pair that keyboard. Put it in pairing mode to try again.\r\n' >"$output"
+  fi
+
+  sleep "$poll_seconds"
+done

--- a/configs/airootfs/usr/local/bin/omarchy-bluetooth-keyboard-pair
+++ b/configs/airootfs/usr/local/bin/omarchy-bluetooth-keyboard-pair
@@ -5,6 +5,8 @@
 # one candidate is visible, pair none rather than guessing.
 
 set -u
+umask 077
+export LC_ALL=C
 
 marker=${1:-/root/bluetooth-keyboard.json}
 output=${2:-/dev/tty}
@@ -21,17 +23,21 @@ device_info() {
 
 is_keyboard() {
   local info=$1
-  [[ $info == *"Icon: input-keyboard"* ||
-    $info == *"Appearance: 0x03c"* ||
-    $info == *"00001812-0000-1000-8000-00805f9b34fb"* ||
-    $info == *"00001124-0000-1000-8000-00805f9b34fb"* ]]
+  # HID service UUIDs also identify mice and gamepads. Require keyboard evidence.
+  [[ $info == *"Icon: input-keyboard"* ]] ||
+    grep -Eq '^[[:space:]]*Appearance: 0x0*3c1([[:space:]]|$)' <<<"$info"
 }
 
 cleanup() {
-  timeout 3s bluetoothctl scan off >/dev/null 2>&1 || true
-  [[ -n ${scanner_pid:-} ]] && kill "$scanner_pid" 2>/dev/null || true
+  local pid
+  for pid in "${pair_pid:-}" "${scanner_pid:-}"; do
+    [[ -n $pid ]] || continue
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  done
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'exit 0' INT TERM
 
 systemctl start bluetooth.service >/dev/null 2>&1 || exit 0
 rfkill unblock bluetooth >/dev/null 2>&1 || true
@@ -46,42 +52,57 @@ while (( SECONDS < deadline )); do
   candidates=()
   while read -r address; do
     valid_address "$address" || continue
-    [[ -z ${tried[$address]:-} ]] || continue
     info=$(device_info "$address")
-    [[ $info == *"Paired: yes"* ]] && continue
+    [[ $info == *"Paired: yes"* && -z ${tried[$address]:-} ]] && continue
     is_keyboard "$info" || continue
     candidates+=("$address")
   done < <(bluetoothctl devices 2>/dev/null | awk '{print $2}' | sort -u)
 
   if (( ${#candidates[@]} == 1 )); then
     address=${candidates[0]}
-    tried[$address]=1
+    if (( SECONDS < ${tried[$address]:-0} )); then
+      sleep "$poll_seconds"
+      continue
+    fi
+    tried[$address]=$((SECONDS + 10))
     info=$(device_info "$address")
-    name=$(sed -n 's/^[[:space:]]*Name: //p' <<<"$info" | head -1 | tr '\t\r\n' '   ' | sed 's/[[:space:]]*$//')
+    name=$(sed -n 's/^[[:space:]]*Name: //p' <<<"$info" | head -1 | LC_ALL=C tr -d '[:cntrl:]' | sed 's/[[:space:]]*$//')
     name=${name:-Bluetooth keyboard}
 
     printf '\r\nBluetooth keyboard found: %s\r\n' "$name" >"$output"
     printf 'If a pairing code appears, type it on that keyboard and press Return.\r\n\r\n' >"$output"
 
-    if bluetoothctl --agent DisplayOnly --timeout 60 pair "$address" >"$output" 2>&1; then
-      bluetoothctl trust "$address" >/dev/null 2>&1 || true
-      bluetoothctl connect "$address" >/dev/null 2>&1 || true
+    paired=false
+    if [[ $info == *"Paired: yes"* ]]; then
+      paired=true
+    else
+      bluetoothctl --agent DisplayOnly --timeout 60 pair "$address" </dev/null >"$output" 2>&1 &
+      pair_pid=$!
+      if wait "$pair_pid"; then
+        paired=true
+      fi
+      pair_pid=""
+    fi
+    if [[ $paired == true ]]; then
+      timeout 5s bluetoothctl trust "$address" >/dev/null 2>&1 || true
+      timeout 10s bluetoothctl connect "$address" >/dev/null 2>&1 || true
       info=$(device_info "$address")
-      if [[ $info == *"Paired: yes"* && $info == *"Trusted: yes"* ]]; then
-        controller=$(bluetoothctl show 2>/dev/null | awk '/^Controller / {print $2; exit}')
+      if [[ $info == *"Paired: yes"* && $info == *"Trusted: yes"* && $info == *"Connected: yes"* ]]; then
+        controller=$(timeout 3s bluetoothctl show 2>/dev/null | awk '/^Controller / {print $2; exit}')
         if valid_address "$controller"; then
+          temporary_marker=$(mktemp "${marker}.XXXXXX") || exit 1
           jq -n \
             --arg controller "${controller^^}" \
             --arg device "${address^^}" \
             --arg name "$name" \
-            '{controller: $controller, device: $device, name: $name}' >"$marker"
-          chmod 0600 "$marker"
+            '{controller: $controller, device: $device, name: $name}' >"$temporary_marker" && mv -f "$temporary_marker" "$marker" || { rm -f "$temporary_marker"; exit 1; }
           printf '\r\nBluetooth keyboard connected. Press Return to start the install.\r\n' >"$output"
           exit 0
         fi
       fi
     fi
 
+    pair_pid=""
     printf '\r\nCould not pair that keyboard. Put it in pairing mode to try again.\r\n' >"$output"
   fi
 

--- a/configs/airootfs/usr/local/bin/omarchy-iso-install
+++ b/configs/airootfs/usr/local/bin/omarchy-iso-install
@@ -19,6 +19,7 @@ while [[ $# -gt 0 ]]; do
     --authorized-keys-file) export OMARCHY_INSTALL_AUTHORIZED_KEYS_FILE="$2"; shift 2 ;;
     --tailscale-authkey-file) export OMARCHY_INSTALL_TAILSCALE_AUTHKEY_FILE="$2"; shift 2 ;;
     --defer-provisioning-file)             export OMARCHY_INSTALL_DEFER_PROVISIONING_FILE="$2"; shift 2 ;;
+    --bluetooth-unlock-file) export OMARCHY_INSTALL_BLUETOOTH_UNLOCK_FILE="$2"; shift 2 ;;
     *)                      echo "omarchy-iso-install: unknown arg $1" >&2; exit 2 ;;
   esac
 done

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/context.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/context.py
@@ -21,6 +21,7 @@ class InstallContext:
     encrypt: bool
     authorized_keys_path: Path | None
     tailscale_authkey_path: Path | None
+    bluetooth_unlock_path: Path | None
 
     user_configuration: dict
     user_credentials: dict
@@ -109,6 +110,7 @@ class InstallContext:
             encrypt=_read_text(os.environ.get("OMARCHY_INSTALL_ENCRYPT_FILE")).lower() in ("true", "yes", "1"),
             authorized_keys_path=_optional_path(os.environ.get("OMARCHY_INSTALL_AUTHORIZED_KEYS_FILE")),
             tailscale_authkey_path=_optional_path(os.environ.get("OMARCHY_INSTALL_TAILSCALE_AUTHKEY_FILE")),
+            bluetooth_unlock_path=_optional_path(os.environ.get("OMARCHY_INSTALL_BLUETOOTH_UNLOCK_FILE")),
             user_configuration=user_configuration,
             user_credentials=user_credentials,
             arch_config_path=arch_config_path,

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/main.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/main.py
@@ -35,6 +35,7 @@ def build_phases(ctx: InstallContext):
         configure_hibernation,
         run_system_finalizer,
         stage_provisioning_state,
+        configure_bluetooth_unlock,
         finalize_limine_boot,
         run_chroot_finalizer,
         configure_dns_resolver,
@@ -52,8 +53,9 @@ def build_phases(ctx: InstallContext):
         ("Configuring hibernation",    configure_hibernation),
         ("Configuring system",         run_system_finalizer),
         # Before finalize_limine_boot: the deferred-provisioning cryptkey drop-in and keyfile
-        # must be in place for the final UKI build.
+        # and optional Bluetooth-unlock hook must be in place for the final UKI build.
         ("Staging provisioning",          stage_provisioning_state),
+        ("Configuring Bluetooth unlock",  configure_bluetooth_unlock),
         ("Finalizing Limine boot",     finalize_limine_boot),
         ("Finalizing user",            run_chroot_finalizer),
         ("Configuring login",          configure_login),

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -1287,14 +1287,21 @@ def configure_bluetooth_unlock(ctx: InstallContext) -> None:
     except (OSError, json.JSONDecodeError) as exc:
         raise RuntimeError(f"invalid Bluetooth unlock marker {marker}: {exc}") from exc
 
+    if not isinstance(selection, dict):
+        raise RuntimeError("Bluetooth unlock marker must contain a JSON object")
+
     controller = str(selection.get("controller", "")).upper()
     device = str(selection.get("device", "")).upper()
     if not BLUETOOTH_ADDRESS_RE.fullmatch(controller) or not BLUETOOTH_ADDRESS_RE.fullmatch(device):
         raise RuntimeError("Bluetooth unlock marker contains an invalid controller or device address")
 
+    runtime = ctx.target / "usr/bin/omarchy-setup-security-bluetooth-unlock"
+    if not runtime.is_file():
+        raise RuntimeError("Installed Omarchy runtime does not support Bluetooth disk unlock")
+
     source_controller = BLUETOOTH_STATE_DIR / controller
     source_device = source_controller / device
-    if source_controller.is_symlink() or source_device.is_symlink() or not source_device.is_dir():
+    if BLUETOOTH_STATE_DIR.is_symlink() or source_controller.is_symlink() or source_device.is_symlink() or not source_device.is_dir():
         raise RuntimeError(f"selected Bluetooth bond is missing or unsafe: {source_device}")
     if any(path.is_symlink() for path in source_device.rglob("*")):
         raise RuntimeError(f"selected Bluetooth bond contains a symlink: {source_device}")
@@ -1302,12 +1309,22 @@ def configure_bluetooth_unlock(ctx: InstallContext) -> None:
     target_root = ctx.target / "var/lib/bluetooth"
     target_controller = target_root / controller
     target_device = target_controller / device
-    for path in (target_root, target_controller, target_device):
+    for path in (ctx.target / "var", ctx.target / "var/lib", target_root, target_controller, target_device,
+                 target_controller / "settings", target_controller / "identity",
+                 target_controller / "cache", target_controller / "cache" / device):
         if path.is_symlink():
             raise RuntimeError(f"refusing Bluetooth state symlink in target: {path}")
 
+    source_cache = source_controller / "cache" / device
+    if (source_controller / "cache").is_symlink() or source_cache.is_symlink():
+        raise RuntimeError(f"refusing Bluetooth cache symlink: {source_cache}")
+    for name in ("settings", "identity"):
+        if (source_controller / name).is_symlink():
+            raise RuntimeError(f"refusing Bluetooth state symlink: {source_controller / name}")
+
     info("› staging selected Bluetooth keyboard bond for disk unlock")
     target_controller.mkdir(parents=True, exist_ok=True)
+    target_root.chmod(0o700)
     target_controller.chmod(0o700)
     for name in ("settings", "identity"):
         source = source_controller / name
@@ -1315,11 +1332,14 @@ def configure_bluetooth_unlock(ctx: InstallContext) -> None:
             raise RuntimeError(f"refusing Bluetooth state symlink: {source}")
         if source.is_file():
             shutil.copy2(source, target_controller / name)
+            (target_controller / name).chmod(0o600)
 
     if target_device.exists():
         shutil.rmtree(target_device)
     shutil.copytree(source_device, target_device, symlinks=False)
     target_device.chmod(0o700)
+    for path in target_device.rglob("*"):
+        path.chmod(0o700 if path.is_dir() else 0o600)
 
     source_cache = source_controller / "cache" / device
     if source_cache.is_symlink():
@@ -1327,7 +1347,9 @@ def configure_bluetooth_unlock(ctx: InstallContext) -> None:
     if source_cache.is_file():
         target_cache = target_controller / "cache"
         target_cache.mkdir(mode=0o700, exist_ok=True)
+        target_cache.chmod(0o700)
         shutil.copy2(source_cache, target_cache / device)
+        (target_cache / device).chmod(0o600)
 
     _run_target_setup_command(ctx, [
         "/usr/bin/omarchy-setup-security-bluetooth-unlock",

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -23,6 +23,7 @@ Phase ordering (full-disk and protected/pre-mounted):
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import re
 import shutil
@@ -1160,6 +1161,8 @@ def run_system_finalizer(ctx: InstallContext) -> None:
 PROVISION_STATE_DIR = "var/lib/omarchy/provisioning"
 PROVISION_KEYFILE = "etc/omarchy/provisioning.key"
 NODE_PACKAGES_DIR = Path("/opt/packages")
+BLUETOOTH_STATE_DIR = Path("/var/lib/bluetooth")
+BLUETOOTH_ADDRESS_RE = re.compile(r"^(?:[0-9A-F]{2}:){5}[0-9A-F]{2}$")
 
 
 def stage_provisioning_state(ctx: InstallContext) -> None:
@@ -1264,6 +1267,76 @@ def _stage_provisioning_luks_unlock(ctx: InstallContext, provisioning_dir) -> No
     files_dropin = ctx.target / "etc/mkinitcpio.conf.d/99-omarchy-provisioning-key.conf"
     files_dropin.parent.mkdir(parents=True, exist_ok=True)
     files_dropin.write_text("FILES+=(/etc/omarchy/provisioning.key)\n")
+
+
+def configure_bluetooth_unlock(ctx: InstallContext) -> None:
+    """Transfer the explicitly selected live-ISO bond into the target and
+    install the runtime's early-boot hook. No marker means a normal no-op."""
+    marker = ctx.bluetooth_unlock_path
+    if marker is None:
+        return
+    if ctx.defer_provisioning:
+        raise RuntimeError("Bluetooth disk unlock cannot be staged for deferred provisioning")
+    if not _provision_install_encrypted(ctx):
+        raise RuntimeError("Bluetooth disk unlock was requested for an unencrypted install")
+    if marker.is_symlink() or not marker.is_file():
+        raise RuntimeError(f"Bluetooth unlock marker is not a regular file: {marker}")
+
+    try:
+        selection = json.loads(marker.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"invalid Bluetooth unlock marker {marker}: {exc}") from exc
+
+    controller = str(selection.get("controller", "")).upper()
+    device = str(selection.get("device", "")).upper()
+    if not BLUETOOTH_ADDRESS_RE.fullmatch(controller) or not BLUETOOTH_ADDRESS_RE.fullmatch(device):
+        raise RuntimeError("Bluetooth unlock marker contains an invalid controller or device address")
+
+    source_controller = BLUETOOTH_STATE_DIR / controller
+    source_device = source_controller / device
+    if source_controller.is_symlink() or source_device.is_symlink() or not source_device.is_dir():
+        raise RuntimeError(f"selected Bluetooth bond is missing or unsafe: {source_device}")
+    if any(path.is_symlink() for path in source_device.rglob("*")):
+        raise RuntimeError(f"selected Bluetooth bond contains a symlink: {source_device}")
+
+    target_root = ctx.target / "var/lib/bluetooth"
+    target_controller = target_root / controller
+    target_device = target_controller / device
+    for path in (target_root, target_controller, target_device):
+        if path.is_symlink():
+            raise RuntimeError(f"refusing Bluetooth state symlink in target: {path}")
+
+    info("› staging selected Bluetooth keyboard bond for disk unlock")
+    target_controller.mkdir(parents=True, exist_ok=True)
+    target_controller.chmod(0o700)
+    for name in ("settings", "identity"):
+        source = source_controller / name
+        if source.is_symlink():
+            raise RuntimeError(f"refusing Bluetooth state symlink: {source}")
+        if source.is_file():
+            shutil.copy2(source, target_controller / name)
+
+    if target_device.exists():
+        shutil.rmtree(target_device)
+    shutil.copytree(source_device, target_device, symlinks=False)
+    target_device.chmod(0o700)
+
+    source_cache = source_controller / "cache" / device
+    if source_cache.is_symlink():
+        raise RuntimeError(f"refusing Bluetooth cache symlink: {source_cache}")
+    if source_cache.is_file():
+        target_cache = target_controller / "cache"
+        target_cache.mkdir(mode=0o700, exist_ok=True)
+        shutil.copy2(source_cache, target_cache / device)
+
+    _run_target_setup_command(ctx, [
+        "/usr/bin/omarchy-setup-security-bluetooth-unlock",
+        "enable",
+        "--controller", controller,
+        "--device", device,
+        "--yes",
+        "--no-rebuild",
+    ])
 
 
 def finalize_limine_boot(ctx: InstallContext) -> None:
@@ -1691,6 +1764,27 @@ def validate_boot(ctx: InstallContext) -> None:
 
     if ctx.defer_provisioning:
         _validate_provisioning_state(ctx)
+
+    if ctx.bluetooth_unlock_path is not None:
+        _validate_bluetooth_unlock(ctx)
+
+
+def _validate_bluetooth_unlock(ctx: InstallContext) -> None:
+    selection = json.loads(ctx.bluetooth_unlock_path.read_text())
+    controller = str(selection.get("controller", "")).upper()
+    device = str(selection.get("device", "")).upper()
+    required = (
+        ctx.target / "var/lib/bluetooth" / controller / device,
+        ctx.target / "etc/omarchy/bluetooth-unlock.conf",
+        ctx.target / "etc/mkinitcpio.conf.d/zz-omarchy-bluetooth-unlock.conf",
+    )
+    for path in required:
+        if not path.exists():
+            raise RuntimeError(f"Bluetooth disk unlock requested but {path} is missing")
+
+    config = required[1].read_text()
+    if controller not in config or device not in config:
+        raise RuntimeError("Bluetooth disk unlock config does not match the selected keyboard")
 
 
 def _validate_provisioning_state(ctx: InstallContext) -> None:

--- a/configs/profiledef.sh
+++ b/configs/profiledef.sh
@@ -37,6 +37,7 @@ file_permissions=(
   ["/root/configurator"]="0:0:755"
   ["/usr/local/bin/choose-mirror"]="0:0:755"
   ["/usr/local/bin/omarchy-cidata-load"]="0:0:755"
+  ["/usr/local/bin/omarchy-bluetooth-keyboard-pair"]="0:0:755"
   ["/usr/local/bin/omarchy-iso-cleanup-disk"]="0:0:755"
   ["/usr/local/bin/omarchy-install-dashboard"]="0:0:755"
   ["/usr/local/bin/omarchy-install-diagnose-media"]="0:0:755"

--- a/test/unit/bluetooth-keyboard-pair-test.sh
+++ b/test/unit/bluetooth-keyboard-pair-test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+HELPER="$ROOT/configs/airootfs/usr/local/bin/omarchy-bluetooth-keyboard-pair"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+
+for command in systemctl rfkill; do
+  printf '#!/bin/bash\nexit 0\n' >"$TMP/bin/$command"
+  chmod +x "$TMP/bin/$command"
+done
+
+cat >"$TMP/bin/timeout" <<'SH'
+#!/bin/bash
+shift
+exec "$@"
+SH
+chmod +x "$TMP/bin/timeout"
+
+cat >"$TMP/bin/bluetoothctl" <<'SH'
+#!/bin/bash
+state=${BLUETOOTH_TEST_STATE:?}
+case " $* " in
+  *" devices "*)
+    printf 'Device 11:22:33:44:55:66 Test Keyboard\n'
+    ;;
+  *" info 11:22:33:44:55:66 "*)
+    printf 'Name: Test Keyboard\nIcon: input-keyboard\n'
+    [[ -f $state/paired ]] && printf 'Paired: yes\n'
+    [[ -f $state/trusted ]] && printf 'Trusted: yes\n'
+    ;;
+  *" pair 11:22:33:44:55:66 "*)
+    touch "$state/paired"
+    ;;
+  *" trust 11:22:33:44:55:66 "*)
+    touch "$state/trusted"
+    ;;
+  *" show "*)
+    printf 'Controller AA:BB:CC:DD:EE:FF live-iso\n'
+    ;;
+esac
+SH
+chmod +x "$TMP/bin/bluetoothctl"
+
+mkdir "$TMP/state"
+PATH="$TMP/bin:$PATH" \
+  BLUETOOTH_TEST_STATE="$TMP/state" \
+  OMARCHY_BLUETOOTH_SCAN_SECONDS=5 \
+  "$HELPER" "$TMP/marker.json" "$TMP/output"
+
+jq -e '
+  .controller == "AA:BB:CC:DD:EE:FF" and
+  .device == "11:22:33:44:55:66" and
+  .name == "Test Keyboard"
+' "$TMP/marker.json" >/dev/null
+[[ $(stat -c %a "$TMP/marker.json") == 600 ]]
+
+printf 'bluetooth keyboard pairing helper: ok\n'

--- a/test/unit/bluetooth-keyboard-pair-test.sh
+++ b/test/unit/bluetooth-keyboard-pair-test.sh
@@ -26,17 +26,43 @@ state=${BLUETOOTH_TEST_STATE:?}
 case " $* " in
   *" devices "*)
     printf 'Device 11:22:33:44:55:66 Test Keyboard\n'
+    [[ ${BLUETOOTH_TEST_MODE:-} == multiple ]] && printf 'Device 22:33:44:55:66:77 Other Keyboard\n'
+    ;;
+  *" info 22:33:44:55:66:77 "*)
+    printf 'Name: Other Keyboard\nIcon: input-keyboard\n'
     ;;
   *" info 11:22:33:44:55:66 "*)
-    printf 'Name: Test Keyboard\nIcon: input-keyboard\n'
+    printf 'Name: Test Keyboard\n'
+    if [[ ${BLUETOOTH_TEST_MODE:-} == mouse ]]; then
+      printf 'Icon: input-mouse\nAppearance: 0x03c2\nUUID: 00001812-0000-1000-8000-00805f9b34fb\n'
+    else
+      printf 'Icon: input-keyboard\n'
+    fi
     [[ -f $state/paired ]] && printf 'Paired: yes\n'
     [[ -f $state/trusted ]] && printf 'Trusted: yes\n'
+    [[ -f $state/connected ]] && printf 'Connected: yes\n'
     ;;
   *" pair 11:22:33:44:55:66 "*)
+    echo pair >>"$state/pair-calls"
+    touch "$state/attempted"
+    if [[ ${BLUETOOTH_TEST_MODE:-} == retry_pair && $(wc -l <"$state/pair-calls") == 1 ]]; then
+      exit 1
+    fi
+    if [[ ${BLUETOOTH_TEST_MODE:-} == hang ]]; then
+      echo $$ >"$state/pair-pid"
+      exec sleep 30
+    fi
     touch "$state/paired"
     ;;
   *" trust 11:22:33:44:55:66 "*)
     touch "$state/trusted"
+    ;;
+  *" connect 11:22:33:44:55:66 "*)
+    echo connect >>"$state/connect-calls"
+    if [[ ${BLUETOOTH_TEST_MODE:-} == retry_connect && $(wc -l <"$state/connect-calls") == 1 ]]; then
+      exit 1
+    fi
+    [[ ${BLUETOOTH_TEST_MODE:-} == disconnected ]] || touch "$state/connected"
     ;;
   *" show "*)
     printf 'Controller AA:BB:CC:DD:EE:FF live-iso\n'
@@ -58,4 +84,113 @@ jq -e '
 ' "$TMP/marker.json" >/dev/null
 [[ $(stat -c %a "$TMP/marker.json") == 600 ]]
 
-printf 'bluetooth keyboard pairing helper: ok\n'
+for mode in mouse disconnected multiple; do
+  mkdir "$TMP/$mode"
+  PATH="$TMP/bin:$PATH" BLUETOOTH_TEST_STATE="$TMP/$mode" BLUETOOTH_TEST_MODE="$mode" \
+    OMARCHY_BLUETOOTH_SCAN_SECONDS=1 OMARCHY_BLUETOOTH_POLL_SECONDS=0.1 \
+    "$HELPER" "$TMP/$mode/marker.json" "$TMP/$mode/output"
+  [[ ! -e $TMP/$mode/marker.json ]]
+done
+[[ ! -e $TMP/mouse/attempted ]]
+[[ ! -e $TMP/multiple/attempted ]]
+
+mkdir "$TMP/hang"
+PATH="$TMP/bin:$PATH" BLUETOOTH_TEST_STATE="$TMP/hang" BLUETOOTH_TEST_MODE=hang \
+  OMARCHY_BLUETOOTH_SCAN_SECONDS=30 \
+  "$HELPER" "$TMP/hang/marker.json" "$TMP/hang/output" &
+helper_pid=$!
+for ((i = 0; i < 100; i++)); do
+  [[ -s $TMP/hang/pair-pid ]] && break
+  sleep 0.02
+done
+[[ -s $TMP/hang/pair-pid ]]
+kill "$helper_pid"
+# A helper that ignores TERM would otherwise leave the welcome screen waiting.
+for ((i = 0; i < 100; i++)); do
+  kill -0 "$helper_pid" 2>/dev/null || break
+  sleep 0.02
+done
+if kill -0 "$helper_pid" 2>/dev/null; then
+  kill -KILL "$helper_pid" "$(cat "$TMP/hang/pair-pid")" 2>/dev/null || true
+  echo 'pairing helper did not exit after TERM' >&2
+  exit 1
+fi
+wait "$helper_pid"
+! kill -0 "$(cat "$TMP/hang/pair-pid")" 2>/dev/null
+[[ ! -e $TMP/hang/marker.json ]]
+printf 'bluetooth keyboard pairing helper: success, mouse rejection, disconnected rejection, cancellation ok\n'
+
+# The greeter must reap its animation before pairing can print a passkey.
+python - "$ROOT/configs/airootfs/root/configurator" <<'PYTEST'
+import pathlib
+import sys
+source = pathlib.Path(sys.argv[1]).read_text()
+greeter = source.split("greeter() {", 1)[1].split("\n}\n", 1)[0]
+assert greeter.index('wait "$anim"') < greeter.index("start_bluetooth_keyboard_pairing")
+assert greeter.index("stty sane") < greeter.index("start_bluetooth_keyboard_pairing")
+assert greeter.index("start_bluetooth_keyboard_pairing") < greeter.index("IFS= read")
+PYTEST
+
+# Exercise the builder's capability marker with supported and older runtimes.
+capability_block=$(sed -n '/^bluetooth_unlock_capability=/,/^fi$/p' "$ROOT/builder/build-iso.sh")
+build_cache_dir="$TMP/build"
+mkdir -p "$build_cache_dir/airootfs/usr/share/omarchy-iso"
+bluetooth_unlock_helper="$TMP/runtime-helper"
+eval "$capability_block"
+[[ ! -e $bluetooth_unlock_capability ]]
+printf '#!/bin/bash\n' >"$bluetooth_unlock_helper"
+chmod +x "$bluetooth_unlock_helper"
+eval "$capability_block"
+[[ -f $bluetooth_unlock_capability ]]
+rm "$bluetooth_unlock_helper"
+eval "$capability_block"
+[[ ! -e $bluetooth_unlock_capability ]]
+
+# Run independent retry cases together; each must cross the real 10-second cooldown.
+retry_pids=()
+for mode in retry_pair retry_connect; do
+  mkdir "$TMP/$mode"
+  PATH="$TMP/bin:$PATH" BLUETOOTH_TEST_STATE="$TMP/$mode" BLUETOOTH_TEST_MODE="$mode" \
+    OMARCHY_BLUETOOTH_SCAN_SECONDS=15 OMARCHY_BLUETOOTH_POLL_SECONDS=0.1 \
+    "$HELPER" "$TMP/$mode/marker.json" "$TMP/$mode/output" &
+  retry_pids+=("$!")
+done
+for pid in "${retry_pids[@]}"; do
+  wait "$pid"
+done
+for mode in retry_pair retry_connect; do
+  jq -e '.controller == "AA:BB:CC:DD:EE:FF" and .device == "11:22:33:44:55:66"' \
+    "$TMP/$mode/marker.json" >/dev/null
+  [[ -f $TMP/$mode/connected ]]
+done
+[[ $(wc -l <"$TMP/retry_pair/pair-calls") == 2 ]]
+[[ $(wc -l <"$TMP/retry_pair/connect-calls") == 1 ]]
+[[ $(wc -l <"$TMP/retry_connect/pair-calls") == 1 ]]
+[[ $(wc -l <"$TMP/retry_connect/connect-calls") == 2 ]]
+printf 'bluetooth keyboard pairing helper: retry pairing, preserve bond on connection retry, multiple candidate refusal ok\n'
+
+# Without runtime support, require acknowledgement of the post-reboot keyboard.
+offer_function=$(sed -n '/^offer_bluetooth_disk_unlock() {/,/^}$/p' "$ROOT/configs/airootfs/root/configurator")
+offer_function=${offer_function//\/usr\/share\/omarchy-iso\/bluetooth-unlock-supported/$TMP/unsupported-runtime}
+(
+  eval "$offer_function"
+  encrypt_installation=true
+  defer_provisioning=false
+  BLUETOOTH_KEYBOARD_MARKER="$TMP/marker.json"
+  BLUETOOTH_UNLOCK_MARKER="$TMP/consent.json"
+  clear_logo() { :; }
+  say() { printf '%s\n' "$*" >>"$TMP/warning"; }
+  gum() { echo "$*" >>"$TMP/confirmation"; return "${confirmation_result:-0}"; }
+  abort() { exit 17; }
+  offer_bluetooth_disk_unlock
+  [[ ! -e $BLUETOOTH_UNLOCK_MARKER ]]
+  grep -q 'wired or 2.4 GHz' "$TMP/warning"
+  grep -q 'I have another keyboard' "$TMP/confirmation"
+  confirmation_result=1
+  if (offer_bluetooth_disk_unlock); then
+    echo 'missing-runtime fallback did not abort after rejection' >&2
+    exit 1
+  else
+    [[ $? == 17 ]]
+  fi
+)

--- a/test/unit/test_bluetooth_unlock.py
+++ b/test/unit/test_bluetooth_unlock.py
@@ -1,0 +1,104 @@
+"""Tests for the opt-in live-ISO to early-boot Bluetooth bond handoff."""
+
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "configs/airootfs/usr/share/omarchy-iso"))
+sys.modules.setdefault(
+    "orchestrator.archinstall_adapter", types.ModuleType("orchestrator.archinstall_adapter")
+)
+
+from orchestrator import phases_impl  # noqa: E402
+
+
+CONTROLLER = "AA:BB:CC:DD:EE:FF"
+KEYBOARD = "11:22:33:44:55:66"
+OTHER = "22:33:44:55:66:77"
+
+
+class BluetoothUnlockTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.live_state = self.root / "live-bluetooth"
+        self.target = self.root / "mnt"
+        self.target.mkdir()
+        self.marker = self.root / "bluetooth-unlock.json"
+        self.marker.write_text(json.dumps({"controller": CONTROLLER, "device": KEYBOARD}))
+
+        controller = self.live_state / CONTROLLER
+        (controller / KEYBOARD).mkdir(parents=True)
+        (controller / KEYBOARD / "info").write_text("[LinkKey]\nKey=selected-secret\n")
+        (controller / OTHER).mkdir()
+        (controller / OTHER / "info").write_text("unrelated-secret\n")
+        (controller / "cache").mkdir()
+        (controller / "cache" / KEYBOARD).write_text("selected cache\n")
+        (controller / "cache" / OTHER).write_text("unrelated cache\n")
+        (controller / "settings").write_text("[General]\nDiscoverable=false\n")
+
+        state_patch = mock.patch.object(phases_impl, "BLUETOOTH_STATE_DIR", self.live_state)
+        state_patch.start()
+        self.addCleanup(state_patch.stop)
+        info_patch = mock.patch.object(phases_impl, "info")
+        info_patch.start()
+        self.addCleanup(info_patch.stop)
+
+    def ctx(self, **overrides):
+        defaults = dict(
+            target=self.target,
+            bluetooth_unlock_path=self.marker,
+            defer_provisioning=False,
+            encrypt=True,
+            omarchy_install={"storage": {}},
+            user_configuration={"disk_config": {}},
+            user_credentials={"users": [{"username": "test"}]},
+        )
+        defaults.update(overrides)
+        return types.SimpleNamespace(**defaults)
+
+    def test_copies_only_selected_bond_and_invokes_runtime_without_rebuild(self):
+        with mock.patch.object(phases_impl, "_run_target_setup_command") as run:
+            phases_impl.configure_bluetooth_unlock(self.ctx())
+
+        target_controller = self.target / "var/lib/bluetooth" / CONTROLLER
+        self.assertEqual(
+            (target_controller / KEYBOARD / "info").read_text(),
+            "[LinkKey]\nKey=selected-secret\n",
+        )
+        self.assertFalse((target_controller / OTHER).exists())
+        self.assertFalse((target_controller / "cache" / OTHER).exists())
+        self.assertEqual(target_controller.stat().st_mode & 0o777, 0o700)
+        run.assert_called_once_with(self.ctx(), [
+            "/usr/bin/omarchy-setup-security-bluetooth-unlock",
+            "enable",
+            "--controller", CONTROLLER,
+            "--device", KEYBOARD,
+            "--yes",
+            "--no-rebuild",
+        ])
+
+    def test_rejects_unencrypted_and_deferred_installs(self):
+        with self.assertRaisesRegex(RuntimeError, "unencrypted"):
+            phases_impl.configure_bluetooth_unlock(self.ctx(encrypt=False))
+        with self.assertRaisesRegex(RuntimeError, "deferred provisioning"):
+            phases_impl.configure_bluetooth_unlock(self.ctx(defer_provisioning=True))
+
+    def test_rejects_invalid_addresses_and_source_symlinks(self):
+        self.marker.write_text(json.dumps({"controller": "../etc", "device": KEYBOARD}))
+        with self.assertRaisesRegex(RuntimeError, "invalid controller"):
+            phases_impl.configure_bluetooth_unlock(self.ctx())
+
+        self.marker.write_text(json.dumps({"controller": CONTROLLER, "device": KEYBOARD}))
+        (self.live_state / CONTROLLER / KEYBOARD / "unsafe").symlink_to("/etc/shadow")
+        with self.assertRaisesRegex(RuntimeError, "contains a symlink"):
+            phases_impl.configure_bluetooth_unlock(self.ctx())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_bluetooth_unlock.py
+++ b/test/unit/test_bluetooth_unlock.py
@@ -29,6 +29,9 @@ class BluetoothUnlockTest(unittest.TestCase):
         self.live_state = self.root / "live-bluetooth"
         self.target = self.root / "mnt"
         self.target.mkdir()
+        runtime = self.target / "usr/bin/omarchy-setup-security-bluetooth-unlock"
+        runtime.parent.mkdir(parents=True)
+        runtime.touch()
         self.marker = self.root / "bluetooth-unlock.json"
         self.marker.write_text(json.dumps({"controller": CONTROLLER, "device": KEYBOARD}))
 
@@ -82,6 +85,45 @@ class BluetoothUnlockTest(unittest.TestCase):
             "--yes",
             "--no-rebuild",
         ])
+
+    def test_rejects_non_object_marker(self):
+        self.marker.write_text("[]")
+        with self.assertRaisesRegex(RuntimeError, "JSON object"):
+            phases_impl.configure_bluetooth_unlock(self.ctx())
+
+    def test_requires_runtime_before_copying_secrets(self):
+        (self.target / "usr/bin/omarchy-setup-security-bluetooth-unlock").unlink()
+        with self.assertRaisesRegex(RuntimeError, "does not support"):
+            phases_impl.configure_bluetooth_unlock(self.ctx())
+        self.assertFalse((self.target / "var/lib/bluetooth").exists())
+
+    def test_rejects_target_and_cache_symlinks_before_copy(self):
+        outside = self.root / "outside"
+        outside.mkdir()
+        for relative in ("var", "var/lib", "var/lib/bluetooth",
+                         f"var/lib/bluetooth/{CONTROLLER}/settings",
+                         f"var/lib/bluetooth/{CONTROLLER}/cache"):
+            with self.subTest(relative=relative):
+                path = self.target / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.symlink_to(outside)
+                with self.assertRaisesRegex(RuntimeError, "symlink"):
+                    phases_impl.configure_bluetooth_unlock(self.ctx())
+                self.assertEqual(list(outside.iterdir()), [])
+                path.unlink()
+        cache = self.live_state / CONTROLLER / "cache"
+        import shutil
+        shutil.rmtree(cache)
+        cache.symlink_to(outside)
+        with self.assertRaisesRegex(RuntimeError, "cache symlink"):
+            phases_impl.configure_bluetooth_unlock(self.ctx())
+
+    def test_secret_permissions_are_restricted(self):
+        with mock.patch.object(phases_impl, "_run_target_setup_command"):
+            phases_impl.configure_bluetooth_unlock(self.ctx())
+        controller = self.target / "var/lib/bluetooth" / CONTROLLER
+        for path in (controller / KEYBOARD / "info", controller / "settings", controller / "cache" / KEYBOARD):
+            self.assertEqual(path.stat().st_mode & 0o777, 0o600)
 
     def test_rejects_unencrypted_and_deferred_installs(self):
         with self.assertRaisesRegex(RuntimeError, "unencrypted"):

--- a/test/unit/test_provisioning_state.py
+++ b/test/unit/test_provisioning_state.py
@@ -48,7 +48,10 @@ class ContextDeferProvisioningTest(unittest.TestCase):
     def from_env(self, **extra_env):
         env = {**self.env, **extra_env}
         with mock.patch.dict(os.environ, env, clear=False):
-            for key in ("OMARCHY_INSTALL_DEFER_PROVISIONING_FILE",):
+            for key in (
+                "OMARCHY_INSTALL_DEFER_PROVISIONING_FILE",
+                "OMARCHY_INSTALL_BLUETOOTH_UNLOCK_FILE",
+            ):
                 if key not in env:
                     os.environ.pop(key, None)
             return InstallContext.from_env()
@@ -85,6 +88,17 @@ class ContextDeferProvisioningTest(unittest.TestCase):
         ctx = self.from_env(OMARCHY_INSTALL_DEFER_PROVISIONING_FILE=str(self.dir / "missing-defer_provisioning"))
         self.assertFalse(ctx.defer_provisioning)
         self.assertEqual(ctx.username, "jeff")
+
+    def test_bluetooth_unlock_marker_is_optional(self):
+        self.write_config(self.base_config())
+        self.write_creds({"users": [{"username": "jeff"}]})
+        marker = self.dir / "bluetooth-unlock.json"
+        marker.write_text("{}")
+        ctx = self.from_env(OMARCHY_INSTALL_BLUETOOTH_UNLOCK_FILE=str(marker))
+        self.assertEqual(ctx.bluetooth_unlock_path, marker)
+
+        ctx = self.from_env(OMARCHY_INSTALL_BLUETOOTH_UNLOCK_FILE=str(self.dir / "missing.json"))
+        self.assertIsNone(ctx.bluetooth_unlock_path)
 
     def test_missing_credentials_without_defer_provisioning_raises(self):
         self.write_config(self.base_config())


### PR DESCRIPTION
## Why

The live installer currently assumes that a keyboard can be connected through
USB or a 2.4 GHz receiver. That is not always possible: some keyboards are
Bluetooth-only, some USB connections provide charging but not wired input, and
some machines do not have a compatible free port or the required cable.

A mouse does not resolve this because the text installer still needs keyboard
input for account details and encryption credentials. The useful path is to
break the pairing catch-22 automatically: discover and pair the keyboard while
the welcome screen is waiting, then use that keyboard for the installer itself.

This complements omacom/omarchy#8816, which provides Bluetooth input at the
encrypted-disk prompt after installation. Both layers are needed for an
installation that does not depend on a temporary USB keyboard.

## Pairing flow

1. The welcome screen asks users with a Bluetooth keyboard to put it in pairing
   mode.
2. The live ISO powers on Bluetooth and scans in the background while that
   screen is waiting.
3. The helper requires keyboard-specific discovery information; a generic HID service alone is not enough.
4. If exactly one eligible unpaired keyboard is visible, pairing starts
   automatically. If several are visible, it pairs none rather than guessing.
5. When required, the user types the displayed pairing code on the Bluetooth
   keyboard itself and presses Return. This is handled by the Bluetooth pairing
   protocol before normal HID input is available, so no existing mouse or
   keyboard is required.
6. The helper trusts and connects the keyboard. The user can then press Return
   on it to enter and complete the normal installer.

Scanning is limited to the welcome screen and is stopped when installation
begins.

## Encrypted first reboot

Pairing only in the ephemeral live environment would leave a cable-free install
stranded at its first LUKS prompt. On encrypted, non-deferred installations,
when the bundled runtime supports it, the configurator therefore offers a separate opt-in to carry the selected bond
into the installed system and enable the early-boot support from
omacom/omarchy#8816.

That second decision is not implied by installer pairing. The prompt explains
that the bond material will be included in the unencrypted boot image and that
Bluetooth radio, firmware, or battery failures remain possible.

The orchestrator validates the controller and device addresses, rejects unsafe
symlinks, copies only the selected bond and controller metadata, and invokes the
runtime setup before the final Limine UKI build. It does not copy unrelated
phones, headsets, or other paired devices.

## Limitations

- Multiple nearby unpaired keyboards require a fallback rather than an
  automatic guess.
- Unusual pairing methods may not support the `DisplayOnly` keyboard flow.
- Adapter or firmware incompatibility can still prevent discovery.
- Firmware and BIOS interfaces remain outside the live operating system and
  cannot gain Bluetooth support from this change.

## Failure handling

The pairing helper stops and reaps its pairing/scanning processes when the welcome screen ends. The welcome animation stops before passkeys are displayed. Failed attempts can retry, and connection retries preserve an existing successful bond. The helper writes its private selection marker atomically only after confirming paired, trusted, and connected state.

The build records whether its runtime includes Bluetooth-unlock support. The configurator gates the encrypted-boot option on that capability. If support is absent, it requires acknowledgement that another keyboard is available after reboot or aborts. The orchestrator checks the installed command before copying bond data. Handoff rejects unsafe source/cache and target ancestor/file symlinks and restricts copied state permissions.

## Validation

- Pairing, cancellation, runtime-capability, and greeter-order fixtures: `bash test/unit/bluetooth-keyboard-pair-test.sh`.
- Bond handoff and provisioning regressions: `python3 -m unittest test.unit.test_bluetooth_unlock test.unit.test_provisioning_state`.
- Python compilation, Bash syntax, and `git diff --check`.

The full Python baseline has 50 existing keyboard-layout errors because `localectl` cannot access the system bus in the test sandbox. That suite is not reported as passing.

## Remaining verification

This PR is open for review. No ISO build, physical Bluetooth keyboard pairing/passkey UI check, encrypted first reboot, or firmware compatibility test has been performed. The fixtures verify software boundaries, not hardware acceptance. Encrypted-boot support requires a runtime package carrying omacom/omarchy#8816; installer pairing remains a separate operation.
