### PR TITLE
Update the tagline to Beautiful, Fun & Agentic

### DIFF
--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -122,7 +122,7 @@ greeter() {
   printf '\033[%d;1H' "$logo_row"
   gum style --foreground 2 --padding "0 0 0 $PADDING_LEFT" "$(<"$LOGO_PATH")"
 
-  tagline="Beautiful, Fun & Opinionated Linux by DHH"
+  tagline="Beautiful, Fun & Agentic Linux by DHH"
   tpad=$(((cols - ${#tagline}) / 2)); (( tpad < 0 )) && tpad=0
   printf '\033[%d;%dH%s' "$tagline_row" "$((tpad + 1))" "$tagline"
 


### PR DESCRIPTION
The installer's boot screen tagline follows omarchy.org and the distro repo to "Beautiful, Fun & Agentic Linux by DHH".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
