### PR TITLE
Change the greeter tagline to "Beautiful, Fun & Opinionated"

### DIFF
--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -122,7 +122,7 @@ greeter() {
   printf '\033[%d;1H' "$logo_row"
   gum style --foreground 2 --padding "0 0 0 $PADDING_LEFT" "$(<"$LOGO_PATH")"
 
-  tagline="Beautiful, Modern & Opinionated Linux by DHH"
+  tagline="Beautiful, Fun & Opinionated Linux by DHH"
   tpad=$(((cols - ${#tagline}) / 2)); (( tpad < 0 )) && tpad=0
   printf '\033[%d;%dH%s' "$tagline_row" "$((tpad + 1))" "$tagline"
 


### PR DESCRIPTION
The install greeter opens on "Beautiful, Modern & Opinionated Linux by DHH". The tagline is now "Beautiful, Fun & Opinionated", so that line changes with it. `configs/airootfs/root/configurator` is the only place in this repository that carries the tagline or any part of it.

The same frame opens omarchy's deferred first boot, from its own copy of the string in `bin/omarchy-provision-owner`, and nothing generates one copy from the other: the vendoring in `builder/build-iso.sh` covers `setup-form.sh`, not the greeter, and the deferred-provisioning check only asserts that `omarchy-provision-owner` exists rather than comparing what is in it. So the two halves have to land together. An ISO built against a runtime package that still says "Modern" would show "Fun" through the install and "Modern" at the first boot that finishes it, and nothing here would catch it — the screen anchors all wait on "Opinionated", which both strings contain. The other half is omacom/omarchy#9163.

The line is centred from its own length (`tpad=$(((cols - ${#tagline}) / 2))`), so losing three characters moves it one column and nothing else: no row, no logo padding, and not the ttfx canvas width, which is measured from the console rather than from the text. On a console between 41 and 43 columns the new tagline fits where the old one wrapped.

🤖 Generated by Opus 5 in Claude Code. Reviewed by Codex XHigh.
