### PR TITLE
Run unit tests in parallel lanes with a manifest and a ledger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Unit tests
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    # The unit tests exercise scripts that ship on the ISO, so they run against
+    # the same userland: Arch's parted, util-linux script, libarchive bsdtar
+    # and systemd localectl. Ubuntu carries most of these too, but not the
+    # same versions, and a difference there is a test failure nobody asked for.
+    container: archlinux:latest
+    steps:
+      - name: Install test dependencies
+        run: |
+          pacman -Syu --noconfirm --needed \
+            bash git jq libarchive parted python systemd util-linux
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run unit tests
+        run: ./test/all
+
+      - name: Upload test result ledger
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results
+          path: test-runs/unit-test-results.json
+          if-no-files-found: ignore

--- a/test/all
+++ b/test/all
@@ -2,15 +2,27 @@
 #
 # Fast, VM-free tests only. The integration scenarios that boot the ISO in
 # QEMU live in test/integration.d/ and run via ./test/integration.
+#
+# The tests are listed in test/parallel-safe.tests and test/serial.tests and
+# run by test/run-manifest.py: the parallel-safe lane first, several at a
+# time, then the serial lane one at a time. A test present under test/unit/
+# but missing from both manifests is an error, so nothing is silently skipped.
+#
+# Exit status: 0 when every test passed, 1 when any test failed, timed out or
+# was cancelled after another failure, 2 when the runner could not start (a
+# manifest out of step with test/unit/, or another test/all already running).
+#
+#   OMARCHY_TEST_JOBS             parallel-safe tests at once (default 10)
+#   OMARCHY_TEST_TIMEOUT_SECONDS  wall-clock budget per test (default 300)
+#   OMARCHY_TEST_RESULT_LEDGER    JSON summary path (default test-runs/unit-test-results.json)
 
 set -euo pipefail
 
 ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
 
-for test in "$ROOT"/test/unit/*-test.sh; do
-  printf '==> %s\n' "${test#$ROOT/}"
-  bash "$test"
-done
+# The tests run under whichever bash started this script rather than whatever
+# `bash` resolves to inside the runner, so `/opt/homebrew/bin/bash test/all`
+# on macOS gets a modern bash for every test and not just for this file.
+export OMARCHY_TEST_BASH=$BASH
 
-printf '==> test/unit/test_*.py\n'
-python3 -m unittest discover -t "$ROOT" -s "$ROOT/test/unit"
+exec python3 "$ROOT/test/run-manifest.py" "$@"

--- a/test/parallel-safe.tests
+++ b/test/parallel-safe.tests
@@ -1,0 +1,14 @@
+# Tests that only touch their own throwaway directory and may run alongside
+# each other. One line per test, relative to the repository root; blank lines
+# and # comments are ignored. Every test under test/unit/ must appear here or
+# in test/serial.tests, or test/all refuses to run.
+test/unit/cidata-load-test.sh
+test/unit/iso-release-checksum-test.sh
+test/unit/partition-numbering-test.sh
+test/unit/test_command_capture.py
+test/unit/test_configure_ssh_access.py
+test/unit/test_configure_tailscale.py
+test/unit/test_keyboard.py
+test/unit/test_offline_mirror_pruning.py
+test/unit/test_provisioning_state.py
+test/unit/test_run_manifest.py

--- a/test/run-manifest.py
+++ b/test/run-manifest.py
@@ -1,0 +1,737 @@
+#!/usr/bin/env python3
+"""Run the unit tests in two lanes: parallel-safe first, then serial.
+
+test/all used to run every test one after another. Most of them only touch a
+throwaway directory and can share a machine, but a few own something global (a
+pty, a fixed port, the docker socket) and only behave when nothing else runs
+alongside. Rather than guess, every test is listed by hand in one of two
+manifests:
+
+  test/parallel-safe.tests  runs concurrently, up to --jobs at a time
+  test/serial.tests         runs one at a time, after the parallel lane passed
+
+The manifests are the source of truth, and they must be complete: a test that
+exists under test/unit/ but sits in neither manifest is an error, not a silent
+skip, so adding a test means deciding which lane it belongs to. Duplicates,
+entries that point nowhere, and symlinks are rejected for the same reason.
+
+Each test runs in its own session (process group) with a wall-clock budget. A
+timeout or a failure takes the whole group down, including anything the test
+left in the background, and cancels the tests that have not finished yet: the
+first failure is the one worth reading, and a hung fixture must not keep CI
+busy for an hour. A test that exits 0 but leaves a background process behind
+is failed as well, since the next test in the same lane would inherit it.
+
+Python tests run one module per process with test/unit on the module path.
+That sidesteps `unittest discover`, which imports the modules as a `test.unit`
+package and loses to the standard library's own `test` package on hosts that
+ship it (macOS, Debian). A module that collects no test cases is a failure,
+not a pass.
+
+Every run writes a JSON ledger (default test-runs/unit-test-results.json)
+naming each test, its lane, status and elapsed time, so a CI failure can be
+read without scrolling through the log.
+"""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import fcntl
+import json
+import math
+from pathlib import Path
+import os
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import threading
+import time
+import uuid
+
+
+DEFAULT_JOBS = 10
+DEFAULT_TEST_TIMEOUT_SECONDS = 300.0
+DEFAULT_RESULT_LEDGER = "test-runs/unit-test-results.json"
+PROCESS_GROUP_TERMINATION_GRACE_SECONDS = 1.0
+TIMEOUT_RETURNCODE = 124
+CANCELLED_RETURNCODE = 130
+RESULT_LEDGER_SCHEMA_VERSION = 1
+TEST_PATTERNS = ("*-test.sh", "test_*.py")
+PYTHON_UNITTEST_RUNNER = """
+import importlib
+import sys
+import unittest
+
+module = importlib.import_module(sys.argv[1])
+suite = unittest.defaultTestLoader.loadTestsFromModule(module)
+if suite.countTestCases() == 0:
+    print(f"no unittest cases collected from {sys.argv[1]}", file=sys.stderr)
+    raise SystemExit(3)
+result = unittest.TextTestRunner().run(suite)
+raise SystemExit(0 if result.wasSuccessful() else 1)
+"""
+
+
+class ManifestError(Exception):
+    """The lane manifests disagree with test/unit/; nothing has run."""
+
+
+@dataclass(frozen=True)
+class Result:
+    path: str
+    returncode: int
+    stdout: str
+    stderr: str
+    elapsed_seconds: float
+    status: str
+
+    @property
+    def passed(self) -> bool:
+        return self.status == "passed"
+
+
+def read_manifest(path: Path) -> list[str]:
+    return [
+        line.strip()
+        for line in path.read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def discover(root: Path) -> list[str]:
+    return sorted(
+        path.relative_to(root).as_posix()
+        for pattern in TEST_PATTERNS
+        for path in (root / "test/unit").glob(pattern)
+    )
+
+
+def validate(root: Path, parallel: list[str], serial: list[str]) -> None:
+    declared = [*parallel, *serial]
+    duplicates = sorted({value for value in declared if declared.count(value) > 1})
+    if duplicates:
+        raise ManifestError("duplicate test manifest entries: " + ", ".join(duplicates))
+    discovered = discover(root)
+    if sorted(declared) != discovered:
+        missing = sorted(set(discovered) - set(declared))
+        extra = sorted(set(declared) - set(discovered))
+        detail = []
+        if missing:
+            detail.append(
+                "not in test/parallel-safe.tests or test/serial.tests: " + ", ".join(missing)
+            )
+        if extra:
+            detail.append("listed but not under test/unit/: " + ", ".join(extra))
+        raise ManifestError("test manifests are incomplete; " + "; ".join(detail))
+    for value in declared:
+        path = root / value
+        if not path.is_file() or path.is_symlink():
+            raise ManifestError(f"test path is missing or unsafe: {value}")
+
+
+def _cancelled_result(relative: str, reason: str) -> Result:
+    return Result(
+        path=relative,
+        returncode=CANCELLED_RETURNCODE,
+        stdout="",
+        stderr=f"cancelled: {reason}\n",
+        elapsed_seconds=0.0,
+        status="cancelled",
+    )
+
+
+def _process_group_exists(process_group_id: int) -> bool:
+    try:
+        os.killpg(process_group_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _terminate_process_group(
+    process: subprocess.Popen[str],
+    *,
+    grace_seconds: float = PROCESS_GROUP_TERMINATION_GRACE_SECONDS,
+) -> tuple[str, str]:
+    """Stop the test and everything it started; SIGTERM first, SIGKILL after."""
+
+    deadline = time.monotonic() + grace_seconds
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        output: tuple[str, str] | None = process.communicate(timeout=grace_seconds)
+    except subprocess.TimeoutExpired:
+        output = None
+
+    while _process_group_exists(process.pid) and time.monotonic() < deadline:
+        time.sleep(0.01)
+    if _process_group_exists(process.pid):
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    if output is None:
+        output = process.communicate()
+
+    kill_deadline = time.monotonic() + grace_seconds
+    while _process_group_exists(process.pid) and time.monotonic() < kill_deadline:
+        time.sleep(0.01)
+    if _process_group_exists(process.pid):
+        raise RuntimeError(f"process group {process.pid} survived SIGKILL")
+    return output
+
+
+def execute(
+    root: Path,
+    relative: str,
+    *,
+    timeout_seconds: float,
+    cancel_event: threading.Event | None = None,
+) -> Result:
+    cancellation = cancel_event or threading.Event()
+    if cancellation.is_set():
+        return _cancelled_result(relative, "another test failed")
+
+    path = root / relative
+    environment = os.environ.copy()
+    # test/all exports the bash it was started with, so the tests run under the
+    # same interpreter on hosts where /bin/bash is too old (macOS ships 3.2).
+    # Its directory goes first on PATH so a test that calls plain `bash` gets
+    # that one as well.
+    bash = environment.get("OMARCHY_TEST_BASH") or shutil.which("bash")
+    if bash is None:
+        raise RuntimeError("bash is unavailable")
+    bash = str(Path(bash).resolve())
+    environment["OMARCHY_TEST_BASH"] = bash
+    environment["PATH"] = os.pathsep.join(
+        [str(Path(bash).parent), environment.get("PATH", "")]
+    )
+    if path.suffix == ".py":
+        environment["PYTHONPATH"] = os.pathsep.join(
+            [str(root / "test/unit"), environment.get("PYTHONPATH", "")]
+        )
+        command = [sys.executable, "-c", PYTHON_UNITTEST_RUNNER, path.stem]
+    else:
+        command = [bash, str(path)]
+
+    started = time.monotonic()
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=environment,
+            start_new_session=True,
+        )
+    except OSError as error:
+        cancellation.set()
+        return Result(
+            path=relative,
+            returncode=1,
+            stdout="",
+            stderr=f"could not start test: {error}\n",
+            elapsed_seconds=time.monotonic() - started,
+            status="failed",
+        )
+
+    deadline = started + timeout_seconds
+    while True:
+        if cancellation.is_set():
+            stdout, stderr = _terminate_process_group(process)
+            return Result(
+                path=relative,
+                returncode=CANCELLED_RETURNCODE,
+                stdout=stdout,
+                stderr=stderr + "cancelled: another test failed\n",
+                elapsed_seconds=time.monotonic() - started,
+                status="cancelled",
+            )
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            cancellation.set()
+            stdout, stderr = _terminate_process_group(process)
+            return Result(
+                path=relative,
+                returncode=TIMEOUT_RETURNCODE,
+                stdout=stdout,
+                stderr=stderr + f"timed out after {timeout_seconds:g} seconds\n",
+                elapsed_seconds=time.monotonic() - started,
+                status="timed-out",
+            )
+
+        try:
+            stdout, stderr = process.communicate(timeout=min(0.1, remaining))
+        except subprocess.TimeoutExpired:
+            continue
+
+        if _process_group_exists(process.pid):
+            _terminate_process_group(process)
+            cancellation.set()
+            return Result(
+                path=relative,
+                returncode=1,
+                stdout=stdout,
+                stderr=stderr + "test left a process group running after exit\n",
+                elapsed_seconds=time.monotonic() - started,
+                status="failed",
+            )
+
+        status = "passed" if process.returncode == 0 else "failed"
+        if status != "passed":
+            cancellation.set()
+        return Result(
+            path=relative,
+            returncode=process.returncode,
+            stdout=stdout,
+            stderr=stderr,
+            elapsed_seconds=time.monotonic() - started,
+            status=status,
+        )
+
+
+def _future_result(future: Future[Result], relative: str) -> Result:
+    try:
+        return future.result()
+    except Exception as error:  # pragma: no cover - defensive worker boundary
+        return Result(
+            path=relative,
+            returncode=1,
+            stdout="",
+            stderr=f"test runner worker failed: {error}\n",
+            elapsed_seconds=0.0,
+            status="failed",
+        )
+
+
+def run_parallel(
+    root: Path,
+    tests: list[str],
+    *,
+    jobs: int,
+    timeout_seconds: float,
+) -> list[Result]:
+    if not tests:
+        return []
+
+    cancellation = threading.Event()
+    results: dict[str, Result] = {}
+    executor = ThreadPoolExecutor(max_workers=min(jobs, len(tests)))
+    futures = {
+        executor.submit(
+            execute,
+            root,
+            relative,
+            timeout_seconds=timeout_seconds,
+            cancel_event=cancellation,
+        ): relative
+        for relative in tests
+    }
+    pending = set(futures)
+    try:
+        while pending:
+            completed, pending = wait(pending, return_when=FIRST_COMPLETED)
+            for future in completed:
+                relative = futures[future]
+                results[relative] = _future_result(future, relative)
+            if any(not results[futures[future]].passed for future in completed):
+                cancellation.set()
+                for future in list(pending):
+                    if future.cancel():
+                        relative = futures[future]
+                        results[relative] = _cancelled_result(
+                            relative,
+                            "another parallel-safe test failed",
+                        )
+                        pending.remove(future)
+    except BaseException:
+        cancellation.set()
+        for future in pending:
+            future.cancel()
+        raise
+    finally:
+        executor.shutdown(wait=True, cancel_futures=True)
+
+    # Report in manifest order regardless of which finished first.
+    return [results[relative] for relative in tests]
+
+
+def run_serial(
+    root: Path,
+    tests: list[str],
+    *,
+    timeout_seconds: float,
+) -> list[Result]:
+    cancellation = threading.Event()
+    results: list[Result] = []
+    for index, relative in enumerate(tests):
+        result = execute(
+            root,
+            relative,
+            timeout_seconds=timeout_seconds,
+            cancel_event=cancellation,
+        )
+        results.append(result)
+        if not result.passed:
+            results.extend(
+                _cancelled_result(value, "an earlier serial test failed")
+                for value in tests[index + 1 :]
+            )
+            break
+    return results
+
+
+def emit(result: Result) -> None:
+    print(f"==> {result.path} [{result.status}; {result.elapsed_seconds:.3f}s]")
+    if result.stdout:
+        print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+    if result.stderr:
+        print(result.stderr, end="" if result.stderr.endswith("\n") else "\n", file=sys.stderr)
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+
+def _ledger(
+    *,
+    run_id: str,
+    started_at: str,
+    completed_at: str | None,
+    result: str,
+    requested_jobs: int,
+    parallel_worker_count: int,
+    timeout_seconds: float,
+    tests: list[dict[str, object]],
+) -> dict[str, object]:
+    return {
+        "completed_at": completed_at,
+        "kind": "omarchy-unit-test-result-ledger",
+        "parallel_worker_count": parallel_worker_count,
+        "requested_worker_count": requested_jobs,
+        "result": result,
+        "run_id": run_id,
+        "schema_version": RESULT_LEDGER_SCHEMA_VERSION,
+        "started_at": started_at,
+        "test_timeout_seconds": timeout_seconds,
+        "tests": tests,
+    }
+
+
+def build_result_ledger(
+    *,
+    run_id: str,
+    started_at: str,
+    completed_at: str,
+    requested_jobs: int,
+    parallel_worker_count: int,
+    timeout_seconds: float,
+    parallel_results: list[Result],
+    serial_results: list[Result],
+) -> dict[str, object]:
+    records: list[dict[str, object]] = [
+        {
+            "elapsed_seconds": round(result.elapsed_seconds, 3),
+            "lane": lane,
+            "path": result.path,
+            "result": result.status,
+            "returncode": result.returncode,
+        }
+        for lane, results in (
+            ("parallel-safe", parallel_results),
+            ("serial", serial_results),
+        )
+        for result in results
+    ]
+    return _ledger(
+        run_id=run_id,
+        started_at=started_at,
+        completed_at=completed_at,
+        result="passed" if all(record["result"] == "passed" for record in records) else "failed",
+        requested_jobs=requested_jobs,
+        parallel_worker_count=parallel_worker_count,
+        timeout_seconds=timeout_seconds,
+        tests=records,
+    )
+
+
+def build_incomplete_ledger(
+    *,
+    run_id: str,
+    started_at: str,
+    requested_jobs: int,
+    parallel_worker_count: int,
+    timeout_seconds: float,
+    parallel_tests: list[str],
+    serial_tests: list[str],
+) -> dict[str, object]:
+    # Written before anything runs, so a runner that dies mid-way (killed CI
+    # job, power loss) leaves a ledger that says "incomplete" rather than the
+    # previous run's "passed".
+    records: list[dict[str, object]] = [
+        {
+            "elapsed_seconds": 0.0,
+            "lane": lane,
+            "path": path,
+            "result": "not-run",
+            "returncode": None,
+        }
+        for lane, tests in (
+            ("parallel-safe", parallel_tests),
+            ("serial", serial_tests),
+        )
+        for path in tests
+    ]
+    return _ledger(
+        run_id=run_id,
+        started_at=started_at,
+        completed_at=None,
+        result="incomplete",
+        requested_jobs=requested_jobs,
+        parallel_worker_count=parallel_worker_count,
+        timeout_seconds=timeout_seconds,
+        tests=records,
+    )
+
+
+def write_result_ledger(path: Path, ledger: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise RuntimeError(f"result ledger path is an unsafe symlink: {path}")
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        temporary.write_text(json.dumps(ledger, indent=2, sort_keys=True) + "\n")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def acquire_result_ledger_lease(path: Path, run_id: str) -> int:
+    """Take an exclusive lock next to the ledger so two runners cannot interleave.
+
+    Two `test/all` invocations at once would race each other's ledger writes
+    and, worse, each other's serial lane. The lock file is opened O_NOFOLLOW
+    and checked to be a plain private file so a symlink dropped in test-runs/
+    cannot redirect the write.
+    """
+
+    if not run_id or "\n" in run_id:
+        raise RuntimeError("test result run identity is invalid")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(f".{path.name}.lock")
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    cloexec = getattr(os, "O_CLOEXEC", 0)
+    if not nofollow:
+        raise RuntimeError("safe test result locking is unsupported")
+    try:
+        descriptor = os.open(
+            lock_path,
+            os.O_RDWR | os.O_CREAT | nofollow | cloexec,
+            0o600,
+        )
+    except OSError as error:
+        raise RuntimeError(f"test result lease is unsafe: {lock_path}") from error
+    try:
+        status = os.fstat(descriptor)
+        if not stat.S_ISREG(status.st_mode) or status.st_nlink != 1:
+            raise RuntimeError(f"test result lease must be a private file: {lock_path}")
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as error:
+            raise RuntimeError(
+                f"another test runner owns the result ledger: {path}"
+            ) from error
+        payload = f"{run_id}\n".encode()
+        os.ftruncate(descriptor, 0)
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        written = 0
+        while written < len(payload):
+            count = os.write(descriptor, payload[written:])
+            if count <= 0:
+                raise RuntimeError("test result lease write made no progress")
+            written += count
+        os.fsync(descriptor)
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def release_result_ledger_lease(descriptor: int) -> None:
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(descriptor)
+
+
+def run_registered_tests(
+    *,
+    root: Path,
+    parallel: list[str],
+    serial: list[str],
+    jobs: int,
+    timeout_seconds: float,
+    result_ledger: Path,
+    run_id: str,
+    started_at: str,
+) -> int:
+    parallel_worker_count = min(jobs, len(parallel))
+    write_result_ledger(
+        result_ledger,
+        build_incomplete_ledger(
+            run_id=run_id,
+            started_at=started_at,
+            requested_jobs=jobs,
+            parallel_worker_count=parallel_worker_count,
+            timeout_seconds=timeout_seconds,
+            parallel_tests=parallel,
+            serial_tests=serial,
+        ),
+    )
+
+    parallel_results = run_parallel(
+        root,
+        parallel,
+        jobs=jobs,
+        timeout_seconds=timeout_seconds,
+    )
+    for result in parallel_results:
+        emit(result)
+
+    if any(not result.passed for result in parallel_results):
+        serial_results = [
+            _cancelled_result(relative, "a parallel-safe test failed")
+            for relative in serial
+        ]
+    else:
+        serial_results = run_serial(
+            root,
+            serial,
+            timeout_seconds=timeout_seconds,
+        )
+        for result in serial_results:
+            emit(result)
+
+    ledger = build_result_ledger(
+        run_id=run_id,
+        started_at=started_at,
+        completed_at=utc_now(),
+        requested_jobs=jobs,
+        parallel_worker_count=parallel_worker_count,
+        timeout_seconds=timeout_seconds,
+        parallel_results=parallel_results,
+        serial_results=serial_results,
+    )
+    write_result_ledger(result_ledger, ledger)
+    print(f"test result ledger: {result_ledger}")
+
+    failures = [
+        result for result in [*parallel_results, *serial_results] if not result.passed
+    ]
+    if failures:
+        print(
+            "test failures: "
+            + ", ".join(f"{result.path} ({result.status})" for result in failures),
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def positive_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("must be finite and positive")
+    return parsed
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--jobs",
+        type=positive_int,
+        default=positive_int(os.environ.get("OMARCHY_TEST_JOBS", str(DEFAULT_JOBS))),
+        help="parallel-safe tests to run at once (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--test-timeout-seconds",
+        type=positive_float,
+        default=positive_float(
+            os.environ.get("OMARCHY_TEST_TIMEOUT_SECONDS", str(DEFAULT_TEST_TIMEOUT_SECONDS))
+        ),
+        help="wall-clock budget per test (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--result-ledger",
+        type=Path,
+        default=Path(os.environ.get("OMARCHY_TEST_RESULT_LEDGER", DEFAULT_RESULT_LEDGER)),
+        help="where to write the JSON summary (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="check the manifests against test/unit/ and exit without running",
+    )
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[1]
+    try:
+        parallel = read_manifest(root / "test/parallel-safe.tests")
+        serial = read_manifest(root / "test/serial.tests")
+        validate(root, parallel, serial)
+    except (ManifestError, OSError) as error:
+        print(f"test runner refused to start: {error}", file=sys.stderr)
+        return 2
+    if args.validate_only:
+        print(f"validated {len(parallel)} parallel-safe and {len(serial)} serial tests")
+        return 0
+
+    result_ledger = args.result_ledger
+    if not result_ledger.is_absolute():
+        result_ledger = root / result_ledger
+    run_id = uuid.uuid4().hex
+    started_at = utc_now()
+    try:
+        lease = acquire_result_ledger_lease(result_ledger, run_id)
+    except RuntimeError as error:
+        print(f"test runner refused to start: {error}", file=sys.stderr)
+        return 2
+    try:
+        return run_registered_tests(
+            root=root,
+            parallel=parallel,
+            serial=serial,
+            jobs=args.jobs,
+            timeout_seconds=args.test_timeout_seconds,
+            result_ledger=result_ledger,
+            run_id=run_id,
+            started_at=started_at,
+        )
+    finally:
+        release_result_ledger_lease(lease)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/serial.tests
+++ b/test/serial.tests
@@ -1,0 +1,8 @@
+# Tests that own something global -- a pty, a port, the docker socket, a shared
+# fixture -- and run one at a time after the parallel-safe lane has passed.
+# Say what the global thing is above each entry so the next person can tell
+# whether a new test belongs here.
+
+# Drives the failure screen through a real pty (script) and asserts on the
+# terminal repaint order, which a busy machine can reorder.
+test/unit/install-media-diagnosis-test.sh

--- a/test/unit/test_run_manifest.py
+++ b/test/unit/test_run_manifest.py
@@ -1,0 +1,291 @@
+"""Unit tests for test/run-manifest.py, the lane runner behind test/all.
+
+Every fixture is a throwaway script under a temp directory laid out like the
+repository, so the runner is driven exactly as test/all drives it. The process
+group cases matter most: a timed-out or cancelled test must take its children
+with it, and a test that exits 0 while leaving a background process behind is
+a failure, not a pass, because the next test would inherit it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import signal
+import sys
+import tempfile
+import time
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "test/run-manifest.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("run_manifest", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {MODULE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class RunManifestTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.module = load_module()
+
+    def make_script(self, root: Path, name: str, content: str) -> str:
+        relative = f"test/unit/{name}"
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("#!/bin/bash\nset -euo pipefail\n" + content)
+        return relative
+
+    def assert_process_exits(self, pid: int) -> None:
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return
+            time.sleep(0.02)
+        self.fail(f"process {pid} survived test cancellation")
+
+    def test_timeout_terminates_the_entire_fixture_process_group(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            relative = self.make_script(
+                root,
+                "timeout-fixture-test.sh",
+                'sleep 60 &\nchild=$!\nprintf "%s\\n" "$child" > test/unit/child.pid\nwait "$child"\n',
+            )
+
+            result = self.module.execute(
+                root,
+                relative,
+                timeout_seconds=0.2,
+            )
+
+            self.assertEqual(result.status, "timed-out")
+            self.assertEqual(result.returncode, self.module.TIMEOUT_RETURNCODE)
+            child_pid = int((root / "test/unit/child.pid").read_text())
+            self.assert_process_exits(child_pid)
+
+    def test_timeout_escalates_to_kill_a_sigterm_resistant_descendant(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            relative = self.make_script(
+                root,
+                "resistant-fixture-test.sh",
+                "(\n"
+                "  trap '' TERM\n"
+                "  exec >/dev/null 2>&1\n"
+                "  while true; do sleep 60; done\n"
+                ") &\n"
+                "child=$!\n"
+                'printf "%s\\n" "$child" > test/unit/resistant.pid\n'
+                'wait "$child"\n',
+            )
+
+            result = self.module.execute(
+                root,
+                relative,
+                timeout_seconds=0.2,
+            )
+
+            self.assertEqual(result.status, "timed-out")
+            child_pid = int((root / "test/unit/resistant.pid").read_text())
+            self.assert_process_exits(child_pid)
+
+    def test_parallel_failure_cancels_a_running_sibling_process_group(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            slow = self.make_script(
+                root,
+                "slow-fixture-test.sh",
+                'sleep 60 &\nchild=$!\nprintf "%s\\n" "$child" > test/unit/sibling.pid\nwait "$child"\n',
+            )
+            failing = self.make_script(
+                root,
+                "failing-fixture-test.sh",
+                "for ((attempt=0; attempt<200; attempt++)); do\n"
+                "  [[ -s test/unit/sibling.pid ]] && exit 7\n"
+                "  sleep 0.01\n"
+                "done\n"
+                "exit 8\n",
+            )
+
+            results = self.module.run_parallel(
+                root,
+                [slow, failing],
+                jobs=2,
+                timeout_seconds=5.0,
+            )
+
+            self.assertEqual([result.path for result in results], [slow, failing])
+            self.assertEqual(results[0].status, "cancelled")
+            self.assertEqual(results[1].status, "failed")
+            sibling_pid = int((root / "test/unit/sibling.pid").read_text())
+            self.assert_process_exits(sibling_pid)
+
+    def test_successful_parent_cannot_leave_a_background_process(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            relative = self.make_script(
+                root,
+                "leaking-success-fixture-test.sh",
+                "(\n"
+                "  trap '' TERM\n"
+                "  exec </dev/null >/dev/null 2>&1\n"
+                "  while true; do sleep 60; done\n"
+                ") &\n"
+                "child=$!\n"
+                'printf "%s\n" "$child" > test/unit/leaked.pid\n'
+                "exit 0\n",
+            )
+
+            result = self.module.execute(root, relative, timeout_seconds=2.0)
+            leaked_pid = int((root / "test/unit/leaked.pid").read_text())
+            try:
+                self.assertEqual(result.status, "failed")
+                self.assertIn("left a process group running", result.stderr)
+                self.assert_process_exits(leaked_pid)
+            finally:
+                try:
+                    leaked_group = os.getpgid(leaked_pid)
+                except ProcessLookupError:
+                    pass
+                else:
+                    os.killpg(leaked_group, signal.SIGKILL)
+
+    def test_a_test_missing_from_both_manifests_is_an_error(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            listed = self.make_script(root, "listed-test.sh", "exit 0\n")
+            self.make_script(root, "forgotten-test.sh", "exit 0\n")
+
+            with self.assertRaisesRegex(self.module.ManifestError, "forgotten-test.sh"):
+                self.module.validate(root, [listed], [])
+
+    def test_a_manifest_entry_without_a_file_is_an_error(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            listed = self.make_script(root, "listed-test.sh", "exit 0\n")
+
+            with self.assertRaisesRegex(self.module.ManifestError, "gone-test.sh"):
+                self.module.validate(root, [listed], ["test/unit/gone-test.sh"])
+
+    def test_a_test_in_both_manifests_is_an_error(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            listed = self.make_script(root, "listed-test.sh", "exit 0\n")
+
+            with self.assertRaisesRegex(self.module.ManifestError, "duplicate"):
+                self.module.validate(root, [listed], [listed])
+
+    def test_the_checked_in_manifests_cover_every_unit_test(self) -> None:
+        parallel = self.module.read_manifest(ROOT / "test/parallel-safe.tests")
+        serial = self.module.read_manifest(ROOT / "test/serial.tests")
+
+        self.module.validate(ROOT, parallel, serial)
+
+    def test_ledger_is_ordered_and_contains_elapsed_result_and_worker_count(self) -> None:
+        parallel_results = [
+            self.module.Result("test/unit/b-test.sh", 0, "", "", 0.1254, "passed"),
+            self.module.Result("test/unit/a-test.sh", 1, "", "", 0.3756, "failed"),
+        ]
+        serial_results = [
+            self.module.Result("test/unit/c-test.sh", 130, "", "", 0.0, "cancelled")
+        ]
+        ledger = self.module.build_result_ledger(
+            run_id="run-1",
+            started_at="2026-08-29T00:00:00.000000Z",
+            completed_at="2026-08-29T00:00:01.000000Z",
+            requested_jobs=10,
+            parallel_worker_count=2,
+            timeout_seconds=300.0,
+            parallel_results=parallel_results,
+            serial_results=serial_results,
+        )
+
+        self.assertEqual(ledger["requested_worker_count"], 10)
+        self.assertEqual(ledger["parallel_worker_count"], 2)
+        self.assertEqual(ledger["schema_version"], 1)
+        self.assertEqual(ledger["run_id"], "run-1")
+        self.assertEqual(ledger["started_at"], "2026-08-29T00:00:00.000000Z")
+        self.assertEqual(ledger["completed_at"], "2026-08-29T00:00:01.000000Z")
+        self.assertEqual(ledger["result"], "failed")
+        self.assertEqual(
+            [record["path"] for record in ledger["tests"]],
+            ["test/unit/b-test.sh", "test/unit/a-test.sh", "test/unit/c-test.sh"],
+        )
+        self.assertEqual(ledger["tests"][0]["elapsed_seconds"], 0.125)
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ledger.json"
+            self.module.write_result_ledger(path, ledger)
+            self.assertEqual(json.loads(path.read_text()), ledger)
+
+    def test_result_ledger_lease_blocks_a_concurrent_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ledger.json"
+            first = self.module.acquire_result_ledger_lease(path, "run-1")
+            try:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "another test runner owns the result ledger",
+                ):
+                    self.module.acquire_result_ledger_lease(path, "run-2")
+            finally:
+                self.module.release_result_ledger_lease(first)
+
+            second = self.module.acquire_result_ledger_lease(path, "run-3")
+            self.module.release_result_ledger_lease(second)
+
+    def test_python_fixture_with_no_collected_tests_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            relative = "test/unit/test_empty_fixture.py"
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("VALUE = 1\n")
+
+            result = self.module.execute(root, relative, timeout_seconds=2.0)
+
+            self.assertEqual(result.status, "failed")
+            self.assertEqual(result.returncode, 3)
+            self.assertIn("no unittest cases collected", result.stderr)
+
+    def test_python_fixture_with_a_collected_test_runs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            relative = "test/unit/test_collected_fixture.py"
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                "import unittest\n\n"
+                "class CollectedTest(unittest.TestCase):\n"
+                "    def test_runs(self):\n"
+                "        self.assertTrue(True)\n"
+            )
+
+            result = self.module.execute(root, relative, timeout_seconds=2.0)
+
+            self.assertEqual(result.status, "passed", result.stderr)
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("Ran 1 test", result.stderr)
+
+    def test_non_finite_timeouts_are_rejected(self) -> None:
+        for value in ("nan", "inf", "-inf", "0", "-1"):
+            with self.subTest(value=value):
+                with self.assertRaises(Exception):
+                    self.module.positive_float(value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Replace the serial loop in `test/all` with a lane-based runner. Tests that only touch their own temp directory run in parallel; tests that own something global (a pty, a port, the docker socket) run one at a time afterwards. Every test under `test/unit/` must be listed in `test/parallel-safe.tests` or `test/serial.tests`, or the runner refuses to start, so a forgotten test is an error rather than a silent skip.

## What changed

- `test/run-manifest.py`: the runner. Thread-pool parallel lane, then the serial lane. Per-test wall-clock timeout (`OMARCHY_TEST_TIMEOUT_SECONDS`, default 300). Each test runs in its own session, so a timeout kills the whole process group, and a test that passes but leaves a background process behind is failed. Python modules run one per process and fail closed when zero cases collect. A JSON ledger is written to `test-runs/` and a flock lease stops two runs interleaving.
- `test/parallel-safe.tests` and `test/serial.tests`: the manifests. Each serial entry says what the global thing is.
- `test/all`: delegates to the runner. Exit 0 all passed, 1 any failure (fail-fast, as before), 2 the runner refused to start.
- `.github/workflows/test.yml`: runs `test/all` in an `archlinux:latest` container on push and pull request. The tests reach for `parted`, util-linux `script`, `bsdtar` and `localectl` at the versions that ship on the ISO, which Ubuntu does not have.

## Testing

- `test_run_manifest.py`: 13 tests covering the process-group timeout, SIGTERM-resistant children, sibling cancellation, leaked background processes, ledger shape, lease contention, empty python modules, and the manifest completeness rules.
- Verified the exit-2 path with an unlisted test file.
- Full `test/all` on Linux is what the new workflow runs; on macOS two upstream tests fail for lack of `localectl` and `script -c`, unchanged from before.

This is the first of two ISO PRs; the aarch64 ISO PR stacks on it because its new tests need manifest entries.
