### PR TITLE
Use systemd-boot instead of GRUB for UEFI

### DIFF
--- a/configs/profiledef.sh
+++ b/configs/profiledef.sh
@@ -8,7 +8,7 @@ iso_application="Omarchy Installer"
 iso_version="$(date --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y.%m.%d)"
 install_dir="arch"
 buildmodes=('iso')
-bootmodes=('bios.syslinux' 'uefi.grub')
+bootmodes=('bios.syslinux' 'uefi.systemd-boot')
 arch="x86_64"
 pacman_conf="pacman-offline.conf"
 airootfs_image_type="squashfs"


### PR DESCRIPTION
Fixes the GRUB `out of memory` boot failure reported in omacom/omarchy#8629, which makes the installer unbootable on AMD Zen 5 (Ryzen AI 9 HX 370 / Strix Point) laptops.

## The problem

On the shipped `omarchy-4.0.1.iso`:

- `EFI/BOOT/BOOTx64.EFI` is a 7,712,768-byte GNU GRUB 2.14 standalone image, and the only x64 UEFI loader on the medium.
- `initramfs-linux-t2.img` is 253,458,904 bytes (242 MB), while the ISO's ESP is only 23 MB — so the kernel and initramfs sit outside the ESP and must be pulled in by the loader.
- GRUB's `linux`/`initrd` path needs a single contiguous allocation below 4 GB. Strix Point firmware fragments that region enough that 242 MB has no home, and `grub_cmd_linux` aborts before the menu renders.

The kernel does not have that constraint: `vmlinuz-linux-t2` reports boot protocol 2.15, "64-bit EFI handoff entry point", "can be above 4G".

## Why this is a regression

`ea707f6` (2025-09-10) set the ISO up with systemd-boot. `5b9bf620` "Use grub" (2025-09-21) replaced those bootmodes with `uefi-x64.grub.esp`/`.eltorito`, and `02a9d48` (2025-09-28) renamed them to today's `uefi.grub`.

The systemd-boot config was never removed, and is still maintained. `94494c8` (#77, April 2026, "Disable xe Panel Replay on live boot for Panther Lake compatibility") edited `configs/efiboot/loader/entries/01-archiso-x86_64-linux.conf` — a file that has not reached a built ISO since September 2025. That fix has never shipped.

This PR just re-wires the existing configuration back into the build.

## What changes

One line in `configs/profiledef.sh`. Two effects:

1. `BOOTx64.EFI` becomes systemd-boot, which chainloads via the kernel's EFI stub. The stub allocates through EFI boot services across the full memory map, so the contiguous sub-4GB heap requirement disappears.
2. The ESP grows 23 MB → 268 MB. `_make_efibootimg` sizes the FAT image from `efiboot_files`; the systemd-boot path includes `vmlinuz-*` and `initramfs-*.img` in that list, the GRUB path does not. Kernel and initramfs end up inside the ESP.

BIOS/syslinux booting is untouched. Secure Boot posture is unchanged — the GRUB images were built `--disable-shim-lock`, so neither loader is shim-signed and Secure Boot must be off either way.

## Verification

Built from `quattro` with only this line changed (`bin/omarchy-iso-make`, exit 0; archiso v87). On the produced ISO:

| | before | after |
|---|---|---|
| `EFI/BOOT/BOOTx64.EFI` | 7,712,768 B GRUB 2.14 | 160,256 B, `systemd-boot 261.2-1-arch` |
| `EFI/BOOT/BOOTIA32.EFI` | absent | 171,520 B systemd-boot |
| `loader/` | absent | `loader.conf` + all 4 `entries/*.conf` |
| ESP partition | 23 MB | 268 MB |
| kernel + initramfs | outside ESP | inside ESP (17,097,216 B + 253,458,904 B) |
| files matching `*grub*` | the only loader | none |

Booted in QEMU/OVMF (q35, KVM, 8 GB, headless): splash at ~6 s — `timeout 0`, straight through, no menu — archiso autologin on the t2 kernel at ~12 s, installer at ~30 s, stable at 240 s. Then written to USB and the same structure re-verified on the physical stick (6,472,525,824 bytes, byte-exact to the ISO).

**Caveat, stated plainly:** QEMU/OVMF does not reproduce Strix Point's fragmented low-memory map. The emulated boot proves the ISO boots correctly via systemd-boot; it is not by itself proof that the Framework 16 failure is fixed. The structural argument — GRUB entirely absent from the UEFI path, kernel EFI stub allocating across the full map — is the basis for expecting it to. I'll follow up on the issue once I've booted the stick on the affected hardware.

## Note for reviewers

This has to be a replacement rather than an addition. Each bootmode function calls `_make_efibootimg`, which recreates the ESP from that bootmode's own `efiboot_files`, so listing both `uefi.grub` and `uefi.systemd-boot` means the last one wins and the outcome depends on array order. Also note `uefi-x64.systemd-boot.esp`/`.eltorito` (the pre-`5b9bf620` names) are deprecated stubs in archiso v87 whose bodies are `return 1` — `uefi.systemd-boot` is the working name.

https://claude.ai/code/session_01V1nN7cVJRp3kF9vc9Fc7o9
