### PR TITLE
Fix omarchy-iso-test staleness against 4.0.2-rc and add VNC visibility

### DIFF
--- a/bin/omarchy-iso-test
+++ b/bin/omarchy-iso-test
@@ -631,7 +631,11 @@ drive_configurator() {
     capture_console "success-installer-04-prepare-disk-warning-encrypted"
     if ! $ENCRYPT; then
       press ctrl-c
-      wait_for_screen "without encryption" 30
+      # The toggled confirm ("Yes, install without encryption") is a highlighted
+      # button OCR cannot read, so don't wait for it. A failed toggle still
+      # surfaces: the encrypted install stalls at the LUKS prompt on first boot
+      # and SSH never comes up.
+      sleep 2
       capture_console "success-installer-05-prepare-disk-warning-unencrypted"
     fi
     press ret
@@ -695,7 +699,11 @@ drive_configurator() {
   capture_console "success-installer-12-disk-warning-encrypted"
   if ! $ENCRYPT; then
     press ctrl-c # toggles the confirm to the unencrypted flow
-    wait_for_screen "without encryption" 30
+    # The toggled confirm ("Yes, install without encryption") is a highlighted
+    # button OCR cannot read, so don't wait for it. A failed toggle still
+    # surfaces: the encrypted install stalls at the LUKS prompt on first boot
+    # and SSH never comes up.
+    sleep 2
     capture_console "success-installer-13-disk-warning-unencrypted"
   fi
   press ret

--- a/bin/omarchy-iso-test
+++ b/bin/omarchy-iso-test
@@ -18,9 +18,10 @@
 #                      first boot runs omarchy-provision-owner and creates it there
 #   --reuse-base       Skip the install phase if a base image already exists
 #   --install-only     Stop after producing the installed base image
-#   --sync-omarchy DIR Push DIR's test/acceptance into the guest before running
+#   --sync-omarchy DIR Push DIR's test suite into the guest before running
 #                      (defaults to OMARCHY_PATH when the suite is present)
 #   --sync-all DIR     Push all of DIR (bin/config/shell/test) into the guest
+#                      and also run the CLI and shell suites there
 #   --port PORT        Host port forwarded to guest SSH (default 2222)
 #   --memory MB        VM memory (default 8192)
 #   --timeout SECS     Install timeout (default 2400)
@@ -1067,16 +1068,13 @@ sync_omarchy() {
     log "Syncing $SYNC_DIR into the guest"
     tar -C "$SYNC_DIR" --exclude .git -cf - . | ssh_guest "mkdir -p $target && tar -C $target -xf -"
   else
-    log "Syncing $SYNC_DIR/test/acceptance into the guest"
-    tar -C "$SYNC_DIR/test" -cf - acceptance acceptance.d | ssh_guest "mkdir -p $target/test && tar -C $target/test -xf -"
+    log "Syncing $SYNC_DIR/test into the guest"
+    tar -C "$SYNC_DIR" -cf - test | ssh_guest "mkdir -p $target && tar -C $target -xf -"
   fi
 }
 
 acceptance_phase() {
   log "Booting acceptance VM from base image overlay"
-
-  local guest_omarchy_path="/usr/share/omarchy"
-  $SYNC_ALL && guest_omarchy_path=".local/share/omarchy"
 
   qemu-img create -f qcow2 -b "$BASE_DISK" -F qcow2 "$RUN_DIR/run.qcow2" >/dev/null
   start_vm "$RUN_DIR/run.qcow2" "$RUN_DIR/serial.log"
@@ -1087,8 +1085,19 @@ acceptance_phase() {
   local status=0
   shortcut_smoke_phase || status=1
 
+  # The synced tree is a full checkout under --sync-all; run the host-style
+  # CLI and shell suites in the guest too before the graphical acceptance
+  # run. They derive their root from their own location in the synced tree.
+  if $SYNC_ALL; then
+    log "Running CLI and shell suites in the guest"
+    ssh_guest "bash .local/share/omarchy/test/all" || status=$?
+  fi
+
+  # The product under test is always the installed tree — VM runs verify the
+  # finished product, never a dev-linked checkout.
   log "Running acceptance suite"
-  ssh_guest "OMARCHY_PATH=$guest_omarchy_path OMARCHY_ACCEPTANCE_DIR=/tmp/omarchy-acceptance bash .local/share/omarchy/test/acceptance" || status=$?
+  ssh_guest "OMARCHY_PATH=/usr/share/omarchy OMARCHY_ACCEPTANCE_DIR=/tmp/omarchy-acceptance \
+    OMARCHY_ACCEPTANCE_SUDO_PASSWORD=$GUEST_PASSWORD bash .local/share/omarchy/test/acceptance" || status=$?
 
   log "Collecting artifacts into $RUN_DIR"
   ssh_guest "tar -C /tmp -cf - omarchy-acceptance 2>/dev/null" | tar -C "$RUN_DIR" -xf - || true

--- a/bin/omarchy-iso-test
+++ b/bin/omarchy-iso-test
@@ -400,7 +400,7 @@ guest_layer_absent() {
 }
 
 cleanup_shortcut_state() {
-  ssh_session 'for plugin in omarchy.launcher omarchy.menu omarchy.emojis omarchy.clipboard omarchy.audio; do
+  ssh_session 'for plugin in omarchy.menu omarchy.emojis omarchy.clipboard omarchy.audio; do
     omarchy-shell shell hide "$plugin" >/dev/null 2>&1 || true
   done
   while read -r address; do
@@ -577,8 +577,8 @@ shortcut_smoke_phase() {
 
   local status=0
   local name chord namespace plugin
-  local shortcuts='launcher|meta_l-spc|omarchy-launcher|omarchy.launcher
-menu|meta_l-alt-spc|omarchy-menu|omarchy.menu
+  local shortcuts='menu|meta_l-spc|omarchy-menu|omarchy.menu
+apps-menu|meta_l-alt-spc|omarchy-menu|omarchy.menu
 emojis|meta_l-ctrl-e|omarchy-emojis|omarchy.emojis
 clipboard|meta_l-ctrl-v|omarchy-clipboard|omarchy.clipboard
 audio-panel|meta_l-ctrl-a|omarchy-keyboard-panel|omarchy.audio'

--- a/bin/omarchy-iso-test
+++ b/bin/omarchy-iso-test
@@ -211,6 +211,7 @@ start_vm() {
     -device virtio-blk-pci,drive=drive0,bootindex=1 \
     -device virtio-vga \
     -display none \
+    -vnc 127.0.0.1:5 \
     -usb -device usb-tablet \
     -netdev user,id=net0,hostfwd=tcp:127.0.0.1:$SSH_PORT-:22 \
     -device virtio-net-pci,netdev=net0 \


### PR DESCRIPTION
Running omarchy-iso-test against omarchy-4.0.2-rc.iso failed in two harness-stale spots (nothing in the ISO itself misbehaved). Three atomic fixes, validated with a full clean install plus a green 136-assertion acceptance rerun against the RC:

- **Stop OCR-waiting on the unencrypted install confirm.** Tesseract cannot read the highlighted "Yes, install without encryption" button under any preprocessing (negate/threshold/green-channel/psm variants), so every unencrypted install timed out at the disk warning. Capture and continue instead; a Ctrl+C toggle that failed to apply still fails the run later, when the unexpectedly encrypted install stalls at the LUKS prompt and SSH never comes up.
- **Match the shortcut smoke to the menu-first bindings.** Super+Space now opens the Omarchy menu and Super+Alt+Space the apps menu; the omarchy.launcher plugin no longer exists. Both surfaces verified in a live guest to open under the `omarchy-menu` layer namespace.
- **Serve a localhost VNC display from test VMs.** Runs stay headless, but `vncviewer 127.0.0.1:5905` lets you watch the driven install live or poke at the acceptance VM left up by `--keep-running`.