### PR TITLE
Persist XKB-only installer layouts (Thai) into vconsole.conf

### DIFF
--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -233,9 +233,11 @@ keyboard_form() {
   done
 
   # Only attempt to load keyboard layout if we're on a real console
-  # loadkeys only works on Linux virtual consoles (tty), not in terminal emulators
+  # loadkeys only works on Linux virtual consoles (tty), not in terminal emulators.
+  # XKB-only picker values have no console map; keep US so the password/LUKS
+  # steps stay Latin (omarchy_console_keymap_for lives in setup-form.sh).
   if [[ $(tty 2>/dev/null) == "/dev/tty"* ]]; then
-    loadkeys "$keyboard" 2>/dev/null
+    loadkeys "$(omarchy_console_keymap_for "$keyboard")" 2>/dev/null
   fi
 }
 

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/keyboard.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/keyboard.py
@@ -11,17 +11,70 @@ generated: nothing on an Omarchy system reads it.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from .command import capture
+
+_XKB_ONLY_RE = re.compile(r'^OMARCHY_XKB_ONLY_LAYOUTS="([^"]*)"', re.MULTILINE)
+
+
+def setup_form_candidates() -> tuple[Path, ...]:
+    """Places the shared picker list is vendored or checked out.
+
+    Live ISO: setup-form.sh sits beside this package at
+    /usr/share/omarchy-iso/setup-form.sh. A developer checkout also looks at a
+    sibling omarchy tree before the installed runtime, so tests see unreleased
+    picker changes rather than /usr/share/omarchy.
+    """
+    here = Path(__file__).resolve()
+    paths = [here.parent.parent / "setup-form.sh"]
+    for parent in here.parents:
+        if parent.name == "omarchy-iso" and (parent / "configs").is_dir():
+            paths.append(parent.parent / "omarchy/install/provisioning/setup-form.sh")
+            break
+    paths.append(Path("/omarchy-source/install/provisioning/setup-form.sh"))
+    paths.append(Path("/usr/share/omarchy/install/provisioning/setup-form.sh"))
+    return tuple(paths)
+
+
+def xkb_only_layouts() -> set[str]:
+    """Picker values that are XKB layouts, not kbd console keymaps."""
+    for candidate in setup_form_candidates():
+        if not candidate.is_file():
+            continue
+        match = _XKB_ONLY_RE.search(candidate.read_text())
+        if match:
+            return {part for part in match.group(1).split() if part}
+    return set()
+
+
+def _set_vconsole_key(path: Path, key: str, value: str) -> None:
+    prefix = f"{key}="
+    lines = path.read_text().splitlines() if path.exists() else []
+    replaced = False
+    new_lines = []
+    for line in lines:
+        if line.startswith(prefix):
+            new_lines.append(f"{prefix}{value}")
+            replaced = True
+        else:
+            new_lines.append(line)
+    if not replaced:
+        new_lines.append(f"{prefix}{value}")
+    path.write_text("\n".join(new_lines) + "\n")
 
 
 def configure_keyboard(target: Path, language: str) -> bool:
     """Write the console keymap into a mounted target without booting it.
 
     Returns False for layouts localectl doesn't know, matching archinstall:
-    warn and keep the default. Every layout the configurator offers is known;
-    the guard is for the kb_layout an autoinstall drive can name freely.
+    warn and keep the default. The guard is for the kb_layout an autoinstall
+    drive can name freely.
+
+    A few picker values (OMARCHY_XKB_ONLY_LAYOUTS in setup-form.sh) are XKB
+    layouts kbd does not ship. Those persist KEYMAP=us so LUKS and the console
+    stay Latin, then XKBLAYOUT is pointed at the chosen layout for Hyprland.
     """
     if not language.strip():
         return True
@@ -30,8 +83,12 @@ def configure_keyboard(target: Path, language: str) -> bool:
     if result.returncode != 0:
         detail = result.stderr.strip() or "localectl returned an error"
         raise RuntimeError(f"Unable to list keyboard layouts: {detail}")
-    if language.lower() not in {layout.lower() for layout in result.stdout.splitlines()}:
+    known = language.lower() in {layout.lower() for layout in result.stdout.splitlines()}
+    xkb_only = language.lower() in {name.lower() for name in xkb_only_layouts()}
+    if not known and not xkb_only:
         return False
+
+    console_keymap = "us" if xkb_only else language
 
     # systemd-firstboot --force rewrites vconsole.conf wholesale, dropping the
     # FONT= line archinstall's set_vconsole wrote earlier.
@@ -43,12 +100,15 @@ def configure_keyboard(target: Path, language: str) -> bool:
             None,
         )
 
-    result = capture(["systemd-firstboot", f"--root={target}", f"--keymap={language}", "--force"])
+    result = capture(["systemd-firstboot", f"--root={target}", f"--keymap={console_keymap}", "--force"])
     if result.returncode != 0:
         detail = result.stderr.strip() or "systemd-firstboot returned an error"
         raise RuntimeError(f"Unable to configure keyboard layout {language}: {detail}")
 
     if font:
         vconsole_path.write_text(vconsole_path.read_text() + font + "\n")
+
+    if xkb_only:
+        _set_vconsole_key(vconsole_path, "XKBLAYOUT", language)
 
     return True

--- a/test/unit/test_keyboard.py
+++ b/test/unit/test_keyboard.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -16,26 +17,39 @@ from orchestrator import keyboard as KEYBOARD  # noqa: E402
 # first-boot owner setup; build-iso.sh vendors it onto the ISO. Read it from
 # wherever this checkout can see a runtime, and skip the coverage test rather
 # than fail when none is around (a bare CI checkout of just this repo).
-SETUP_FORM_CANDIDATES = (
-    Path("/omarchy-source/install/provisioning/setup-form.sh"),
-    ROOT.parent / "omarchy/install/provisioning/setup-form.sh",
-    Path("/usr/share/omarchy/install/provisioning/setup-form.sh"),
-)
+SETUP_FORM_CANDIDATES = KEYBOARD.setup_form_candidates()
 
 
-def supported_keymaps():
+def setup_form_text():
     for candidate in SETUP_FORM_CANDIDATES:
-        if not candidate.is_file():
-            continue
-        block = re.search(
-            r"OMARCHY_KEYBOARD_LAYOUTS=\$'(.*?)'\n", candidate.read_text(), re.DOTALL
-        )
-        assert block, f"no layout list in {candidate}"
-        return [line.split("|", 1)[1] for line in block.group(1).splitlines()]
+        if candidate.is_file():
+            return candidate.read_text()
     return None
 
 
+def supported_keymaps():
+    text = setup_form_text()
+    if text is None:
+        return None
+    block = re.search(
+        r"OMARCHY_KEYBOARD_LAYOUTS=\$'(.*?)'\n", text, re.DOTALL
+    )
+    assert block, "no layout list in setup-form.sh"
+    return [line.split("|", 1)[1] for line in block.group(1).splitlines()]
+
+
+def xkb_only_from_setup_form():
+    text = setup_form_text()
+    if text is None:
+        return None
+    match = re.search(r'^OMARCHY_XKB_ONLY_LAYOUTS="([^"]*)"', text, re.MULTILINE)
+    if match is None:
+        return set()
+    return {part for part in match.group(1).split() if part}
+
+
 SUPPORTED_KEYMAPS = supported_keymaps()
+XKB_ONLY_LAYOUTS = xkb_only_from_setup_form()
 
 
 class KeyboardConfigurationTest(unittest.TestCase):
@@ -58,16 +72,50 @@ class KeyboardConfigurationTest(unittest.TestCase):
             self.assertIn("XKBLAYOUT=us", lines)
             self.assertEqual(lines.count("FONT=default8x16"), 1)
 
-    def test_all_configurator_keymaps_are_known_to_localectl(self):
+    def test_console_keymaps_from_the_picker_still_write_themselves(self):
         if SUPPORTED_KEYMAPS is None:
             self.skipTest("no Omarchy runtime checkout to read the layout list from")
-        for keymap in SUPPORTED_KEYMAPS:
+        xkb_only = XKB_ONLY_LAYOUTS or set()
+        console_maps = [keymap for keymap in SUPPORTED_KEYMAPS if keymap not in xkb_only]
+        self.assertTrue(console_maps, "picker still offers console keymaps")
+        for keymap in console_maps:
             with self.subTest(keymap=keymap), tempfile.TemporaryDirectory() as directory:
                 target = self.target(directory)
                 self.assertTrue(KEYBOARD.configure_keyboard(target, keymap))
                 lines = (target / "etc/vconsole.conf").read_text().splitlines()
                 self.assertIn(f"KEYMAP={keymap}", lines)
                 self.assertEqual(lines.count("FONT=default8x16"), 1)
+
+    def test_xkb_only_picker_values_write_us_console_and_xkb_layout(self):
+        if XKB_ONLY_LAYOUTS is None:
+            self.skipTest("no Omarchy runtime checkout to read the layout list from")
+        if not XKB_ONLY_LAYOUTS:
+            self.skipTest("setup-form.sh names no xkb-only layouts")
+        for keymap in sorted(XKB_ONLY_LAYOUTS):
+            with self.subTest(keymap=keymap), tempfile.TemporaryDirectory() as directory:
+                target = self.target(directory)
+                self.assertTrue(KEYBOARD.configure_keyboard(target, keymap))
+                lines = (target / "etc/vconsole.conf").read_text().splitlines()
+                self.assertIn("KEYMAP=us", lines)
+                self.assertIn(f"XKBLAYOUT={keymap}", lines)
+                self.assertEqual(lines.count("FONT=default8x16"), 1)
+                self.assertEqual(sum(1 for line in lines if line.startswith("XKBLAYOUT=")), 1)
+
+    def test_thai_persists_as_us_console_and_th_xkb_even_without_setup_form(self):
+        with patch.object(KEYBOARD, "xkb_only_layouts", return_value={"th"}):
+            with tempfile.TemporaryDirectory() as directory:
+                target = self.target(directory)
+                self.assertTrue(KEYBOARD.configure_keyboard(target, "th"))
+                lines = (target / "etc/vconsole.conf").read_text().splitlines()
+                self.assertIn("KEYMAP=us", lines)
+                self.assertIn("XKBLAYOUT=th", lines)
+                self.assertEqual(lines.count("FONT=default8x16"), 1)
+
+    def test_configurator_loadkeys_uses_shared_console_helper(self):
+        configurator = ROOT / "configs/airootfs/root/configurator"
+        text = configurator.read_text()
+        self.assertIn("omarchy_console_keymap_for", text)
+        self.assertIn('loadkeys "$(omarchy_console_keymap_for "$keyboard")"', text)
 
     def test_unknown_and_empty_keymaps_match_archinstall_behavior(self):
         for keymap, expected in (("definitely-not-a-keymap", False), ("", True)):


### PR DESCRIPTION
Some layouts the shared `setup-form.sh` picker now offers are XKB layouts, not kbd console keymaps (`th` today). `configure_keyboard` used to return False for those, so the installed `vconsole.conf` never got `XKBLAYOUT` and Hyprland fell back to US.

For names listed in `OMARCHY_XKB_ONLY_LAYOUTS`, write `KEYMAP=us` (so systemd-firstboot and LUKS stay Latin) and `XKBLAYOUT=<choice>`. Unknown names that are not on that list still return False. The live configurator `loadkeys` uses `omarchy_console_keymap_for` from the vendored form so Thai keeps a US console during password entry.

Depends on https://github.com/omacom/omarchy/pull/9358 (adds the picker row and `OMARCHY_XKB_ONLY_LAYOUTS`).

## Testing

- `python test/unit/test_keyboard.py` — real `configure_keyboard` + `systemd-firstboot --root`:
  - every remaining console keymap still writes `KEYMAP=<itself>`
  - `th` writes `KEYMAP=us` / `XKBLAYOUT=th` and keeps FONT
  - `definitely-not-a-keymap` still refused
- `./test/all` green (66 Python tests + existing shell unit tests)

ISO QEMU (`./bin/omarchy-iso-make --local-source ../omarchy` then `./bin/omarchy-iso-boot`) was not run here: no `qemu-system-x86_64`. The install persist path this PR owns is `configure_keyboard`, which the unit tests drive against a fake root with the real `systemd-firstboot`.