### PR TITLE
Build a generic aarch64 ISO

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Unit tests
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    # The unit tests exercise scripts that ship on the ISO, so they run against
+    # the same userland: Arch's parted, util-linux script, libarchive bsdtar
+    # and systemd localectl. Ubuntu carries most of these too, but not the
+    # same versions, and a difference there is a test failure nobody asked for.
+    container: archlinux:latest
+    steps:
+      - name: Install test dependencies
+        run: |
+          pacman -Syu --noconfirm --needed \
+            bash git jq libarchive parted python systemd util-linux
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run unit tests
+        run: ./test/all
+
+      - name: Upload test result ledger
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results
+          path: test-runs/unit-test-results.json
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Corruption anywhere in the ISO is worth catching before the write, and corruptio
 
 Run `./bin/omarchy-iso-make`; output goes into `./release`. By default the ISO uses the Omarchy packages and tracks the `quattro` branch, from the stable mirror. Pass `--edge` to use `omarchy-dev` and `omarchy-settings-dev` from the edge mirror.
 
+The build defaults to `x86_64`. Pass `--arch aarch64` for the generic UEFI ARM64 ISO (Ampere, Graviton, Snapdragon X, dev kits — anything with vanilla UEFI + ACPI; Apple Silicon is not a target). It builds in an Arch Linux ARM container, so an arm64 host is strongly preferred; on x86_64 it runs under QEMU binfmt emulation and takes several times longer. The aarch64 ISO is named `omarchy-<date>-aarch64-<ref>.iso` and can share `release/` with the x86_64 one. See `plans/aarch64-support.md` for what is covered and what still blocks a bootable image.
+
 For local development, build the ISO from sibling checkouts:
 
 ```bash

--- a/bin/omarchy-iso-make
+++ b/bin/omarchy-iso-make
@@ -6,8 +6,17 @@ NO_CACHE=""
 KEEP_PKG_CACHE=""
 LOCAL_OMARCHY_PATH=""
 LOCAL_PKGS_PATH=""
+OMARCHY_ARCH="x86_64"
 while [[ $# -gt 0 ]]; do
   case $1 in
+  --arch)
+    OMARCHY_ARCH="${2:-}"
+    shift 2
+    ;;
+  --arch=*)
+    OMARCHY_ARCH="${1#*=}"
+    shift
+    ;;
   --no-cache)
     NO_CACHE=1
     shift
@@ -57,11 +66,33 @@ while [[ $# -gt 0 ]]; do
     ;;
   *)
     echo "Unknown option: $1"
-    echo "Usage: $0 [--no-cache] [--keep-pkg-cache] [--no-boot-offer] [--debug] [--edge] [--dev|--rc] [--local-source <omarchy-checkout> <pkgs-checkout>]"
+    echo "Usage: $0 [--arch x86_64|aarch64] [--no-cache] [--keep-pkg-cache] [--no-boot-offer] [--debug] [--edge] [--dev|--rc] [--local-source <omarchy-checkout> <pkgs-checkout>]"
     exit 1
     ;;
   esac
 done
+
+# The build container must match the ISO's architecture: pacman resolves
+# $arch from the running system and mkarchiso pacstraps with the host's
+# pacman, so an aarch64 ISO needs an arm64 container. On an x86_64 host that
+# means QEMU binfmt emulation (slow, 30-60 min); a native arm64 host is
+# preferred. archlinux/archlinux publishes no arm64 image, and Arch Linux ARM
+# is the aarch64 base distribution anyway, so use an ALARM image there.
+case "$OMARCHY_ARCH" in
+  x86_64)
+    BUILD_IMAGE="archlinux/archlinux:latest"
+    BUILD_PLATFORM_ARGS=()
+    ;;
+  aarch64)
+    BUILD_IMAGE="menci/archlinuxarm:latest"
+    BUILD_PLATFORM_ARGS=(--platform linux/arm64)
+    ;;
+  *)
+    echo "Unsupported architecture: $OMARCHY_ARCH" >&2
+    echo "Supported architectures: x86_64, aarch64" >&2
+    exit 1
+    ;;
+esac
 
 if [[ -n $LOCAL_OMARCHY_PATH ]]; then
   [[ -d $LOCAL_OMARCHY_PATH ]] || { echo "Error: Omarchy checkout not found at $LOCAL_OMARCHY_PATH" >&2; exit 1; }
@@ -125,6 +156,7 @@ DOCKER_ARGS=(
   --privileged
   -e "OMARCHY_ISO_REF=$OMARCHY_ISO_REF"
   -e "OMARCHY_MIRROR=$OMARCHY_MIRROR"
+  -e "OMARCHY_ARCH=$OMARCHY_ARCH"
   -e "OMARCHY_INSTALL_DEBUG=${OMARCHY_INSTALL_DEBUG:-}"
   -e "HOST_UID=$(id -u)"
   -e "HOST_GID=$(id -g)"
@@ -147,9 +179,13 @@ if [[ -d /var/cache/pacman/pkg ]]; then
 fi
 
 # Mount the build cache directory where packages are downloaded. Channels use
-# different package snapshots and must never share an offline mirror cache.
+# different package snapshots and must never share an offline mirror cache,
+# and neither can architectures: the offline repo db and every package in it
+# are per-arch. x86_64 keeps its existing directory name.
 if [[ -z "$NO_CACHE" ]]; then
-  OFFLINE_REPO_BUILD_CACHE_DIR="$HOME/.cache/omarchy/iso_${OMARCHY_MIRROR}/airootfs/var/cache/omarchy"
+  cache_scope="iso_${OMARCHY_MIRROR}"
+  [[ $OMARCHY_ARCH == "x86_64" ]] || cache_scope+="_${OMARCHY_ARCH}"
+  OFFLINE_REPO_BUILD_CACHE_DIR="$HOME/.cache/omarchy/$cache_scope/airootfs/var/cache/omarchy"
   mkdir -p "$OFFLINE_REPO_BUILD_CACHE_DIR"
   DOCKER_ARGS+=(-v "$OFFLINE_REPO_BUILD_CACHE_DIR:/var/cache/airootfs/var/cache/omarchy")
 else
@@ -166,9 +202,11 @@ if ! docker version &>/dev/null; then
   DOCKER=(sudo docker)
 fi
 
-"${DOCKER[@]}" run "${DOCKER_ARGS[@]}" archlinux/archlinux:latest /$BUILD_SCRIPT
+"${DOCKER[@]}" run "${BUILD_PLATFORM_ARGS[@]}" "${DOCKER_ARGS[@]}" "$BUILD_IMAGE" /$BUILD_SCRIPT
 
-latest_iso=$(\ls -t "$BUILD_RELEASE_PATH"/*.iso | head -n1)
+# mkarchiso names the ISO after profiledef's arch, so two architectures can
+# share release/ and each build picks up only its own output.
+latest_iso=$(\ls -t "$BUILD_RELEASE_PATH"/*-"$OMARCHY_ARCH".iso | head -n1)
 iso_ref="${latest_iso%.*}-$OMARCHY_ISO_REF.iso"
 mv -f "$latest_iso" "$iso_ref"
 

--- a/bin/omarchy-iso-test
+++ b/bin/omarchy-iso-test
@@ -24,9 +24,14 @@
 #                      and also run the CLI and shell suites there
 #   --port PORT        Host port forwarded to guest SSH (default 2222)
 #   --memory MB        VM memory (default 8192)
+#   --cpus COUNT       Virtual CPUs (default: all host CPUs)
 #   --timeout SECS     Install timeout (default 2400)
 #   --keep-running     Leave the acceptance VM running after the suite finishes
 #   --no-preview       Do not open the collected screenshots in imv
+#
+# The guest architecture follows the ISO name (omarchy-*-aarch64-*.iso boots
+# qemu-system-aarch64 with the ARM virt machine). Hosts: Linux with KVM, or
+# macOS on Apple Silicon (Homebrew qemu, HVF) for aarch64 ISOs only.
 
 set -euo pipefail
 
@@ -36,6 +41,11 @@ REPO_DIR="$(dirname "$SCRIPT_DIR")"
 ISO=""
 SSH_PORT=2222
 MEMORY=8192
+if command -v nproc >/dev/null 2>&1; then
+  CPUS=$(nproc)
+else
+  CPUS=$(sysctl -n hw.logicalcpu)
+fi
 INSTALL_TIMEOUT=2400
 BOOT_TIMEOUT=600
 ENCRYPT=false
@@ -63,6 +73,7 @@ while (($#)); do
     --sync-all) SYNC_DIR="$2"; SYNC_ALL=true; shift ;;
     --port) SSH_PORT="$2"; shift ;;
     --memory) MEMORY="$2"; shift ;;
+    --cpus) CPUS="$2"; shift ;;
     --timeout) INSTALL_TIMEOUT="$2"; shift ;;
     -*) echo "Unknown option: $1" >&2; exit 1 ;;
     *) ISO="$1" ;;
@@ -84,10 +95,56 @@ if [[ ! -f ${ISO:-} ]]; then
   exit 1
 fi
 
-omarchy-pkg-add qemu-full edk2-ovmf socat imagemagick tesseract tesseract-data-eng
+case "$CPUS" in
+  ''|*[!0-9]*) echo "CPU count must be a positive integer" >&2; exit 1 ;;
+esac
+(( CPUS > 0 )) || { echo "CPU count must be a positive integer" >&2; exit 1; }
 
-OVMF_CODE="/usr/share/edk2/x64/OVMF_CODE.4m.fd"
-OVMF_VARS_TEMPLATE="/usr/share/edk2/x64/OVMF_VARS.4m.fd"
+HOST_OS=$(uname -s)
+GUEST_ARCH=x86_64
+[[ $(basename "$ISO") == *-aarch64*.iso ]] && GUEST_ARCH=aarch64
+
+# Firmware and tooling per host. Linux gets the Arch packages; macOS relies
+# on Homebrew's qemu (which bundles edk2 for aarch64) and coreutils' gtimeout,
+# and can only run aarch64 guests natively under HVF.
+if [[ $HOST_OS == "Darwin" ]]; then
+  if [[ $GUEST_ARCH != "aarch64" || $(uname -m) != "arm64" ]]; then
+    echo "macOS acceptance currently supports native aarch64 ISOs on Apple Silicon only" >&2
+    exit 1
+  fi
+
+  export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+  for command in qemu-system-aarch64 qemu-img socat magick tesseract ssh ssh-keygen python3; do
+    command -v "$command" >/dev/null 2>&1 || {
+      echo "Missing macOS acceptance dependency: $command" >&2
+      exit 1
+    }
+  done
+
+  QEMU_SHARE="$(brew --prefix qemu)/share/qemu"
+  OVMF_CODE="$QEMU_SHARE/edk2-aarch64-code.fd"
+  OVMF_VARS_TEMPLATE="$QEMU_SHARE/edk2-arm-vars.fd"
+  ACCEL=hvf
+  TIMEOUT_COMMAND=()
+  command -v gtimeout >/dev/null 2>&1 && TIMEOUT_COMMAND=(gtimeout 5)
+else
+  omarchy-pkg-add qemu-full edk2-ovmf socat imagemagick tesseract tesseract-data-eng
+  if [[ $GUEST_ARCH == "aarch64" ]]; then
+    omarchy-pkg-add edk2-armvirt
+    OVMF_CODE="/usr/share/edk2/aarch64/QEMU_CODE.fd"
+    OVMF_VARS_TEMPLATE="/usr/share/edk2/aarch64/QEMU_VARS.fd"
+  else
+    OVMF_CODE="/usr/share/edk2/x64/OVMF_CODE.4m.fd"
+    OVMF_VARS_TEMPLATE="/usr/share/edk2/x64/OVMF_VARS.4m.fd"
+  fi
+  ACCEL=kvm
+  TIMEOUT_COMMAND=(timeout 5)
+fi
+
+[[ -f $OVMF_CODE && -f $OVMF_VARS_TEMPLATE ]] || {
+  echo "Missing UEFI firmware for $GUEST_ARCH: $OVMF_CODE" >&2
+  exit 1
+}
 
 BASE_NAME="$(basename "$ISO" .iso)"
 $ENCRYPT && BASE_NAME+="-encrypted"
@@ -95,7 +152,7 @@ $PROVISION && BASE_NAME+="-provision"
 BASE_DIR="$REPO_DIR/test-runs/$BASE_NAME"
 RUN_DIR="$BASE_DIR/runs/$(date +%Y%m%d-%H%M%S)"
 BASE_DISK="$BASE_DIR/base.qcow2"
-BASE_OVMF="$BASE_DIR/OVMF_VARS.4m.fd"
+BASE_OVMF="$BASE_DIR/OVMF_VARS.fd"
 SSH_KEY="$BASE_DIR/id_ed25519"
 HTTP_PORT=$((SSH_PORT + 1))
 HTTP_PID=""
@@ -104,7 +161,9 @@ mkdir -p "$BASE_DIR" "$RUN_DIR"
 
 # Unix socket paths are capped at ~108 bytes, which a run directory nested in
 # test-runs/<iso-name>/runs/<timestamp> can exceed. Keep the socket in /tmp.
-QMP_SOCK=$(mktemp -u "${TMPDIR:-/tmp}/omarchy-iso-test-qmp.XXXXXX.sock")
+# macOS mktemp only substitutes a trailing run of X's, so the suffix is
+# appended after the template.
+QMP_SOCK="$(mktemp -u "${TMPDIR:-/tmp}/omarchy-iso-test-qmp.XXXXXX").sock"
 PIDFILE="$RUN_DIR/qemu.pid"
 
 log() {
@@ -119,7 +178,7 @@ vm_running() {
 
 qmp() {
   printf '{"execute":"qmp_capabilities"}\n{"execute":%s}\n' "$1" |
-    timeout 5 socat -t 2 - "UNIX-CONNECT:$QMP_SOCK" 2>/dev/null || true
+    "${TIMEOUT_COMMAND[@]}" socat -t 2 - "UNIX-CONNECT:$QMP_SOCK" 2>/dev/null || true
 }
 
 screendump() {
@@ -164,11 +223,18 @@ open_screenshots() {
   local entry
   local -a screenshots=()
 
+  # Ordered by capture time. BSD find has no -printf; stat -f gives the same
+  # "<mtime> <path>" pairs there.
   while IFS= read -r -d '' entry; do
     screenshots+=("${entry#* }")
   done < <(
-    find "$RUN_DIR" -type f \( -name "success-*.png" -o -name "failure-*.png" \) -printf '%T@ %p\0' |
-      sort -zn
+    if [[ $HOST_OS == "Darwin" ]]; then
+      find "$RUN_DIR" -type f \( -name "success-*.png" -o -name "failure-*.png" \) -exec stat -f '%m %N' {} + |
+        sort -n | tr '\n' '\0'
+    else
+      find "$RUN_DIR" -type f \( -name "success-*.png" -o -name "failure-*.png" \) -printf '%T@ %p\0' |
+        sort -zn
+    fi
   )
 
   (( ${#screenshots[@]} > 0 )) || return 0
@@ -191,7 +257,7 @@ cleanup() {
     stop_vm
   fi
 
-  rm -f "$RUN_DIR/.screen.ppm" "$RUN_DIR/.screen.png"
+  rm -f "$RUN_DIR/.screen.ppm" "$RUN_DIR/.screen.png" "$QMP_SOCK"
   open_screenshots
 
   return $status
@@ -207,18 +273,36 @@ start_vm() {
   # virtio-gpu before the system comes up.
   log "Watch (do not resize): vncviewer -RemoteResize=0 127.0.0.1:5905"
 
-  qemu-system-x86_64 \
-    -cpu host -enable-kvm -machine q35,accel=kvm \
-    -smp "$(nproc)" \
+  # The two machines differ in what they can emulate, not in how the harness
+  # drives them: the ARM virt machine has no q35 legacy USB or VGA, so it gets
+  # virtio-gpu and an xHCI controller with a USB keyboard for send-key.
+  local -a machine_args
+  if [[ $GUEST_ARCH == "aarch64" ]]; then
+    machine_args=(
+      qemu-system-aarch64
+      -cpu host -machine "virt,accel=$ACCEL"
+      -device virtio-gpu-pci
+      -device qemu-xhci,id=xhci
+      -device usb-kbd,bus=xhci.0 -device usb-tablet,bus=xhci.0
+    )
+  else
+    machine_args=(
+      qemu-system-x86_64
+      -cpu host -enable-kvm -machine "q35,accel=$ACCEL"
+      -device virtio-vga
+      -usb -device usb-tablet
+    )
+  fi
+
+  "${machine_args[@]}" \
+    -smp "$CPUS" \
     -m "$MEMORY" \
     -drive if=pflash,format=raw,readonly=on,file="$OVMF_CODE" \
     -drive if=pflash,format=raw,file="$BASE_OVMF" \
     -drive file="$disk",format=qcow2,if=none,id=drive0 \
     -device virtio-blk-pci,drive=drive0,bootindex=1 \
-    -device virtio-vga \
     -display none \
     -vnc 127.0.0.1:5 \
-    -usb -device usb-tablet \
     -netdev user,id=net0,hostfwd=tcp:127.0.0.1:$SSH_PORT-:22 \
     -device virtio-net-pci,netdev=net0 \
     -qmp "unix:$QMP_SOCK,server,nowait" \
@@ -255,7 +339,7 @@ wait_for_screen() {
     fi
 
     if ((waited >= timeout)); then
-      slug=${text,,}
+      slug=$(printf '%s' "$text" | tr '[:upper:]' '[:lower:]') # macOS bash 3 has no ${var,,}
       slug=${slug// /-}
       slug=${slug//[^a-z0-9-]/}
       capture_console "failure-installer-waiting-for-$slug"
@@ -290,7 +374,7 @@ type_text() {
     ch=${text:i:1}
     case "$ch" in
       [a-z0-9]) press "$ch" ;;
-      [A-Z]) press "shift-${ch,,}" ;;
+      [A-Z]) press "shift-$(printf '%s' "$ch" | tr '[:upper:]' '[:lower:]')" ;;
       " ") press spc ;;
       .) press dot ;;
       ,) press comma ;;
@@ -990,9 +1074,20 @@ install_phase() {
   qemu-img create -f qcow2 "$BASE_DISK" 40G >/dev/null
   cp "$OVMF_VARS_TEMPLATE" "$BASE_OVMF"
 
-  start_vm "$BASE_DISK" "$RUN_DIR/install-serial.log" \
-    -drive "file=$ISO,media=cdrom,if=none,format=raw,id=cdrom0" \
-    -device ide-cd,drive=cdrom0,bootindex=2
+  # The ARM virt machine has no IDE; the ISO rides a virtio-scsi CD there.
+  local -a iso_boot_args=(
+    -drive "file=$ISO,media=cdrom,if=none,format=raw,id=cdrom0"
+  )
+  if [[ $GUEST_ARCH == "aarch64" ]]; then
+    iso_boot_args+=(
+      -device virtio-scsi-pci,id=scsi0
+      -device scsi-cd,drive=cdrom0,bus=scsi0.0,bootindex=2
+    )
+  else
+    iso_boot_args+=(-device ide-cd,drive=cdrom0,bootindex=2)
+  fi
+
+  start_vm "$BASE_DISK" "$RUN_DIR/install-serial.log" "${iso_boot_args[@]}"
 
   drive_configurator
   wait_for_install

--- a/builder/archiso-aarch64.patch
+++ b/builder/archiso-aarch64.patch
@@ -1,0 +1,56 @@
+--- mkarchiso.orig
++++ mkarchiso
+@@ -430,10 +430,16 @@
+ # Copy kernel and initramfs to ISO 9660
+ _make_boot_on_iso9660() {
+     local ucode_image
++    local -a kernel_images
+     _msg_info "Preparing kernel and initramfs for the ISO 9660 file system..."
+     install -d -m 0755 -- "${isofs_dir}/${install_dir}/boot/${arch}"
+     install -m 0644 -- "${pacstrap_dir}/boot/initramfs-"*".img" "${isofs_dir}/${install_dir}/boot/${arch}/"
+-    install -m 0644 -- "${pacstrap_dir}/boot/vmlinuz-"* "${isofs_dir}/${install_dir}/boot/${arch}/"
++    if [[ "$arch" == 'aarch64' && -e "${pacstrap_dir}/boot/Image" ]]; then
++        kernel_images=("${pacstrap_dir}/boot/Image")
++    else
++        kernel_images=("${pacstrap_dir}"/boot/vmlinuz-*)
++    fi
++    install -m 0644 -- "${kernel_images[@]}" "${isofs_dir}/${install_dir}/boot/${arch}/"
+ 
+     if (( need_external_ucodes )); then
+         for ucode_image in "${ucodes[@]}"; do
+@@ -692,6 +698,22 @@
+                  minicmd normal ntfs ntfscomp part_apple part_gpt part_msdos png read reboot regexp search \
+                  search_fs_file search_fs_uuid search_label serial sleep tpm udf usb usbserial_common usbserial_ftdi \
+                  usbserial_pl2303 usbserial_usbdebug video xfs zstd)
++    if [[ "$arch" == 'aarch64' ]]; then
++        local module
++        local -a available_grubmodules=()
++        local -a required_grubmodules=(configfile iso9660 linux normal search search_fs_uuid)
++        for module in "${required_grubmodules[@]}"; do
++            if [[ ! -e "/usr/lib/grub/${grub_target}/${module}.mod" ]]; then
++                _msg_error "Required ${grub_target} GRUB module is missing: ${module}" 1
++            fi
++        done
++        for module in "${grubmodules[@]}"; do
++            if [[ -e "/usr/lib/grub/${grub_target}/${module}.mod" ]]; then
++                available_grubmodules+=("${module}")
++            fi
++        done
++        grubmodules=("${available_grubmodules[@]}")
++    fi
+     grub-mkstandalone -O "$grub_target" \
+         --modules="${grubmodules[*]}" \
+         --locales="en@quot" \
+@@ -699,8 +721,10 @@
+         --disable-shim-lock \
+         -o "${work_dir}/BOOT${uefi_arch[$arch]}.EFI" "boot/grub/grub.cfg=${work_dir}/grub-embed.cfg"
+     # Add GRUB to the list of files used to calculate the required FAT image size.
+-    efiboot_files+=("${work_dir}/BOOT${uefi_arch[$arch]}.EFI"
+-                    "${pacstrap_dir}/usr/share/edk2-shell/${uefi_arch[$arch],,}/Shell_Full.efi")
++    efiboot_files+=("${work_dir}/BOOT${uefi_arch[$arch]}.EFI")
++    if [[ -e "${pacstrap_dir}/usr/share/edk2-shell/${uefi_arch[$arch],,}/Shell_Full.efi" ]]; then
++        efiboot_files+=("${pacstrap_dir}/usr/share/edk2-shell/${uefi_arch[$arch],,}/Shell_Full.efi")
++    fi
+ 
+     # Create IA32 EFI binary for mixed-mode booting on x86_64 systems with IA32 UEFI
+     if [[ "$arch" == 'x86_64' ]]; then

--- a/builder/architecture.sh
+++ b/builder/architecture.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+# Architecture and media-target selection for the ISO build. Sourced by
+# build-iso.sh (inside the container) and by the unit tests (on the host), so
+# it only sets variables and defines functions; the caller decides what to do.
+#
+# Two targets exist: x86_64/pc (the ISO shipped today) and aarch64/generic
+# (vanilla UEFI + ACPI ARM64: Ampere, Graviton, Snapdragon X, dev kits).
+# Apple Silicon and U-Boot SBCs are out of scope — see plans/aarch64-support.md.
+
+source "${BASH_SOURCE[0]%/*}/package-architecture.sh"
+
+OMARCHY_ARCH=${OMARCHY_ARCH:-x86_64}
+OMARCHY_MIRROR=${OMARCHY_MIRROR:-stable}
+# build-iso.sh selects the settings package before sourcing this; the default
+# only serves callers (tests) that source the selection on its own.
+OMARCHY_SETTINGS_PACKAGE=${OMARCHY_SETTINGS_PACKAGE:-omarchy-settings}
+if [[ -z ${OMARCHY_MEDIA_TARGET:-} ]]; then
+  if [[ $OMARCHY_ARCH == "x86_64" ]]; then
+    OMARCHY_MEDIA_TARGET=x86_64/pc
+  else
+    OMARCHY_MEDIA_TARGET=aarch64/generic
+  fi
+fi
+
+case "$OMARCHY_ARCH:$OMARCHY_MEDIA_TARGET" in
+  x86_64:x86_64/pc)
+    OMARCHY_PLATFORM=pc
+    ;;
+  aarch64:aarch64/generic)
+    OMARCHY_PLATFORM=generic
+    ;;
+  *)
+    echo "Unsupported architecture/media target: $OMARCHY_ARCH:$OMARCHY_MEDIA_TARGET" >&2
+    echo "Supported targets: x86_64/pc, aarch64/generic" >&2
+    return 1 2>/dev/null || exit 1
+    ;;
+esac
+# Both targets install Limine on the target; the live ISO boots via GRUB on
+# both (plus syslinux for BIOS on x86_64, see profiledef.sh).
+OMARCHY_BOOT_BACKEND=limine
+export OMARCHY_ARCH OMARCHY_MEDIA_TARGET OMARCHY_PLATFORM OMARCHY_BOOT_BACKEND
+
+configure_package_architecture
+
+case "$OMARCHY_ARCH" in
+  x86_64)
+    LIVE_KERNEL=linux-t2
+    LIVE_KERNEL_BOOT_NAME=vmlinuz-linux-t2
+    LIVE_INITRAMFS_BOOT_NAME=initramfs-linux-t2.img
+    MKARCHISO=(mkarchiso)
+    ;;
+  aarch64)
+    # ALARM kernels install /boot/Image rather than vmlinuz-*, and their
+    # presets name the initramfs initramfs-linux.img regardless of pkgbase.
+    LIVE_KERNEL=linux-aarch64
+    LIVE_KERNEL_BOOT_NAME=Image
+    LIVE_INITRAMFS_BOOT_NAME=initramfs-linux.img
+    # A copy of the submodule's mkarchiso with archiso-aarch64.patch applied;
+    # build-iso.sh creates it. ALARM ships no archiso package.
+    MKARCHISO=(/tmp/omarchy-mkarchiso-aarch64)
+    ;;
+esac
+export LIVE_KERNEL LIVE_KERNEL_BOOT_NAME LIVE_INITRAMFS_BOOT_NAME
+
+# Adjust the seeded archiso profile (releng + configs/) for the selected
+# architecture, after both have been copied into $profile. x86_64 is left
+# untouched so the shipped ISO cannot change under this refactor.
+prepare_media_profile() {
+  local profile=$1
+  local archiso_config="$profile/airootfs/etc/mkinitcpio.conf.d/archiso.conf"
+  local grub_config="$profile/grub/grub.cfg"
+  local loopback_config="$profile/grub/loopback.cfg"
+
+  [[ $OMARCHY_ARCH == aarch64 ]] || return 0
+
+  prepare_package_profile "$profile"
+
+  # The preset filename is the pkgbase, and that is load-bearing (see the
+  # comment in airootfs/etc/mkinitcpio.d/linux-t2.preset). Neither releng's
+  # linux.preset nor our linux-t2.preset matches the linux-aarch64 package.
+  # Unlike Arch's kernels, ALARM's linux-aarch64 ships its own preset, and
+  # pacman refuses a file the profile put there first (NoExtract does not
+  # help: the conflict check runs before it). So the package's preset stays,
+  # ours go, and the live initramfs is shaped through the config instead --
+  # see the drop-in below.
+  rm -f \
+    "$profile/airootfs/etc/mkinitcpio.d/linux.preset" \
+    "$profile/airootfs/etc/mkinitcpio.d/linux-t2.preset"
+
+  # No CPU microcode on ARM, and archiso's memdisk hook is x86 PXE plumbing.
+  sed -i.bak -e 's/ microcode / /' -e 's/ memdisk / /' "$archiso_config"
+  rm -f -- "$archiso_config.bak"
+
+  # ALARM's preset builds /boot/initramfs-linux.img from the default config,
+  # which is /etc/mkinitcpio.conf plus every /etc/mkinitcpio.conf.d/*.conf in
+  # name order, last HOOKS= wins. The x86 presets sidestep that by pinning
+  # archiso.conf as the config; here omarchy-settings' omarchy_hooks.conf
+  # sorts after archiso.conf and would replace the live-boot hooks with the
+  # installed-system ones (autodetect then fails in the chroot and the ISO
+  # drops to an emergency shell). Re-assert archiso's config from a name that
+  # sorts last.
+  # omarchy-settings' thunderbolt_module.conf also forces MODULES=(thunderbolt),
+  # which the generic ARM kernel does not build, and mkinitcpio treats a
+  # missing forced module as an error. The live image needs no forced modules.
+  {
+    cat "$archiso_config"
+    echo
+    echo "# Reset any module list a package drop-in forced; the live initramfs"
+    echo "# relies on hooks alone."
+    echo "MODULES=()"
+  } >"$profile/airootfs/etc/mkinitcpio.conf.d/zz-archiso-live.conf"
+
+  # The GRUB menu entries name the x86 live kernel; point them at ALARM's.
+  # %ARCH% and the x86-only memtest/shell fragments are handled by mkarchiso
+  # and grub_cpu guards respectively, so nothing else in the files changes.
+  sed -i.bak \
+    -e "s/vmlinuz-linux-t2/$LIVE_KERNEL_BOOT_NAME/g" \
+    -e "s/initramfs-linux-t2\\.img/$LIVE_INITRAMFS_BOOT_NAME/g" \
+    "$grub_config" "$loopback_config"
+  rm -f -- "$grub_config.bak" "$loopback_config.bak"
+}
+
+# Produce the mkarchiso this build runs. On aarch64 that is the submodule's
+# script with archiso-aarch64.patch applied (kernel named Image, no edk2-shell
+# in the EFI image, only the GRUB modules the arm64-efi target actually ships).
+prepare_mkarchiso() {
+  [[ $OMARCHY_ARCH == aarch64 ]] || return 0
+  cp /archiso/archiso/mkarchiso "${MKARCHISO[0]}"
+  patch --forward --silent "${MKARCHISO[0]}" /builder/archiso-aarch64.patch
+  chmod +x "${MKARCHISO[0]}"
+}

--- a/builder/build-iso.sh
+++ b/builder/build-iso.sh
@@ -23,14 +23,37 @@ esac
 : "${OMARCHY_NVIM_PACKAGE:=omarchy-nvim}"
 export OMARCHY_RUNTIME_PACKAGE OMARCHY_SETTINGS_PACKAGE OMARCHY_NVIM_PACKAGE
 
+# Everything that differs between x86_64 and aarch64 (keyring, package lists,
+# online pacman config, live kernel, mkarchiso) is selected there; this script
+# stays one linear x86_64 build with the arch read from those variables.
+OMARCHY_ARCH="${OMARCHY_ARCH:-x86_64}"
+source /builder/architecture.sh
+
+# pacman 7 runs its downloads behind a Landlock sandbox and refuses to sync
+# at all when the kernel has no Landlock. Docker Desktop's kernel is one such
+# kernel, so a build on a macOS host died at the first -Sy. Detect it once and
+# disable the sandbox for this build container only: the online config is
+# copied with the option added, and the offline config gets it only after the
+# ISO's own copy has been taken, so nothing shipped on the media changes.
+PACMAN_SANDBOX_DISABLED=""
+if ! grep -qw landlock /sys/kernel/security/lsm 2>/dev/null; then
+  echo "Kernel has no Landlock; disabling pacman's download sandbox for the build container" >&2
+  PACMAN_SANDBOX_DISABLED=1
+  sed -i '/^\[options\]/a DisableSandbox' /etc/pacman.conf
+  sandboxless_online_config="/tmp/$(basename "$PACMAN_ONLINE_CONFIG")"
+  sed '/^\[options\]/a DisableSandbox' "$PACMAN_ONLINE_CONFIG" >"$sandboxless_online_config"
+  PACMAN_ONLINE_CONFIG="$sandboxless_online_config"
+fi
+
 # Packages installed into the Arch container used to build the ISO.
 pacman-key --init
-pacman --noconfirm -Sy archlinux-keyring
+pacman --noconfirm -Sy "$DISTRO_KEYRING_PACKAGE"
+pacman-key --populate "$DISTRO_KEYRING_NAME"
 # Full upgrade, not just -Sy: docker never re-pulls :latest once it's cached,
 # so this container can be months behind the mirror it installs from. A plain
 # -Sy install is then a partial upgrade — new packages linked against a glibc
 # the container doesn't have yet.
-pacman --noconfirm -Syu archiso git sudo base-devel jq grub imagemagick neovim nodejs npm tree-sitter-cli
+pacman --noconfirm -Syu "${BUILD_HOST_PACKAGES[@]}"
 
 # Pre-import the omarchy signing key (so pacman trusts our [omarchy] repo
 # during the build without keyserver lookups).
@@ -38,20 +61,24 @@ pacman-key --add /builder/omarchy.gpg
 pacman-key --lsign-key 40DFB630FF42BCFFB047046CF0134EE680CAC571
 
 # omarchy-keyring is needed inside the offline mirror too.
-pacman --config /configs/pacman-online-${OMARCHY_MIRROR}.conf --noconfirm -Sy omarchy-keyring
+pacman --config "$PACMAN_ONLINE_CONFIG" --noconfirm -Sy omarchy-keyring
 pacman-key --populate omarchy
 
 # Append the [omarchy] repo to the container's /etc/pacman.conf so subsequent
 # tools (notably makepkg in build-omarchy-packages.sh) can resolve omarchy-
 # only build deps like limine-snapper-sync and limine-mkinitcpio-hook.
 if ! grep -q '^\[omarchy\]' /etc/pacman.conf; then
-  awk '/^\[omarchy\]/,/^$/' /configs/pacman-online-${OMARCHY_MIRROR}.conf >> /etc/pacman.conf
+  awk '/^\[omarchy\]/,/^$/' "$PACMAN_ONLINE_CONFIG" >> /etc/pacman.conf
 fi
 
 # Build locations
 build_cache_dir=/var/cache
 offline_mirror_dir="$build_cache_dir/airootfs/var/cache/omarchy/mirror/offline"
 mkdir -p "$build_cache_dir" "$offline_mirror_dir"
+
+# aarch64 runs the submodule's mkarchiso with builder/archiso-aarch64.patch
+# applied; x86_64 keeps the packaged one. No-op on x86_64.
+prepare_mkarchiso
 
 # Seed from the official Arch releng profile.
 cp -r /archiso/configs/releng/* "$build_cache_dir/"
@@ -64,6 +91,17 @@ rm -rf "$build_cache_dir/airootfs/etc/xdg/reflector"
 
 # Bring in our archiso profile additions.
 cp -r /configs/* "$build_cache_dir/"
+# The profile copy of the offline config is what this build resolves and
+# pacstraps with; see the Landlock note above. The ISO's own copy is taken
+# from it below with the option stripped again.
+if [[ -n $PACMAN_SANDBOX_DISABLED ]]; then
+  sed -i '/^\[options\]/a DisableSandbox' "$build_cache_dir/pacman-offline.conf"
+fi
+
+# releng and configs/ are written for x86_64; on aarch64 rename the package
+# list, swap the live kernel preset, and point GRUB at ALARM's kernel names.
+# No-op on x86_64.
+prepare_media_profile "$build_cache_dir"
 mkdir -p "$build_cache_dir/airootfs/usr/share/omarchy-iso"
 echo "$OMARCHY_MIRROR" > "$build_cache_dir/airootfs/root/omarchy_mirror"
 echo "$OMARCHY_ISO_REF" > "$build_cache_dir/airootfs/root/omarchy_iso_ref"
@@ -80,6 +118,8 @@ if [[ ${OMARCHY_INSTALL_DEBUG:-} == "1" ]]; then
     echo "built_at=$(date -Is)"
     echo "ref=$OMARCHY_ISO_REF"
     echo "mirror=$OMARCHY_MIRROR"
+    echo "arch=$OMARCHY_ARCH"
+    echo "media_target=$OMARCHY_MEDIA_TARGET"
     echo "runtime_package=$OMARCHY_RUNTIME_PACKAGE"
     echo "settings_package=$OMARCHY_SETTINGS_PACKAGE"
     echo "nvim_package=$OMARCHY_NVIM_PACKAGE"
@@ -107,21 +147,20 @@ fi
 # Node.js binary for offline mise install.
 NODE_DIST_URL="https://nodejs.org/dist/latest"
 NODE_SHASUMS=$(curl -fsSL "$NODE_DIST_URL/SHASUMS256.txt")
-NODE_FILENAME=$(echo "$NODE_SHASUMS" | grep "linux-x64.tar.gz" | awk '{print $2}')
-NODE_SHA=$(echo "$NODE_SHASUMS" | grep "linux-x64.tar.gz" | awk '{print $1}')
+NODE_FILENAME=$(echo "$NODE_SHASUMS" | grep "linux-$NODE_DIST_ARCH.tar.gz" | awk '{print $2}')
+NODE_SHA=$(echo "$NODE_SHASUMS" | grep "linux-$NODE_DIST_ARCH.tar.gz" | awk '{print $1}')
 curl -fsSL "$NODE_DIST_URL/$NODE_FILENAME" -o "/tmp/$NODE_FILENAME"
 echo "$NODE_SHA /tmp/$NODE_FILENAME" | sha256sum -c -
 mkdir -p "$build_cache_dir/airootfs/opt/packages/"
 cp "/tmp/$NODE_FILENAME" "$build_cache_dir/airootfs/opt/packages/"
 
 # Packages installed into the live ISO environment itself (NOT the target system).
-# The selected omarchy-settings package is needed here so its post_install hook
-# drops Omarchy's plymouthd.conf into /etc/plymouth before mkarchiso builds the
-# live initramfs.
-arch_packages=(linux-t2 git gum jq openssl plymouth ttfx tzupdate omarchy-keyring "$OMARCHY_SETTINGS_PACKAGE" lvm2 cryptsetup parted)
-printf '%s\n' "${arch_packages[@]}" >> "$build_cache_dir/packages.x86_64"
+# LIVE_PACKAGES is per-arch (builder/package-architecture.sh); the selected
+# omarchy-settings package is in it so its post_install hook drops Omarchy's
+# plymouthd.conf into /etc/plymouth before mkarchiso builds the live initramfs.
+printf '%s\n' "${LIVE_PACKAGES[@]}" >> "$build_cache_dir/$PROFILE_PACKAGES"
 
-# The live ISO boots linux-t2 (see airootfs/etc/mkinitcpio.d/linux-t2.preset), so
+# The x86_64 live ISO boots linux-t2 (see airootfs/etc/mkinitcpio.d/linux-t2.preset), so
 # stock linux is a second kernel nobody boots: ~147MB of ISO, plus its own archiso
 # initramfs, copied into both the ISO tree and the size-constrained FAT EFI image.
 #
@@ -131,8 +170,11 @@ printf '%s\n' "${arch_packages[@]}" >> "$build_cache_dir/packages.x86_64"
 # kernel we boot, so it has done nothing since we started booting T2 anyway. The
 # install is entirely offline and the live environment needs no Wi-Fi driver.
 #
-# Anchored so linux-t2 and linux-firmware are untouched.
-sed -i -E '/^(linux|broadcom-wl)$/d' "$build_cache_dir/packages.x86_64"
+# Anchored so linux-t2 and linux-firmware are untouched. On aarch64 both
+# entries were already pruned with the rest of releng's x86-only list.
+if [[ $OMARCHY_ARCH == x86_64 ]]; then
+  sed -i -E '/^(linux|broadcom-wl)$/d' "$build_cache_dir/packages.x86_64"
+fi
 
 # Build the offline mirror: everything pacstrap might want during the target
 # install. With --local-source, the omarchy* packages we just built are
@@ -147,7 +189,7 @@ else
   bootstrap_cache_dir=/tmp/omarchy-pkg-bootstrap
   rm -rf "$bootstrap_cache_dir" /tmp/offlinedb-bootstrap /tmp/omarchy-pkglists
   mkdir -p "$bootstrap_cache_dir" /tmp/offlinedb-bootstrap
-  pacman --config /configs/pacman-online-${OMARCHY_MIRROR}.conf --noconfirm -Syw "$OMARCHY_RUNTIME_PACKAGE" --cachedir "$bootstrap_cache_dir" --dbpath /tmp/offlinedb-bootstrap >/dev/null
+  pacman --config "$PACMAN_ONLINE_CONFIG" --noconfirm -Syw "$OMARCHY_RUNTIME_PACKAGE" --cachedir "$bootstrap_cache_dir" --dbpath /tmp/offlinedb-bootstrap >/dev/null
   omarchy_pkg=$(find "$bootstrap_cache_dir" -maxdepth 1 -type f -name "$OMARCHY_RUNTIME_PACKAGE-*.pkg.tar.zst" | sort | head -1)
   if [[ -z $omarchy_pkg ]]; then
     echo "ERROR: downloaded package for $OMARCHY_RUNTIME_PACKAGE not found in $bootstrap_cache_dir" >&2
@@ -164,9 +206,29 @@ else
   setup_form=/tmp/omarchy-pkglists/usr/share/omarchy/install/provisioning/setup-form.sh
 fi
 
+# The shipped copies are what the installer reads at install time. They are
+# filtered for the architecture (identity on x86_64; on aarch64 no microcode,
+# linux -> linux-aarch64), and from here on they are also the lists this
+# build resolves against, so the mirror and the installer cannot disagree.
 mkdir -p "$build_cache_dir/airootfs/usr/share/omarchy-iso"
-cp "${base_pkg_lists[0]}" "$build_cache_dir/airootfs/usr/share/omarchy-iso/omarchy-base.packages"
-cp "${base_pkg_lists[1]}" "$build_cache_dir/airootfs/usr/share/omarchy-iso/omarchy-other.packages"
+shipped_base_packages="$build_cache_dir/airootfs/usr/share/omarchy-iso/omarchy-base.packages"
+shipped_other_packages="$build_cache_dir/airootfs/usr/share/omarchy-iso/omarchy-other.packages"
+filter_target_packages <"${base_pkg_lists[0]}" >"$shipped_base_packages"
+filter_target_packages <"${base_pkg_lists[1]}" >"$shipped_other_packages"
+# The installed system needs ALARM's keyring to keep trusting its mirrors,
+# the same way archlinux-keyring rides along in the x86_64 base list.
+if [[ $OMARCHY_ARCH == aarch64 ]] && ! grep -Fxq archlinuxarm-keyring "$shipped_base_packages"; then
+  printf '%s\n' archlinuxarm-keyring >>"$shipped_base_packages"
+fi
+base_pkg_lists=("$shipped_base_packages" "$shipped_other_packages")
+
+# archinstall.packages lists both microcode packages so the mirror carries
+# either; neither exists for ARM, and the kernel name differs there.
+archinstall_package_list=/builder/archinstall.packages
+if [[ $OMARCHY_ARCH == aarch64 ]]; then
+  archinstall_package_list=/tmp/archinstall.packages.aarch64
+  filter_target_packages </builder/archinstall.packages >"$archinstall_package_list"
+fi
 
 # The configurator's setup form comes from the runtime this ISO bundles, so the
 # installer and the first-boot setup that finishes a deferred install can never
@@ -191,9 +253,9 @@ cp "$setup_form" "$build_cache_dir/airootfs/usr/share/omarchy-iso/setup-form.sh"
 declare -a all_packages
 mapfile -t all_packages < <(
   {
-    cat "$build_cache_dir/packages.x86_64"
+    cat "$build_cache_dir/$PROFILE_PACKAGES"
     grep -hv '^#\|^$' "${base_pkg_lists[@]}"
-    grep -hv '^#\|^$' /builder/archinstall.packages
+    grep -hv '^#\|^$' "$archinstall_package_list"
     # Always include the selected Omarchy packages so the target install can
     # find the runtime and companion packages in the offline mirror.
     printf '%s\n' "$OMARCHY_RUNTIME_PACKAGE" "$OMARCHY_SETTINGS_PACKAGE" "$OMARCHY_NVIM_PACKAGE"
@@ -215,7 +277,7 @@ fi
 
 mkdir -p /tmp/offlinedb
 download_offline_packages() {
-  pacman --config /configs/pacman-online-${OMARCHY_MIRROR}.conf --noconfirm -Syw \
+  pacman --config "$PACMAN_ONLINE_CONFIG" --noconfirm -Syw \
     "${all_packages[@]}" --cachedir "$offline_mirror_dir/" --dbpath /tmp/offlinedb --needed
 }
 
@@ -233,7 +295,7 @@ fi
 # newest version of every cached package name) removes packages that have left
 # the lists or dependency closure, such as an old Electron major version.
 if ! resolved_package_files="$(
-  pacman --config "/configs/pacman-online-${OMARCHY_MIRROR}.conf" --noconfirm \
+  pacman --config "$PACMAN_ONLINE_CONFIG" --noconfirm \
     --dbpath /tmp/offlinedb -S --print --print-format '%f' "${all_packages[@]}"
 )"; then
   echo "ERROR: could not resolve the package files required by the offline mirror" >&2
@@ -272,7 +334,12 @@ printf '%s\n' "${required_package_files[@]}" |
 # Rebuild the offline repo db from scratch so size/checksum/depends entries
 # always reflect only the package files selected for this build.
 rm -f "$offline_mirror_dir"/offline.db* "$offline_mirror_dir"/offline.files*
-repo-add "$offline_mirror_dir/offline.db.tar.gz" "$offline_mirror_dir/"*.pkg.tar.zst
+# Arch packages are .pkg.tar.zst, Arch Linux ARM's are .pkg.tar.xz; match on
+# the archive, not the compressor, and keep detached signatures out.
+mapfile -t offline_package_files < <(
+  find "$offline_mirror_dir" -maxdepth 1 -type f -name '*.pkg.tar.*' ! -name '*.sig' | sort
+)
+repo-add "$offline_mirror_dir/offline.db.tar.gz" "${offline_package_files[@]}"
 
 # mkarchiso expects the mirror at /var/cache/omarchy/mirror/offline inside the
 # container (the airootfs path); symlink rather than duplicate.
@@ -299,7 +366,7 @@ resolve_expected_packages() {
 
   mapfile -t targets < <(
     {
-      grep -hv '^#\|^$' /builder/archinstall.packages
+      grep -hv '^#\|^$' "$archinstall_package_list"
       # Read the shipped copy, which is what _runtime_package_list reads at
       # install time, not the build-time source it came from.
       grep -hv '^#\|^$' \
@@ -344,10 +411,11 @@ else
 fi
 
 # Live ISO uses the same offline pacman.conf.
-cp "$build_cache_dir/pacman-offline.conf" "$build_cache_dir/airootfs/etc/pacman.conf"
+# Minus the build-only sandbox opt-out (Landlock note above).
+sed '/^DisableSandbox$/d' "$build_cache_dir/pacman-offline.conf" >"$build_cache_dir/airootfs/etc/pacman.conf"
 
 # Build the ISO.
-mkarchiso -v -w "$build_cache_dir/work/" -o /out/ "$build_cache_dir/"
+"${MKARCHISO[@]}" -v -w "$build_cache_dir/work/" -o /out/ "$build_cache_dir/"
 
 # Match host UID/GID on output.
 if [[ -n $HOST_UID && -n $HOST_GID ]]; then

--- a/builder/build-omarchy-packages.sh
+++ b/builder/build-omarchy-packages.sh
@@ -70,7 +70,8 @@ for pkg in "${packages[@]}"; do
 done
 
 mkdir -p "$offline_mirror_dir"
-for package_file in "$work_dir"/*.pkg.tar.zst; do
+for package_file in "$work_dir"/*.pkg.tar.zst "$work_dir"/*.pkg.tar.xz; do
+  [[ -e $package_file ]] || continue
   destination="$offline_mirror_dir/$(basename "$package_file")"
 
   # A cached signature belongs to the previously downloaded or locally built
@@ -82,4 +83,4 @@ done
 
 echo
 echo "Built Omarchy packages, placed in $offline_mirror_dir:"
-ls "$offline_mirror_dir"/omarchy*.pkg.tar.zst | sed 's|^|  |'
+ls "$offline_mirror_dir"/omarchy*.pkg.tar.zst "$offline_mirror_dir"/omarchy*.pkg.tar.xz 2>/dev/null | sed 's|^|  |'

--- a/builder/package-architecture.sh
+++ b/builder/package-architecture.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Package-only architecture selection: which keyring, which Node.js tarball,
+# which archiso package list, which packages the build container and the live
+# ISO need, and which online pacman config feeds the offline mirror. Sourced
+# by architecture.sh; kept separate so the package inventory of a build can
+# be reasoned about without the boot/profile side.
+
+configure_package_architecture() {
+  case "$OMARCHY_ARCH" in
+    x86_64)
+      DISTRO_KEYRING_PACKAGE=archlinux-keyring
+      DISTRO_KEYRING_NAME=archlinux
+      NODE_DIST_ARCH=x64
+      PROFILE_PACKAGES=packages.x86_64
+      PACMAN_ONLINE_CONFIG="/configs/pacman-online-${OMARCHY_MIRROR}.conf"
+      BUILD_HOST_PACKAGES=(
+        archiso git sudo base-devel jq grub imagemagick neovim nodejs npm tree-sitter-cli
+      )
+      # The selected omarchy-settings package is needed here so its
+      # post_install hook drops Omarchy's plymouthd.conf into /etc/plymouth
+      # before mkarchiso builds the live initramfs.
+      LIVE_PACKAGES=(
+        linux-t2 git gum jq openssl plymouth ttfx tzupdate omarchy-keyring
+        "$OMARCHY_SETTINGS_PACKAGE" lvm2 cryptsetup parted
+      )
+      ;;
+    aarch64)
+      # Arch Linux ARM is the aarch64 base distribution (see
+      # plans/aarch64-support.md, prerequisite 1): vanilla Arch has no
+      # core/os/aarch64, so the keyring, mirrors, and kernel all come from ALARM.
+      DISTRO_KEYRING_PACKAGE=archlinuxarm-keyring
+      DISTRO_KEYRING_NAME=archlinuxarm
+      NODE_DIST_ARCH=arm64
+      PROFILE_PACKAGES=packages.aarch64
+      PACMAN_ONLINE_CONFIG=/configs/pacman-online-arm.conf
+      # ALARM does not package archiso itself, so the build container gets
+      # mkarchiso's runtime dependencies and runs the submodule's copy instead.
+      BUILD_HOST_PACKAGES=(
+        arch-install-scripts dosfstools e2fsprogs findutils grub gzip libarchive
+        libisoburn mtools openssl pacman sed squashfs-tools git sudo base-devel jq
+        imagemagick neovim nodejs npm tree-sitter-cli
+      )
+      # No ttfx (x86-only package) and no tzupdate on ALARM; the configurator
+      # and dashboard skip the logo animation when ttfx is absent.
+      LIVE_PACKAGES=(
+        linux-aarch64 git gum jq openssl plymouth omarchy-keyring
+        "$OMARCHY_SETTINGS_PACKAGE" lvm2 cryptsetup parted
+      )
+      ;;
+    *)
+      echo "Unsupported OMARCHY_ARCH: $OMARCHY_ARCH" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Rewrite an Omarchy package list (stdin) for the selected architecture. On
+# x86_64 this is the identity. On aarch64, microcode does not exist, tzupdate
+# is not packaged by ALARM, and the kernel is linux-aarch64.
+filter_target_packages() {
+  local line excluded
+  declare -A excluded=()
+
+  # builder/packages.aarch64-exclude says what is dropped and why.
+  if [[ $OMARCHY_ARCH == aarch64 ]]; then
+    while IFS= read -r line || [[ -n $line ]]; do
+      [[ -z $line || $line == \#* ]] && continue
+      excluded["$line"]=1
+    done <"${BUILDER_ROOT:-/builder}/packages.aarch64-exclude"
+  fi
+
+  while IFS= read -r line || [[ -n $line ]]; do
+    if [[ $OMARCHY_ARCH == aarch64 ]]; then
+      [[ -n $line && -n ${excluded[$line]:-} ]] && continue
+      case "$line" in
+        linux)
+          line=linux-aarch64
+          ;;
+        linux-headers)
+          line=linux-aarch64-headers
+          ;;
+      esac
+    fi
+    printf '%s\n' "$line"
+  done
+}
+
+# The archiso releng profile ships only packages.x86_64. For aarch64, rename it
+# and prune the entries that are x86-only (microcode, BIOS/EFI shells,
+# memtest, syslinux, x86 guest tools) or replaced by ALARM's kernel (linux,
+# and broadcom-wl which is a prebuilt module for stock linux).
+prepare_package_profile() {
+  local profile=$1
+
+  [[ $OMARCHY_ARCH == aarch64 ]] || return 0
+  mv "$profile/packages.x86_64" "$profile/packages.aarch64"
+  sed -i.bak -E '/^(amd-ucode|broadcom-wl|edk2-shell|hyperv|intel-ucode|linux|memtest86\+|memtest86\+-efi|open-vm-tools|refind|reflector|syslinux|virtualbox-guest-utils-nox)$/d' \
+    "$profile/packages.aarch64"
+  rm -f -- "$profile/packages.aarch64.bak"
+}

--- a/builder/packages.aarch64-exclude
+++ b/builder/packages.aarch64-exclude
@@ -1,0 +1,50 @@
+# Packages in the shared lists that cannot be resolved for aarch64, dropped by
+# filter_target_packages (builder/package-architecture.sh) when building
+# aarch64 media. Two kinds live here; keep them apart so the second shrinks.
+#
+# x86-only hardware support. There is no ARM machine these apply to, so they
+# stay out for good.
+amd-ucode
+intel-ucode
+apple-bcm-firmware
+apple-t2-audio-config
+asdcontrol
+asusctl
+broadcom-wl
+dell-xps-touchpad-haptics
+intel-ipu7-camera
+intel-lpmd
+intel-media-driver
+lib32-nvidia-580xx-utils
+lib32-nvidia-utils
+libva-intel-driver
+linux-ptl
+linux-ptl-headers
+linux-t2
+linux-t2-headers
+macbook12-spi-driver-dkms
+nvidia-580xx-dkms
+nvidia-580xx-utils
+qemu-user-static-binfmt
+t2fanrd
+thermald
+tuxedo-drivers-nocompatcheck-dkms
+vpl-gpu-rt
+yt6801-dkms
+#
+# Not built for aarch64 yet. Omarchy's own packages here need an aarch64 build
+# in omarchy-pkgs; the rest are absent from Arch Linux ARM's repositories.
+# Remove an entry once the package resolves on aarch64.
+dotnet-runtime
+herdr
+hyprland-preview-share-picker
+mise-bin
+obsidian
+obs-studio
+omacalc
+pinta
+qmk-hid
+tensaku
+ttfx
+tzupdate
+yay-debug

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -7,6 +7,14 @@ OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
 OMARCHY_RUNTIME_PACKAGE="${OMARCHY_RUNTIME_PACKAGE:-omarchy}"
 OMARCHY_SETTINGS_PACKAGE="${OMARCHY_SETTINGS_PACKAGE:-omarchy-settings}"
 
+# Limine ships one EFI binary per architecture; the archinstall JSON below
+# names the one to install on the ESP, so read the running machine's.
+case "$(uname -m)" in
+  aarch64|arm64) LIMINE_EFI_BINARY=limine_aa64.efi ;;
+  x86_64) LIMINE_EFI_BINARY=limine_x64.efi ;;
+  *) echo "ERROR: unsupported Limine EFI architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
 LOGO_PATH="$OMARCHY_PATH/logo.txt"
 
 # The setup form — keyboard, account, hostname, and timezone questions, plus the
@@ -149,24 +157,32 @@ greeter() {
   # Two columns narrower than the console: ttfx centers its text two columns
   # right of plain centering, so a full-width canvas would sit the animated
   # logo a column off the gum-drawn one underneath it.
-  ttfx -i "$LOGO_PATH" \
-    --canvas-width "$((cols > 2 ? cols - 2 : cols))" \
-    --anchor-text c \
-    --frame-rate 60 \
-    --reuse-canvas \
-    --xterm-colors \
-    colorshift \
-    --gradient-stops 2 10 6 10 \
-    --gradient-frames 3 \
-    --cycles 1000 \
-    --final-gradient-stops 2 \
-    </dev/null >/dev/tty 2>/dev/null &
-  anim=$!
+  #
+  # ttfx is not packaged for every architecture the ISO builds for (no ALARM
+  # build), so without it the static logo above simply stays put.
+  anim=""
+  if command -v ttfx >/dev/null; then
+    ttfx -i "$LOGO_PATH" \
+      --canvas-width "$((cols > 2 ? cols - 2 : cols))" \
+      --anchor-text c \
+      --frame-rate 60 \
+      --reuse-canvas \
+      --xterm-colors \
+      colorshift \
+      --gradient-stops 2 10 6 10 \
+      --gradient-frames 3 \
+      --cycles 1000 \
+      --final-gradient-stops 2 \
+      </dev/null >/dev/tty 2>/dev/null &
+    anim=$!
+  fi
 
   IFS= read -r _ </dev/tty || true
   # Tolerate ttfx's kill signal in `wait` so a future `set -e` here can't abort.
-  kill "$anim" 2>/dev/null
-  wait "$anim" 2>/dev/null || true
+  if [[ -n $anim ]]; then
+    kill "$anim" 2>/dev/null
+    wait "$anim" 2>/dev/null || true
+  fi
   # ttfx leaves the tty in raw/no-echo mode when killed; restore it or the gum
   # prompts in the keyboard step that follows silently die.
   stty sane </dev/tty 2>/dev/null || true
@@ -412,7 +428,10 @@ to_gb() {
 
 # T2 Macs need their own kernel for keyboard/wifi drivers.
 detect_kernel() {
-  if lspci -nn 2>/dev/null | grep -q "106b:180[12]"; then
+  # ALARM's generic kernel package is linux-aarch64; there is no plain linux.
+  if [[ $(uname -m) == "aarch64" ]]; then
+    echo "linux-aarch64"
+  elif lspci -nn 2>/dev/null | grep -q "106b:180[12]"; then
     echo "linux-t2"
   else
     echo "linux"
@@ -805,7 +824,7 @@ run_partition_execute() {
         "boot": {
             "esp_mount": "$esp_mount_in_target",
             "esp_path": "/EFI/limine",
-            "efi_binary": "limine_x64.efi",
+            "efi_binary": "$LIMINE_EFI_BINARY",
             "enable_fallback": false
         },
         "storage": {
@@ -1144,7 +1163,7 @@ cat <<-_EOF_ >user_configuration.json
         "boot": {
             "esp_mount": "/boot",
             "esp_path": "/EFI/limine",
-            "efi_binary": "limine_x64.efi",
+            "efi_binary": "$LIMINE_EFI_BINARY",
             "enable_fallback": true
         },
         "storage": {

--- a/configs/airootfs/usr/local/bin/omarchy-install-dashboard
+++ b/configs/airootfs/usr/local/bin/omarchy-install-dashboard
@@ -515,7 +515,9 @@ render_finish() {
     blank_line
   } >"$TTY_PATH"
 
-  if [[ -f $LOGO_PATH ]]; then
+  # ttfx is not packaged for every architecture (no ALARM build); the static
+  # logo drawn above stands in for the effect there.
+  if [[ -f $LOGO_PATH ]] && command -v ttfx >/dev/null; then
     # Reuse mode restores a saved cursor before moving up over its input. Save
     # this anchor so the effect redraws the same logo rows shown above.
     printf '%s%d;1H\0337' "$CSI" "$((FINISH_TOP_ROW + LOGO_HEIGHT))" >"$TTY_PATH"

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/context.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/context.py
@@ -184,7 +184,8 @@ def _default_omarchy_install(user_configuration: dict) -> dict[str, Any]:
         "boot": {
             "esp_mount": "/boot",
             "esp_path": "/EFI/limine",
-            "efi_binary": "limine_x64.efi",
+            # No efi_binary: phases_impl derives the per-architecture Limine
+            # name (limine_x64.efi / limine_aa64.efi) from the running machine.
             "enable_fallback": mode == "full_disk",
         },
         "storage": {},

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/keyboard.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/keyboard.py
@@ -19,18 +19,14 @@ from .command import capture
 def configure_keyboard(target: Path, language: str) -> bool:
     """Write the console keymap into a mounted target without booting it.
 
-    Returns False for layouts localectl doesn't know, matching archinstall:
+    Returns False for layouts the installed kbd package doesn't know, matching archinstall:
     warn and keep the default. Every layout the configurator offers is known;
     the guard is for the kb_layout an autoinstall drive can name freely.
     """
     if not language.strip():
         return True
 
-    result = capture(["localectl", "--no-pager", "list-keymaps"])
-    if result.returncode != 0:
-        detail = result.stderr.strip() or "localectl returned an error"
-        raise RuntimeError(f"Unable to list keyboard layouts: {detail}")
-    if language.lower() not in {layout.lower() for layout in result.stdout.splitlines()}:
+    if language.casefold() not in _installed_keymaps(target):
         return False
 
     # systemd-firstboot --force rewrites vconsole.conf wholesale, dropping the
@@ -52,3 +48,32 @@ def configure_keyboard(target: Path, language: str) -> bool:
         vconsole_path.write_text(vconsole_path.read_text() + font + "\n")
 
     return True
+
+
+def _installed_keymaps(target: Path) -> set[str]:
+    """Return console keymap names from the mounted target's kbd package.
+
+    Host `localectl list-keymaps` talks to PID 1 and therefore fails in image
+    builders that are not booted with systemd. The target has already been
+    pacstrapped at this point, so its keymap files are the authoritative catalog
+    for the system being built and require no live service.
+    """
+    roots = (
+        target / "usr/share/kbd/keymaps",
+        target / "usr/lib/kbd/keymaps",
+    )
+    existing_roots = [root for root in roots if root.is_dir()]
+    if not existing_roots:
+        raise RuntimeError("Unable to list keyboard layouts: target kbd keymaps are missing")
+
+    layouts: set[str] = set()
+    for root in existing_roots:
+        for path in root.rglob("*.map*"):
+            name = path.name
+            for suffix in (".gz", ".bz2", ".xz", ".zst"):
+                if name.endswith(suffix):
+                    name = name[: -len(suffix)]
+                    break
+            if name.endswith(".map"):
+                layouts.add(name[:-4].casefold())
+    return layouts

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -387,7 +387,7 @@ def _install_pre_mounted_limine(ctx: InstallContext) -> None:
         disk=Path(disk),
         part=part,
         esp_path=boot.get("esp_path", "/EFI/limine"),
-        efi_binary=boot.get("efi_binary", "limine_x64.efi"),
+        efi_binary=boot.get("efi_binary", _limine_efi_names()[1]),
         pre_state=pre_state,
     )
 
@@ -395,6 +395,20 @@ def _install_pre_mounted_limine(ctx: InstallContext) -> None:
     windows_after = _find_label_entries(post_state["entries"], "Windows")
     if windows_before and not windows_after:
         raise RuntimeError("Windows boot entry disappeared during Limine install — aborting")
+
+
+def _limine_efi_names(machine: str | None = None) -> tuple[str, str, str]:
+    """Limine's (shipped binary, installed name, removable-media name) for a machine.
+
+    Limine ships BOOTX64.EFI and BOOTAA64.EFI under /usr/share/limine; the
+    installed name is the one the configurator's JSON and the pacman hook use.
+    """
+    machine = (machine or os.uname().machine).lower()
+    if machine in {"aarch64", "arm64"}:
+        return "BOOTAA64.EFI", "limine_aa64.efi", "BOOTAA64.EFI"
+    if machine == "x86_64":
+        return "BOOTX64.EFI", "limine_x64.efi", "BOOTX64.EFI"
+    raise RuntimeError(f"Unsupported Limine EFI architecture: {machine}")
 
 
 def _install_limine_efi(
@@ -405,15 +419,17 @@ def _install_limine_efi(
     part: int,
     removable: bool = False,
     esp_path: str = "/EFI/limine",
-    efi_binary: str = "limine_x64.efi",
+    efi_binary: str | None = None,
     pre_state: dict | None = None,
 ) -> None:
+    source_name, default_binary, removable_binary = _limine_efi_names()
+    if efi_binary is None:
+        efi_binary = default_binary
     if removable:
         esp_path = "/EFI/BOOT"
-        efi_binary = "BOOTX64.EFI"
+        efi_binary = removable_binary
 
     limine_path = ctx.target / "usr" / "share" / "limine"
-    source_name = "BOOTX64.EFI"
     target_dir = Path(esp_mount) / esp_path.lstrip("/")
     target_path = target_dir / efi_binary
     _copy_required(limine_path / source_name, ctx.target / target_path.relative_to("/"))
@@ -755,7 +771,7 @@ def _boot_intent(ctx: InstallContext) -> dict:
     boot = dict(ctx.omarchy_install.get("boot") or {})
     boot.setdefault("esp_mount", "/boot")
     boot.setdefault("esp_path", "/EFI/limine")
-    boot.setdefault("efi_binary", "limine_x64.efi")
+    boot.setdefault("efi_binary", _limine_efi_names()[1])
     boot.setdefault("enable_fallback", not ctx.is_protected)
     return boot
 
@@ -1669,7 +1685,7 @@ def validate_boot(ctx: InstallContext) -> None:
     kernel = storage.get("kernel") or (ctx.user_configuration.get("kernels") or ["linux"])[0]
 
     if arch.has_uefi():
-        limine_binary = esp_mount / boot.get("esp_path", "/EFI/limine").lstrip("/") / boot.get("efi_binary", "limine_x64.efi")
+        limine_binary = esp_mount / boot.get("esp_path", "/EFI/limine").lstrip("/") / boot.get("efi_binary", _limine_efi_names()[1])
         if not limine_binary.exists() or limine_binary.stat().st_size == 0:
             raise RuntimeError(f"{limine_binary} missing or empty")
 

--- a/configs/pacman-online-arm.conf
+++ b/configs/pacman-online-arm.conf
@@ -1,0 +1,46 @@
+#
+# pacman.conf used inside the aarch64 build container to fill the offline
+# mirror. Arch Linux ARM is the base distribution: vanilla Arch mirrors carry
+# no core/os/aarch64, so core/extra/alarm/aur all come from ALARM mirrors
+# (see plans/aarch64-support.md, hard prerequisite 1).
+#
+# See the pacman.conf(5) manpage for option and repository directives
+
+[options]
+HoldPkg     = pacman glibc
+Architecture = aarch64
+ParallelDownloads = 5
+
+# By default, pacman accepts packages signed by keys that its local keyring
+# trusts (see pacman-key and its man page), as well as unsigned packages.
+SigLevel    = Required DatabaseOptional
+LocalFileSigLevel = Optional
+
+[core]
+Server = https://ca.us.mirror.archlinuxarm.org/$arch/$repo
+Server = https://fl.us.mirror.archlinuxarm.org/$arch/$repo
+
+[extra]
+Server = https://ca.us.mirror.archlinuxarm.org/$arch/$repo
+Server = https://fl.us.mirror.archlinuxarm.org/$arch/$repo
+
+[alarm]
+Server = https://ca.us.mirror.archlinuxarm.org/$arch/$repo
+Server = https://fl.us.mirror.archlinuxarm.org/$arch/$repo
+
+[aur]
+Server = https://ca.us.mirror.archlinuxarm.org/$arch/$repo
+Server = https://fl.us.mirror.archlinuxarm.org/$arch/$repo
+
+# The Omarchy packages (omarchy, omarchy-settings, omarchy-nvim, omarchy-keyring
+# and the Limine integration) resolve from here. pkgs.omarchy.org serves no
+# aarch64 tree yet — https://pkgs.omarchy.org/stable/aarch64/ is a 404 — so an
+# aarch64 build stops at the first omarchy-keyring download until omarchy-pkgs
+# publishes one (omacom/omarchy-pkgs#277, omarchy-iso issue #199). The section
+# is kept live rather than commented out so that build fails loudly on the
+# missing repo instead of silently building an ISO without Omarchy.
+#
+# No [arch-mact2]: the T2 Mac repo is x86-only by definition.
+[omarchy]
+SigLevel = Optional TrustAll
+Server = https://pkgs.omarchy.org/stable/$arch

--- a/configs/profiledef.sh
+++ b/configs/profiledef.sh
@@ -8,8 +8,15 @@ iso_application="Omarchy Installer"
 iso_version="$(date --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y.%m.%d)"
 install_dir="arch"
 buildmodes=('iso')
-bootmodes=('bios.syslinux' 'uefi.grub')
-arch="x86_64"
+# OMARCHY_ARCH is exported by builder/architecture.sh; mkarchiso sources this
+# file with bash, so reading the environment here keeps one profile for both.
+arch="${OMARCHY_ARCH:-x86_64}"
+case "$arch" in
+  # BIOS boot is x86-only; ARM64 firmware is UEFI without exception.
+  x86_64) bootmodes=('bios.syslinux' 'uefi.grub') ;;
+  aarch64) bootmodes=('uefi.grub') ;;
+  *) echo "Unsupported architecture: $arch" >&2; return 1 ;;
+esac
 pacman_conf="pacman-offline.conf"
 airootfs_image_type="squashfs"
 # Package archives in the offline mirror are already zstd-compressed. Storing
@@ -22,12 +29,26 @@ airootfs_image_type="squashfs"
 # cold on every boot: kernel, plymouth, systemd, python, archinstall, gum. The
 # whole ISO grows well under a percent for it, and dropping the x86 BCJ filter
 # also removes one of the blockers listed in plans/aarch64-support.md.
-airootfs_image_tool_options=(
-  '-comp' 'zstd'
-  '-Xcompression-level' '19'
-  '-b' '1M'
-  '-action' 'uncompressed@subpathname(var/cache/omarchy/mirror/offline)'
-)
+#
+# The generic ARM kernel (ALARM's linux-aarch64) enables SquashFS XZ but not
+# Zstandard, so aarch64 media must be xz to boot at all — slower cold reads,
+# but the alternative is an ISO the kernel cannot mount. No BCJ filter there
+# either: the arm filter is for 32-bit ARM and does nothing useful on arm64.
+if [[ $arch == "aarch64" ]]; then
+  airootfs_image_tool_options=(
+    '-comp' 'xz'
+    '-b' '1M'
+    '-Xdict-size' '1M'
+    '-action' 'uncompressed@subpathname(var/cache/omarchy/mirror/offline)'
+  )
+else
+  airootfs_image_tool_options=(
+    '-comp' 'zstd'
+    '-Xcompression-level' '19'
+    '-b' '1M'
+    '-action' 'uncompressed@subpathname(var/cache/omarchy/mirror/offline)'
+  )
+fi
 bootstrap_tarball_compression=('zstd' '-c' '-T0' '--auto-threads=logical' '--long' '-19')
 file_permissions=(
   ["/etc/shadow"]="0:0:400"

--- a/plans/aarch64-support.md
+++ b/plans/aarch64-support.md
@@ -176,3 +176,35 @@ No new files unless we go the dual-list route on archinstall.packages or efiboot
 1. **mkarchiso on aarch64 is less-trodden ground.** It accepts `arch="aarch64"`, but the upstream Arch project doesn't dogfood it. Expect to file/patch around small bugs in archiso's helper scripts. Keep the archiso submodule pin tight so a regression doesn't surprise nightly.
 2. **Limine + LUKS + Btrfs + Snapper on aarch64** — every one of these works individually on ARM, but the combination is what omarchy ships. Worth one manual end-to-end pass before declaring done.
 3. **Apple T2 / linux-t2 / `arch-mact2` repo** are silently dropped on aarch64; users mistakenly trying to install the aarch64 ISO on a T2 Mac will get an obviously-wrong result. The configurator could refuse to install when arch mismatch is detected, but that's outside this plan.
+
+---
+
+## Implementation status
+
+The `--arch aarch64` build path from this plan is implemented as far as
+omarchy-iso alone can take it; the hard prerequisites above still gate a
+bootable image. What landed, by section:
+
+| Section | State | Where |
+| --- | --- | --- |
+| 1. Build entrypoint | Done. `--arch x86_64\|aarch64` (default `x86_64`), `OMARCHY_ARCH` passed into the container, `menci/archlinuxarm:latest` with `--platform linux/arm64` for aarch64, arch-scoped offline-mirror cache directory, arch-suffixed ISO glob at rename time. | `bin/omarchy-iso-make` |
+| 2. Profile | Done, the second option: `profiledef.sh` reads `OMARCHY_ARCH`; `bootmodes=('uefi.grub')` and an xz squashfs on aarch64 (ALARM's generic kernel has no SquashFS zstd). | `configs/profiledef.sh` |
+| 3. Build script | Done. Arch selection lives in `builder/architecture.sh` + `builder/package-architecture.sh` (keyring, Node tarball, `packages.$ARCH`, build-host and live package sets, online pacman config, live kernel names); `build-iso.sh` stays one linear script reading those. The releng `packages.x86_64` → `packages.aarch64` rename-and-prune is `prepare_package_profile`. | `builder/build-iso.sh`, `builder/architecture.sh`, `builder/package-architecture.sh` |
+| 4. archinstall package list | Done, the filter-step option: `filter_target_packages` drops microcode (and `tzupdate`, unpackaged on ALARM) and maps `linux` → `linux-aarch64` for the shipped `omarchy-*.packages` copies and `archinstall.packages`. `archlinuxarm-keyring` is added to the shipped base list. | `builder/package-architecture.sh` |
+| 5. Bootloader configs | Done for GRUB: `bootmodes` drops syslinux on aarch64, and `prepare_media_profile` points `grub.cfg`/`loopback.cfg` at ALARM's `Image`/`initramfs-linux.img`; the `grub_cpu` guards already hide the memtest/shell entries. `efiboot/loader` (systemd-boot) is not in `bootmodes` and was left alone. | `builder/architecture.sh` |
+| 6. mkinitcpio preset | Done: on aarch64 both `linux.preset` and `linux-t2.preset` are replaced by a generated `linux-aarch64.preset` (pkgbase-named, archiso preset only), and the `microcode`/`memdisk` hooks are dropped from `archiso.conf`. | `builder/architecture.sh` |
+| 7. Configurator | Done: `LIMINE_EFI_BINARY` from `uname -m` (`limine_aa64.efi` on ARM), `detect_kernel` returns `linux-aarch64` there, and the `ttfx` logo animation is skipped when the binary is absent (no ALARM package). The orchestrator derives the Limine binary names per machine instead of hard-coding `limine_x64.efi`/`BOOTX64.EFI`. Keyboard layouts are validated against the target's kbd catalog rather than `localectl` (needs PID 1). | `configs/airootfs/root/configurator`, `orchestrator/phases_impl.py`, `orchestrator/context.py`, `orchestrator/keyboard.py` |
+| 8. pacman configs | Done: `configs/pacman-online-arm.conf` (ALARM core/extra/alarm/aur, no `arch-mact2`). Its `[omarchy]` section points at `pkgs.omarchy.org/stable/aarch64`, which does not exist yet — see prerequisite 2 (omacom/omarchy-pkgs#277, issue #199). | `configs/pacman-online-arm.conf` |
+| mkarchiso | archiso v87 assumes `vmlinuz-*`, an edk2-shell binary, and the full x86 GRUB module list. `builder/archiso-aarch64.patch` is applied to a copy of the submodule's `mkarchiso` for aarch64 builds only. | `builder/archiso-aarch64.patch`, `builder/architecture.sh` |
+| 9. Smoke-test scripts | `bin/omarchy-iso-test` boots aarch64 ISOs (`qemu-system-aarch64 -machine virt`, `edk2-armvirt` on Linux, HVF + Homebrew qemu on Apple Silicon macOS). `bin/omarchy-iso-boot` and `bin/omarchy-vm` are still x86_64-only. | `bin/omarchy-iso-test` |
+| 10. Release script | Not done: `bin/omarchy-iso-release` still globs `x86_64`. | — |
+| 11. CI | Not done: no aarch64 matrix leg yet. | — |
+
+Unit coverage: `test/unit/architecture-selector-test.sh` (flag → container/platform/naming),
+`test/unit/arm-profile-test.sh` (selection, profile rewrite, patch, profiledef, pacman conf,
+and that x86_64 is byte-for-byte untouched), `test/unit/test_arm_limine.py` (installer
+architecture detection), `test/unit/test_keyboard.py`.
+
+Still open before the first green aarch64 build, beyond the prerequisites: nobody has
+run `--arch aarch64` end to end against a published aarch64 `[omarchy]` tree, so the
+package closure (Hyprland and friends on ALARM's `extra`/`alarm`) is unverified.

--- a/test/all
+++ b/test/all
@@ -2,15 +2,27 @@
 #
 # Fast, VM-free tests only. The integration scenarios that boot the ISO in
 # QEMU live in test/integration.d/ and run via ./test/integration.
+#
+# The tests are listed in test/parallel-safe.tests and test/serial.tests and
+# run by test/run-manifest.py: the parallel-safe lane first, several at a
+# time, then the serial lane one at a time. A test present under test/unit/
+# but missing from both manifests is an error, so nothing is silently skipped.
+#
+# Exit status: 0 when every test passed, 1 when any test failed, timed out or
+# was cancelled after another failure, 2 when the runner could not start (a
+# manifest out of step with test/unit/, or another test/all already running).
+#
+#   OMARCHY_TEST_JOBS             parallel-safe tests at once (default 10)
+#   OMARCHY_TEST_TIMEOUT_SECONDS  wall-clock budget per test (default 300)
+#   OMARCHY_TEST_RESULT_LEDGER    JSON summary path (default test-runs/unit-test-results.json)
 
 set -euo pipefail
 
 ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
 
-for test in "$ROOT"/test/unit/*-test.sh; do
-  printf '==> %s\n' "${test#$ROOT/}"
-  bash "$test"
-done
+# The tests run under whichever bash started this script rather than whatever
+# `bash` resolves to inside the runner, so `/opt/homebrew/bin/bash test/all`
+# on macOS gets a modern bash for every test and not just for this file.
+export OMARCHY_TEST_BASH=$BASH
 
-printf '==> test/unit/test_*.py\n'
-python3 -m unittest discover -t "$ROOT" -s "$ROOT/test/unit"
+exec python3 "$ROOT/test/run-manifest.py" "$@"

--- a/test/parallel-safe.tests
+++ b/test/parallel-safe.tests
@@ -1,0 +1,14 @@
+# Tests that only touch their own throwaway directory and may run alongside
+# each other. One line per test, relative to the repository root; blank lines
+# and # comments are ignored. Every test under test/unit/ must appear here or
+# in test/serial.tests, or test/all refuses to run.
+test/unit/cidata-load-test.sh
+test/unit/iso-release-checksum-test.sh
+test/unit/partition-numbering-test.sh
+test/unit/test_command_capture.py
+test/unit/test_configure_ssh_access.py
+test/unit/test_configure_tailscale.py
+test/unit/test_keyboard.py
+test/unit/test_offline_mirror_pruning.py
+test/unit/test_provisioning_state.py
+test/unit/test_run_manifest.py

--- a/test/parallel-safe.tests
+++ b/test/parallel-safe.tests
@@ -12,3 +12,6 @@ test/unit/test_keyboard.py
 test/unit/test_offline_mirror_pruning.py
 test/unit/test_provisioning_state.py
 test/unit/test_run_manifest.py
+test/unit/architecture-selector-test.sh
+test/unit/arm-profile-test.sh
+test/unit/test_arm_limine.py

--- a/test/run-manifest.py
+++ b/test/run-manifest.py
@@ -1,0 +1,737 @@
+#!/usr/bin/env python3
+"""Run the unit tests in two lanes: parallel-safe first, then serial.
+
+test/all used to run every test one after another. Most of them only touch a
+throwaway directory and can share a machine, but a few own something global (a
+pty, a fixed port, the docker socket) and only behave when nothing else runs
+alongside. Rather than guess, every test is listed by hand in one of two
+manifests:
+
+  test/parallel-safe.tests  runs concurrently, up to --jobs at a time
+  test/serial.tests         runs one at a time, after the parallel lane passed
+
+The manifests are the source of truth, and they must be complete: a test that
+exists under test/unit/ but sits in neither manifest is an error, not a silent
+skip, so adding a test means deciding which lane it belongs to. Duplicates,
+entries that point nowhere, and symlinks are rejected for the same reason.
+
+Each test runs in its own session (process group) with a wall-clock budget. A
+timeout or a failure takes the whole group down, including anything the test
+left in the background, and cancels the tests that have not finished yet: the
+first failure is the one worth reading, and a hung fixture must not keep CI
+busy for an hour. A test that exits 0 but leaves a background process behind
+is failed as well, since the next test in the same lane would inherit it.
+
+Python tests run one module per process with test/unit on the module path.
+That sidesteps `unittest discover`, which imports the modules as a `test.unit`
+package and loses to the standard library's own `test` package on hosts that
+ship it (macOS, Debian). A module that collects no test cases is a failure,
+not a pass.
+
+Every run writes a JSON ledger (default test-runs/unit-test-results.json)
+naming each test, its lane, status and elapsed time, so a CI failure can be
+read without scrolling through the log.
+"""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import fcntl
+import json
+import math
+from pathlib import Path
+import os
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import threading
+import time
+import uuid
+
+
+DEFAULT_JOBS = 10
+DEFAULT_TEST_TIMEOUT_SECONDS = 300.0
+DEFAULT_RESULT_LEDGER = "test-runs/unit-test-results.json"
+PROCESS_GROUP_TERMINATION_GRACE_SECONDS = 1.0
+TIMEOUT_RETURNCODE = 124
+CANCELLED_RETURNCODE = 130
+RESULT_LEDGER_SCHEMA_VERSION = 1
+TEST_PATTERNS = ("*-test.sh", "test_*.py")
+PYTHON_UNITTEST_RUNNER = """
+import importlib
+import sys
+import unittest
+
+module = importlib.import_module(sys.argv[1])
+suite = unittest.defaultTestLoader.loadTestsFromModule(module)
+if suite.countTestCases() == 0:
+    print(f"no unittest cases collected from {sys.argv[1]}", file=sys.stderr)
+    raise SystemExit(3)
+result = unittest.TextTestRunner().run(suite)
+raise SystemExit(0 if result.wasSuccessful() else 1)
+"""
+
+
+class ManifestError(Exception):
+    """The lane manifests disagree with test/unit/; nothing has run."""
+
+
+@dataclass(frozen=True)
+class Result:
+    path: str
+    returncode: int
+    stdout: str
+    stderr: str
+    elapsed_seconds: float
+    status: str
+
+    @property
+    def passed(self) -> bool:
+        return self.status == "passed"
+
+
+def read_manifest(path: Path) -> list[str]:
+    return [
+        line.strip()
+        for line in path.read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def discover(root: Path) -> list[str]:
+    return sorted(
+        path.relative_to(root).as_posix()
+        for pattern in TEST_PATTERNS
+        for path in (root / "test/unit").glob(pattern)
+    )
+
+
+def validate(root: Path, parallel: list[str], serial: list[str]) -> None:
+    declared = [*parallel, *serial]
+    duplicates = sorted({value for value in declared if declared.count(value) > 1})
+    if duplicates:
+        raise ManifestError("duplicate test manifest entries: " + ", ".join(duplicates))
+    discovered = discover(root)
+    if sorted(declared) != discovered:
+        missing = sorted(set(discovered) - set(declared))
+        extra = sorted(set(declared) - set(discovered))
+        detail = []
+        if missing:
+            detail.append(
+                "not in test/parallel-safe.tests or test/serial.tests: " + ", ".join(missing)
+            )
+        if extra:
+            detail.append("listed but not under test/unit/: " + ", ".join(extra))
+        raise ManifestError("test manifests are incomplete; " + "; ".join(detail))
+    for value in declared:
+        path = root / value
+        if not path.is_file() or path.is_symlink():
+            raise ManifestError(f"test path is missing or unsafe: {value}")
+
+
+def _cancelled_result(relative: str, reason: str) -> Result:
+    return Result(
+        path=relative,
+        returncode=CANCELLED_RETURNCODE,
+        stdout="",
+        stderr=f"cancelled: {reason}\n",
+        elapsed_seconds=0.0,
+        status="cancelled",
+    )
+
+
+def _process_group_exists(process_group_id: int) -> bool:
+    try:
+        os.killpg(process_group_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _terminate_process_group(
+    process: subprocess.Popen[str],
+    *,
+    grace_seconds: float = PROCESS_GROUP_TERMINATION_GRACE_SECONDS,
+) -> tuple[str, str]:
+    """Stop the test and everything it started; SIGTERM first, SIGKILL after."""
+
+    deadline = time.monotonic() + grace_seconds
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        output: tuple[str, str] | None = process.communicate(timeout=grace_seconds)
+    except subprocess.TimeoutExpired:
+        output = None
+
+    while _process_group_exists(process.pid) and time.monotonic() < deadline:
+        time.sleep(0.01)
+    if _process_group_exists(process.pid):
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    if output is None:
+        output = process.communicate()
+
+    kill_deadline = time.monotonic() + grace_seconds
+    while _process_group_exists(process.pid) and time.monotonic() < kill_deadline:
+        time.sleep(0.01)
+    if _process_group_exists(process.pid):
+        raise RuntimeError(f"process group {process.pid} survived SIGKILL")
+    return output
+
+
+def execute(
+    root: Path,
+    relative: str,
+    *,
+    timeout_seconds: float,
+    cancel_event: threading.Event | None = None,
+) -> Result:
+    cancellation = cancel_event or threading.Event()
+    if cancellation.is_set():
+        return _cancelled_result(relative, "another test failed")
+
+    path = root / relative
+    environment = os.environ.copy()
+    # test/all exports the bash it was started with, so the tests run under the
+    # same interpreter on hosts where /bin/bash is too old (macOS ships 3.2).
+    # Its directory goes first on PATH so a test that calls plain `bash` gets
+    # that one as well.
+    bash = environment.get("OMARCHY_TEST_BASH") or shutil.which("bash")
+    if bash is None:
+        raise RuntimeError("bash is unavailable")
+    bash = str(Path(bash).resolve())
+    environment["OMARCHY_TEST_BASH"] = bash
+    environment["PATH"] = os.pathsep.join(
+        [str(Path(bash).parent), environment.get("PATH", "")]
+    )
+    if path.suffix == ".py":
+        environment["PYTHONPATH"] = os.pathsep.join(
+            [str(root / "test/unit"), environment.get("PYTHONPATH", "")]
+        )
+        command = [sys.executable, "-c", PYTHON_UNITTEST_RUNNER, path.stem]
+    else:
+        command = [bash, str(path)]
+
+    started = time.monotonic()
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=environment,
+            start_new_session=True,
+        )
+    except OSError as error:
+        cancellation.set()
+        return Result(
+            path=relative,
+            returncode=1,
+            stdout="",
+            stderr=f"could not start test: {error}\n",
+            elapsed_seconds=time.monotonic() - started,
+            status="failed",
+        )
+
+    deadline = started + timeout_seconds
+    while True:
+        if cancellation.is_set():
+            stdout, stderr = _terminate_process_group(process)
+            return Result(
+                path=relative,
+                returncode=CANCELLED_RETURNCODE,
+                stdout=stdout,
+                stderr=stderr + "cancelled: another test failed\n",
+                elapsed_seconds=time.monotonic() - started,
+                status="cancelled",
+            )
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            cancellation.set()
+            stdout, stderr = _terminate_process_group(process)
+            return Result(
+                path=relative,
+                returncode=TIMEOUT_RETURNCODE,
+                stdout=stdout,
+                stderr=stderr + f"timed out after {timeout_seconds:g} seconds\n",
+                elapsed_seconds=time.monotonic() - started,
+                status="timed-out",
+            )
+
+        try:
+            stdout, stderr = process.communicate(timeout=min(0.1, remaining))
+        except subprocess.TimeoutExpired:
+            continue
+
+        if _process_group_exists(process.pid):
+            _terminate_process_group(process)
+            cancellation.set()
+            return Result(
+                path=relative,
+                returncode=1,
+                stdout=stdout,
+                stderr=stderr + "test left a process group running after exit\n",
+                elapsed_seconds=time.monotonic() - started,
+                status="failed",
+            )
+
+        status = "passed" if process.returncode == 0 else "failed"
+        if status != "passed":
+            cancellation.set()
+        return Result(
+            path=relative,
+            returncode=process.returncode,
+            stdout=stdout,
+            stderr=stderr,
+            elapsed_seconds=time.monotonic() - started,
+            status=status,
+        )
+
+
+def _future_result(future: Future[Result], relative: str) -> Result:
+    try:
+        return future.result()
+    except Exception as error:  # pragma: no cover - defensive worker boundary
+        return Result(
+            path=relative,
+            returncode=1,
+            stdout="",
+            stderr=f"test runner worker failed: {error}\n",
+            elapsed_seconds=0.0,
+            status="failed",
+        )
+
+
+def run_parallel(
+    root: Path,
+    tests: list[str],
+    *,
+    jobs: int,
+    timeout_seconds: float,
+) -> list[Result]:
+    if not tests:
+        return []
+
+    cancellation = threading.Event()
+    results: dict[str, Result] = {}
+    executor = ThreadPoolExecutor(max_workers=min(jobs, len(tests)))
+    futures = {
+        executor.submit(
+            execute,
+            root,
+            relative,
+            timeout_seconds=timeout_seconds,
+            cancel_event=cancellation,
+        ): relative
+        for relative in tests
+    }
+    pending = set(futures)
+    try:
+        while pending:
+            completed, pending = wait(pending, return_when=FIRST_COMPLETED)
+            for future in completed:
+                relative = futures[future]
+                results[relative] = _future_result(future, relative)
+            if any(not results[futures[future]].passed for future in completed):
+                cancellation.set()
+                for future in list(pending):
+                    if future.cancel():
+                        relative = futures[future]
+                        results[relative] = _cancelled_result(
+                            relative,
+                            "another parallel-safe test failed",
+                        )
+                        pending.remove(future)
+    except BaseException:
+        cancellation.set()
+        for future in pending:
+            future.cancel()
+        raise
+    finally:
+        executor.shutdown(wait=True, cancel_futures=True)
+
+    # Report in manifest order regardless of which finished first.
+    return [results[relative] for relative in tests]
+
+
+def run_serial(
+    root: Path,
+    tests: list[str],
+    *,
+    timeout_seconds: float,
+) -> list[Result]:
+    cancellation = threading.Event()
+    results: list[Result] = []
+    for index, relative in enumerate(tests):
+        result = execute(
+            root,
+            relative,
+            timeout_seconds=timeout_seconds,
+            cancel_event=cancellation,
+        )
+        results.append(result)
+        if not result.passed:
+            results.extend(
+                _cancelled_result(value, "an earlier serial test failed")
+                for value in tests[index + 1 :]
+            )
+            break
+    return results
+
+
+def emit(result: Result) -> None:
+    print(f"==> {result.path} [{result.status}; {result.elapsed_seconds:.3f}s]")
+    if result.stdout:
+        print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+    if result.stderr:
+        print(result.stderr, end="" if result.stderr.endswith("\n") else "\n", file=sys.stderr)
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+
+def _ledger(
+    *,
+    run_id: str,
+    started_at: str,
+    completed_at: str | None,
+    result: str,
+    requested_jobs: int,
+    parallel_worker_count: int,
+    timeout_seconds: float,
+    tests: list[dict[str, object]],
+) -> dict[str, object]:
+    return {
+        "completed_at": completed_at,
+        "kind": "omarchy-unit-test-result-ledger",
+        "parallel_worker_count": parallel_worker_count,
+        "requested_worker_count": requested_jobs,
+        "result": result,
+        "run_id": run_id,
+        "schema_version": RESULT_LEDGER_SCHEMA_VERSION,
+        "started_at": started_at,
+        "test_timeout_seconds": timeout_seconds,
+        "tests": tests,
+    }
+
+
+def build_result_ledger(
+    *,
+    run_id: str,
+    started_at: str,
+    completed_at: str,
+    requested_jobs: int,
+    parallel_worker_count: int,
+    timeout_seconds: float,
+    parallel_results: list[Result],
+    serial_results: list[Result],
+) -> dict[str, object]:
+    records: list[dict[str, object]] = [
+        {
+            "elapsed_seconds": round(result.elapsed_seconds, 3),
+            "lane": lane,
+            "path": result.path,
+            "result": result.status,
+            "returncode": result.returncode,
+        }
+        for lane, results in (
+            ("parallel-safe", parallel_results),
+            ("serial", serial_results),
+        )
+        for result in results
+    ]
+    return _ledger(
+        run_id=run_id,
+        started_at=started_at,
+        completed_at=completed_at,
+        result="passed" if all(record["result"] == "passed" for record in records) else "failed",
+        requested_jobs=requested_jobs,
+        parallel_worker_count=parallel_worker_count,
+        timeout_seconds=timeout_seconds,
+        tests=records,
+    )
+
+
+def build_incomplete_ledger(
+    *,
+    run_id: str,
+    started_at: str,
+    requested_jobs: int,
+    parallel_worker_count: int,
+    timeout_seconds: float,
+    parallel_tests: list[str],
+    serial_tests: list[str],
+) -> dict[str, object]:
+    # Written before anything runs, so a runner that dies mid-way (killed CI
+    # job, power loss) leaves a ledger that says "incomplete" rather than the
+    # previous run's "passed".
+    records: list[dict[str, object]] = [
+        {
+            "elapsed_seconds": 0.0,
+            "lane": lane,
+            "path": path,
+            "result": "not-run",
+            "returncode": None,
+        }
+        for lane, tests in (
+            ("parallel-safe", parallel_tests),
+            ("serial", serial_tests),
+        )
+        for path in tests
+    ]
+    return _ledger(
+        run_id=run_id,
+        started_at=started_at,
+        completed_at=None,
+        result="incomplete",
+        requested_jobs=requested_jobs,
+        parallel_worker_count=parallel_worker_count,
+        timeout_seconds=timeout_seconds,
+        tests=records,
+    )
+
+
+def write_result_ledger(path: Path, ledger: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise RuntimeError(f"result ledger path is an unsafe symlink: {path}")
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        temporary.write_text(json.dumps(ledger, indent=2, sort_keys=True) + "\n")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def acquire_result_ledger_lease(path: Path, run_id: str) -> int:
+    """Take an exclusive lock next to the ledger so two runners cannot interleave.
+
+    Two `test/all` invocations at once would race each other's ledger writes
+    and, worse, each other's serial lane. The lock file is opened O_NOFOLLOW
+    and checked to be a plain private file so a symlink dropped in test-runs/
+    cannot redirect the write.
+    """
+
+    if not run_id or "\n" in run_id:
+        raise RuntimeError("test result run identity is invalid")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(f".{path.name}.lock")
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    cloexec = getattr(os, "O_CLOEXEC", 0)
+    if not nofollow:
+        raise RuntimeError("safe test result locking is unsupported")
+    try:
+        descriptor = os.open(
+            lock_path,
+            os.O_RDWR | os.O_CREAT | nofollow | cloexec,
+            0o600,
+        )
+    except OSError as error:
+        raise RuntimeError(f"test result lease is unsafe: {lock_path}") from error
+    try:
+        status = os.fstat(descriptor)
+        if not stat.S_ISREG(status.st_mode) or status.st_nlink != 1:
+            raise RuntimeError(f"test result lease must be a private file: {lock_path}")
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as error:
+            raise RuntimeError(
+                f"another test runner owns the result ledger: {path}"
+            ) from error
+        payload = f"{run_id}\n".encode()
+        os.ftruncate(descriptor, 0)
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        written = 0
+        while written < len(payload):
+            count = os.write(descriptor, payload[written:])
+            if count <= 0:
+                raise RuntimeError("test result lease write made no progress")
+            written += count
+        os.fsync(descriptor)
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def release_result_ledger_lease(descriptor: int) -> None:
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(descriptor)
+
+
+def run_registered_tests(
+    *,
+    root: Path,
+    parallel: list[str],
+    serial: list[str],
+    jobs: int,
+    timeout_seconds: float,
+    result_ledger: Path,
+    run_id: str,
+    started_at: str,
+) -> int:
+    parallel_worker_count = min(jobs, len(parallel))
+    write_result_ledger(
+        result_ledger,
+        build_incomplete_ledger(
+            run_id=run_id,
+            started_at=started_at,
+            requested_jobs=jobs,
+            parallel_worker_count=parallel_worker_count,
+            timeout_seconds=timeout_seconds,
+            parallel_tests=parallel,
+            serial_tests=serial,
+        ),
+    )
+
+    parallel_results = run_parallel(
+        root,
+        parallel,
+        jobs=jobs,
+        timeout_seconds=timeout_seconds,
+    )
+    for result in parallel_results:
+        emit(result)
+
+    if any(not result.passed for result in parallel_results):
+        serial_results = [
+            _cancelled_result(relative, "a parallel-safe test failed")
+            for relative in serial
+        ]
+    else:
+        serial_results = run_serial(
+            root,
+            serial,
+            timeout_seconds=timeout_seconds,
+        )
+        for result in serial_results:
+            emit(result)
+
+    ledger = build_result_ledger(
+        run_id=run_id,
+        started_at=started_at,
+        completed_at=utc_now(),
+        requested_jobs=jobs,
+        parallel_worker_count=parallel_worker_count,
+        timeout_seconds=timeout_seconds,
+        parallel_results=parallel_results,
+        serial_results=serial_results,
+    )
+    write_result_ledger(result_ledger, ledger)
+    print(f"test result ledger: {result_ledger}")
+
+    failures = [
+        result for result in [*parallel_results, *serial_results] if not result.passed
+    ]
+    if failures:
+        print(
+            "test failures: "
+            + ", ".join(f"{result.path} ({result.status})" for result in failures),
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def positive_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError("must be finite and positive")
+    return parsed
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--jobs",
+        type=positive_int,
+        default=positive_int(os.environ.get("OMARCHY_TEST_JOBS", str(DEFAULT_JOBS))),
+        help="parallel-safe tests to run at once (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--test-timeout-seconds",
+        type=positive_float,
+        default=positive_float(
+            os.environ.get("OMARCHY_TEST_TIMEOUT_SECONDS", str(DEFAULT_TEST_TIMEOUT_SECONDS))
+        ),
+        help="wall-clock budget per test (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--result-ledger",
+        type=Path,
+        default=Path(os.environ.get("OMARCHY_TEST_RESULT_LEDGER", DEFAULT_RESULT_LEDGER)),
+        help="where to write the JSON summary (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="check the manifests against test/unit/ and exit without running",
+    )
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[1]
+    try:
+        parallel = read_manifest(root / "test/parallel-safe.tests")
+        serial = read_manifest(root / "test/serial.tests")
+        validate(root, parallel, serial)
+    except (ManifestError, OSError) as error:
+        print(f"test runner refused to start: {error}", file=sys.stderr)
+        return 2
+    if args.validate_only:
+        print(f"validated {len(parallel)} parallel-safe and {len(serial)} serial tests")
+        return 0
+
+    result_ledger = args.result_ledger
+    if not result_ledger.is_absolute():
+        result_ledger = root / result_ledger
+    run_id = uuid.uuid4().hex
+    started_at = utc_now()
+    try:
+        lease = acquire_result_ledger_lease(result_ledger, run_id)
+    except RuntimeError as error:
+        print(f"test runner refused to start: {error}", file=sys.stderr)
+        return 2
+    try:
+        return run_registered_tests(
+            root=root,
+            parallel=parallel,
+            serial=serial,
+            jobs=args.jobs,
+            timeout_seconds=args.test_timeout_seconds,
+            result_ledger=result_ledger,
+            run_id=run_id,
+            started_at=started_at,
+        )
+    finally:
+        release_result_ledger_lease(lease)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/serial.tests
+++ b/test/serial.tests
@@ -1,0 +1,8 @@
+# Tests that own something global -- a pty, a port, the docker socket, a shared
+# fixture -- and run one at a time after the parallel-safe lane has passed.
+# Say what the global thing is above each entry so the next person can tell
+# whether a new test belongs here.
+
+# Drives the failure screen through a real pty (script) and asserts on the
+# terminal repaint order, which a busy machine can reorder.
+test/unit/install-media-diagnosis-test.sh

--- a/test/unit/architecture-selector-test.sh
+++ b/test/unit/architecture-selector-test.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+#
+# Unit tests for the --arch flag of omarchy-iso-make: which container image,
+# platform, and OMARCHY_ARCH the build runs with, and how the ISO is named.
+# docker and git are stubbed; the script itself runs for real from a sandbox
+# copy of the repo so nothing lands in the real release/ directory.
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+fail() {
+  local description="$1"
+  local detail="${2:-}"
+
+  [[ -n $detail ]] && printf '%s\n' "$detail" >&2
+  printf 'not ok - %s\n' "$description" >&2
+  exit 1
+}
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# omarchy-iso-make resolves release/ and the mounts from its own location and
+# lints configs/ from the working directory, so give it a sandbox repo.
+sandbox="$work/repo"
+mkdir -p "$sandbox/bin" "$work/stubs"
+cp "$ROOT/bin/omarchy-iso-make" "$sandbox/bin/"
+cp -R "$ROOT/builder" "$ROOT/configs" "$sandbox/"
+mkdir -p "$sandbox/archiso"
+
+# The stub records its argument list, then produces the ISO mkarchiso would
+# have written into /out/, named after the architecture like profiledef does.
+cat >"$work/stubs/docker" <<'STUB'
+#!/bin/bash
+set -euo pipefail
+[[ ${1:-} == version ]] && exit 0
+printf '%s\n' "$@" >"$TEST_DOCKER_ARGS"
+arch="" out="" previous=""
+for argument in "$@"; do
+  if [[ $previous == "-e" && $argument == OMARCHY_ARCH=* ]]; then
+    arch="${argument#*=}"
+  elif [[ $previous == "-v" && $argument == *:/out/ ]]; then
+    out="${argument%:/out/}"
+  fi
+  previous="$argument"
+done
+[[ -n $arch && -n $out ]]
+touch "$out/omarchy-test-$arch.iso"
+STUB
+
+cat >"$work/stubs/git" <<'STUB'
+#!/bin/bash
+# No submodule to update and no index to consult in the sandbox.
+exit 0
+STUB
+chmod +x "$work/stubs/docker" "$work/stubs/git"
+
+# The script's permissions lint uses grep -P; on a BSD host borrow GNU grep.
+if ! grep -qP 'x' <<<"x" 2>/dev/null && command -v ggrep >/dev/null; then
+  ln -s "$(command -v ggrep)" "$work/stubs/grep"
+fi
+
+run_make() {
+  local label="$1"
+  shift
+  export TEST_DOCKER_ARGS="$work/docker-$label.args"
+  (
+    cd "$sandbox"
+    PATH="$work/stubs:$PATH" HOME="$work/home" \
+      "$BASH" bin/omarchy-iso-make "$@" --keep-pkg-cache --no-cache --no-boot-offer >/dev/null
+  )
+}
+
+assert_arg() {
+  local file="$1"
+  local expected="$2"
+
+  grep -qxF -- "$expected" "$file" ||
+    fail "docker argument $expected" "$(printf 'arguments were:\n'; cat "$file")"
+}
+
+refute_arg() {
+  local file="$1"
+  local unexpected="$2"
+
+  if grep -qxF -- "$unexpected" "$file"; then
+    fail "docker must not receive $unexpected" "$(printf 'arguments were:\n'; cat "$file")"
+  fi
+}
+
+run_make default
+assert_arg "$work/docker-default.args" "OMARCHY_ARCH=x86_64"
+assert_arg "$work/docker-default.args" "archlinux/archlinux:latest"
+refute_arg "$work/docker-default.args" "--platform"
+[[ -f $sandbox/release/omarchy-test-x86_64-quattro.iso ]] ||
+  fail "default build names the x86_64 ISO" "$(ls "$sandbox/release")"
+pass "default build is x86_64 in the Arch container with no platform override"
+rm -f "$sandbox/release"/*.iso
+
+run_make x86_64 --arch x86_64
+assert_arg "$work/docker-x86_64.args" "OMARCHY_ARCH=x86_64"
+assert_arg "$work/docker-x86_64.args" "archlinux/archlinux:latest"
+refute_arg "$work/docker-x86_64.args" "--platform"
+pass "--arch x86_64 matches the default"
+rm -f "$sandbox/release"/*.iso
+
+# Leave an x86_64 ISO behind: the aarch64 build must pick up its own output
+# even when a newer-looking x86_64 file shares release/.
+run_make aarch64 --arch=aarch64
+assert_arg "$work/docker-aarch64.args" "OMARCHY_ARCH=aarch64"
+assert_arg "$work/docker-aarch64.args" "--platform"
+assert_arg "$work/docker-aarch64.args" "linux/arm64"
+assert_arg "$work/docker-aarch64.args" "menci/archlinuxarm:latest"
+refute_arg "$work/docker-aarch64.args" "archlinux/archlinux:latest"
+[[ -f $sandbox/release/omarchy-test-aarch64-quattro.iso ]] ||
+  fail "aarch64 build names the aarch64 ISO" "$(ls "$sandbox/release")"
+pass "--arch aarch64 builds in an arm64 Arch Linux ARM container"
+
+touch "$sandbox/release/omarchy-test-x86_64.iso"
+run_make aarch64-shared --arch aarch64
+[[ -f $sandbox/release/omarchy-test-x86_64.iso ]] ||
+  fail "aarch64 build leaves the x86_64 output alone" "$(ls "$sandbox/release")"
+pass "release/ is shared between architectures"
+
+set +e
+invalid_output=$(cd "$sandbox" && PATH="$work/stubs:$PATH" "$BASH" bin/omarchy-iso-make --arch sparc 2>&1)
+invalid_status=$?
+set -e
+(( invalid_status != 0 )) || fail "unsupported architecture is rejected"
+[[ $invalid_output == *"Unsupported architecture: sparc"* ]] ||
+  fail "unsupported architecture names itself" "$invalid_output"
+pass "--arch rejects anything but x86_64 and aarch64"

--- a/test/unit/arm-profile-test.sh
+++ b/test/unit/arm-profile-test.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+#
+# Unit tests for builder/architecture.sh and configs/profiledef.sh: the
+# variables each architecture selects, the releng/profile rewrite for aarch64,
+# and that x86_64 is left exactly as it was.
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+export BUILDER_ROOT="$ROOT/builder"
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+fail() {
+  local description="$1"
+  local detail="${2:-}"
+
+  [[ -n $detail ]] && printf '%s\n' "$detail" >&2
+  printf 'not ok - %s\n' "$description" >&2
+  exit 1
+}
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# profiledef.sh uses GNU date's --date=@EPOCH. On a BSD host (macOS) shim just
+# that form so the profile can be sourced here too.
+mkdir -p "$work/shim"
+if ! date --date=@0 +%Y >/dev/null 2>&1; then
+  cat >"$work/shim/date" <<'SHIM'
+#!/bin/bash
+epoch=${1#--date=@}
+exec python3 -c 'import sys, time; print(time.strftime(sys.argv[2].lstrip("+"), time.gmtime(int(sys.argv[1]))))' "$epoch" "$2"
+SHIM
+  chmod +x "$work/shim/date"
+fi
+export PATH="$work/shim:$PATH"
+
+# ---------------------------------------------------------------- selection
+
+arm_selection=$(
+  export OMARCHY_ARCH=aarch64 OMARCHY_MIRROR=stable OMARCHY_SETTINGS_PACKAGE=omarchy-settings
+  source "$ROOT/builder/architecture.sh"
+  printf '%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
+    "$OMARCHY_MEDIA_TARGET" "$OMARCHY_PLATFORM" "$OMARCHY_BOOT_BACKEND" \
+    "$DISTRO_KEYRING_PACKAGE" "$DISTRO_KEYRING_NAME" "$NODE_DIST_ARCH" \
+    "$PROFILE_PACKAGES" "$PACMAN_ONLINE_CONFIG" \
+    "$LIVE_KERNEL/$LIVE_KERNEL_BOOT_NAME/$LIVE_INITRAMFS_BOOT_NAME" "${MKARCHISO[*]}"
+  printf '%s\n' "${LIVE_PACKAGES[*]}" "${BUILD_HOST_PACKAGES[*]}"
+)
+[[ $(sed -n 1p <<<"$arm_selection") == \
+  "aarch64/generic|generic|limine|archlinuxarm-keyring|archlinuxarm|arm64|packages.aarch64|/configs/pacman-online-arm.conf|linux-aarch64/Image/initramfs-linux.img|/tmp/omarchy-mkarchiso-aarch64" ]] ||
+  fail "aarch64 selects the ALARM keyring, arm64 Node, packages.aarch64 and the patched mkarchiso" "$arm_selection"
+live=$(sed -n 2p <<<"$arm_selection")
+[[ " $live " == *" linux-aarch64 "* && " $live " != *" linux-t2 "* && " $live " != *" ttfx "* ]] ||
+  fail "aarch64 live packages boot linux-aarch64 without ttfx" "$live"
+host=$(sed -n 3p <<<"$arm_selection")
+[[ " $host " != *" archiso "* && " $host " == *" squashfs-tools "* ]] ||
+  fail "aarch64 build host installs mkarchiso's dependencies, not the archiso package" "$host"
+pass "aarch64 selection"
+
+x86_selection=$(
+  export OMARCHY_ARCH=x86_64 OMARCHY_MIRROR=edge OMARCHY_SETTINGS_PACKAGE=omarchy-settings-dev
+  source "$ROOT/builder/architecture.sh"
+  printf '%s|%s|%s|%s|%s|%s|%s\n' \
+    "$OMARCHY_MEDIA_TARGET" "$DISTRO_KEYRING_PACKAGE" "$NODE_DIST_ARCH" \
+    "$PROFILE_PACKAGES" "$PACMAN_ONLINE_CONFIG" "$LIVE_KERNEL" "${MKARCHISO[*]}"
+  printf '%s\n' "${LIVE_PACKAGES[*]}" "${BUILD_HOST_PACKAGES[*]}"
+)
+[[ $(sed -n 1p <<<"$x86_selection") == \
+  "x86_64/pc|archlinux-keyring|x64|packages.x86_64|/configs/pacman-online-edge.conf|linux-t2|mkarchiso" ]] ||
+  fail "x86_64 selection is unchanged" "$x86_selection"
+[[ $(sed -n 2p <<<"$x86_selection") == \
+  "linux-t2 git gum jq openssl plymouth ttfx tzupdate omarchy-keyring omarchy-settings-dev lvm2 cryptsetup parted" ]] ||
+  fail "x86_64 live packages are unchanged" "$x86_selection"
+[[ $(sed -n 3p <<<"$x86_selection") == \
+  "archiso git sudo base-devel jq grub imagemagick neovim nodejs npm tree-sitter-cli" ]] ||
+  fail "x86_64 build host packages are unchanged" "$x86_selection"
+pass "x86_64 selection is the pre-existing build"
+
+default_arch=$(
+  unset OMARCHY_ARCH OMARCHY_MEDIA_TARGET
+  source "$ROOT/builder/architecture.sh"
+  printf '%s|%s\n' "$OMARCHY_ARCH" "$OMARCHY_MEDIA_TARGET"
+)
+[[ $default_arch == "x86_64|x86_64/pc" ]] || fail "default is x86_64/pc" "$default_arch"
+pass "architecture defaults to x86_64"
+
+for bad in "aarch64:aarch64/apple-silicon" "x86_64:aarch64/generic" "riscv64:"; do
+  if (
+    export OMARCHY_ARCH=${bad%%:*} OMARCHY_MEDIA_TARGET=${bad#*:}
+    source "$ROOT/builder/architecture.sh"
+  ) 2>/dev/null; then
+    fail "architecture.sh rejects $bad"
+  fi
+done
+pass "unsupported architecture/target pairs are rejected"
+
+# ----------------------------------------------------------- package lists
+
+filtered=$(
+  export OMARCHY_ARCH=aarch64 OMARCHY_MIRROR=stable OMARCHY_SETTINGS_PACKAGE=omarchy-settings
+  source "$ROOT/builder/architecture.sh"
+  printf '%s\n' linux linux-headers amd-ucode intel-ucode tzupdate base limine | filter_target_packages
+)
+[[ $filtered == $'linux-aarch64\nlinux-aarch64-headers\nbase\nlimine' ]] ||
+  fail "aarch64 drops microcode and tzupdate and renames the kernel" "$filtered"
+
+x86_filtered=$(
+  export OMARCHY_ARCH=x86_64 OMARCHY_MIRROR=stable OMARCHY_SETTINGS_PACKAGE=omarchy-settings
+  source "$ROOT/builder/architecture.sh"
+  printf '%s\n' linux linux-headers amd-ucode intel-ucode tzupdate | filter_target_packages
+)
+[[ $x86_filtered == $'linux\nlinux-headers\namd-ucode\nintel-ucode\ntzupdate' ]] ||
+  fail "x86_64 package lists pass through untouched" "$x86_filtered"
+pass "target package list filtering"
+
+# -------------------------------------------------------------- profile
+
+make_profile() {
+  local profile=$1
+
+  mkdir -p \
+    "$profile/airootfs/etc/mkinitcpio.d" \
+    "$profile/airootfs/etc/mkinitcpio.conf.d" \
+    "$profile/grub"
+  printf '%s\n' linux broadcom-wl memtest86+ intel-ucode syslinux edk2-shell base linux-firmware >"$profile/packages.x86_64"
+  printf '%s\n' \
+    'HOOKS=(base udev microcode modconf kms memdisk archiso plymouth block filesystems keyboard)' \
+    >"$profile/airootfs/etc/mkinitcpio.conf.d/archiso.conf"
+  touch \
+    "$profile/airootfs/etc/mkinitcpio.d/linux.preset" \
+    "$profile/airootfs/etc/mkinitcpio.d/linux-t2.preset"
+  cp "$ROOT/configs/grub/grub.cfg" "$profile/grub/grub.cfg"
+  cp "$ROOT/configs/grub/loopback.cfg" "$profile/grub/loopback.cfg"
+  cp "$ROOT/configs/pacman-offline.conf" "$profile/pacman-offline.conf"
+}
+
+profile="$work/arm-profile"
+make_profile "$profile"
+(
+  export OMARCHY_ARCH=aarch64 OMARCHY_MIRROR=stable OMARCHY_SETTINGS_PACKAGE=omarchy-settings
+  source "$ROOT/builder/architecture.sh"
+  prepare_media_profile "$profile"
+)
+[[ -f $profile/packages.aarch64 && ! -e $profile/packages.x86_64 ]] ||
+  fail "releng's packages.x86_64 becomes packages.aarch64"
+[[ $(cat "$profile/packages.aarch64") == $'base\nlinux-firmware' ]] ||
+  fail "x86-only releng packages are pruned" "$(cat "$profile/packages.aarch64")"
+[[ ! -e $profile/airootfs/etc/mkinitcpio.d/linux.preset && ! -e $profile/airootfs/etc/mkinitcpio.d/linux-t2.preset ]] ||
+  fail "the x86 kernel presets are removed"
+# ALARM's linux-aarch64 ships its own preset; a copy in airootfs would make
+# pacstrap fail on a conflicting file. Its default-config build must still
+# come out with archiso's hooks, so a drop-in that sorts last re-asserts them.
+[[ ! -e $profile/airootfs/etc/mkinitcpio.d/linux-aarch64.preset ]] ||
+  fail "no preset is shipped for the linux-aarch64 package"
+live_conf="$profile/airootfs/etc/mkinitcpio.conf.d/zz-archiso-live.conf"
+[[ -f $live_conf ]] || fail "a last-sorting drop-in re-asserts archiso's config"
+grep -q '^HOOKS=(.* archiso .*)' "$live_conf" || fail "the live drop-in carries the archiso hooks" "$(cat "$live_conf")"
+grep -q ' microcode \| memdisk ' "$live_conf" && fail "the live drop-in has no x86 hooks" "$(cat "$live_conf")"
+grep -Fxq 'MODULES=()' "$live_conf" || fail "the live drop-in resets forced modules" "$(cat "$live_conf")"
+grep -Fxq 'HOOKS=(base udev modconf kms archiso plymouth block filesystems keyboard)' \
+  "$profile/airootfs/etc/mkinitcpio.conf.d/archiso.conf" ||
+  fail "microcode and memdisk hooks are dropped" "$(cat "$profile/airootfs/etc/mkinitcpio.conf.d/archiso.conf")"
+for cfg in grub.cfg loopback.cfg; do
+  grep -q 'linux /%INSTALL_DIR%/boot/%ARCH%/Image ' "$profile/grub/$cfg" ||
+    fail "$cfg boots ALARM's kernel" "$(grep -n 'linux /' "$profile/grub/$cfg")"
+  grep -q 'initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img' "$profile/grub/$cfg" ||
+    fail "$cfg loads ALARM's initramfs" "$(grep -n 'initrd ' "$profile/grub/$cfg")"
+  ! grep -q 'linux-t2' "$profile/grub/$cfg" || fail "$cfg no longer mentions linux-t2"
+done
+pass "aarch64 profile rewrite"
+
+x86_profile="$work/x86-profile"
+make_profile "$x86_profile"
+cp -R "$x86_profile" "$work/x86-before"
+(
+  export OMARCHY_ARCH=x86_64 OMARCHY_MIRROR=stable OMARCHY_SETTINGS_PACKAGE=omarchy-settings
+  source "$ROOT/builder/architecture.sh"
+  prepare_media_profile "$x86_profile"
+  prepare_mkarchiso
+)
+diff -r "$work/x86-before" "$x86_profile" >/dev/null || fail "x86_64 profile is untouched" "$(diff -r "$work/x86-before" "$x86_profile")"
+pass "x86_64 profile is untouched"
+
+# ------------------------------------------------------------- mkarchiso
+
+patch=$ROOT/builder/archiso-aarch64.patch
+grep -Fq 'kernel_images=("${pacstrap_dir}/boot/Image")' "$patch" || fail "patch copies /boot/Image as the kernel"
+grep -Fq 'efiboot_files+=("${work_dir}/BOOT${uefi_arch[$arch]}.EFI")' "$patch" || fail "patch makes edk2-shell optional"
+grep -Fq 'required_grubmodules=(configfile iso9660 linux normal search search_fs_uuid)' "$patch" ||
+  fail "patch keeps the GRUB modules the ISO cannot boot without"
+if [[ -f $ROOT/archiso/archiso/mkarchiso ]]; then
+  cp "$ROOT/archiso/archiso/mkarchiso" "$work/mkarchiso"
+  patch --forward --silent "$work/mkarchiso" "$patch" || fail "patch applies to the pinned archiso"
+  pass "archiso-aarch64.patch applies to the archiso submodule"
+else
+  pass "archiso-aarch64.patch is intact (submodule not checked out, apply skipped)"
+fi
+grep -Fq 'prepare_mkarchiso' "$ROOT/builder/build-iso.sh" || fail "build-iso.sh prepares mkarchiso"
+grep -Fq '"${MKARCHISO[@]}" -v -w' "$ROOT/builder/build-iso.sh" || fail "build-iso.sh runs the selected mkarchiso"
+
+# ------------------------------------------------------------ profiledef
+
+profile_values() {
+  (
+    export OMARCHY_ARCH=$1 SOURCE_DATE_EPOCH=0
+    declare -A file_permissions=()
+    source "$ROOT/configs/profiledef.sh"
+    printf '%s|%s|%s\n' "$arch" "${bootmodes[*]}" "${airootfs_image_tool_options[*]}"
+  )
+}
+arm_values=$(profile_values aarch64)
+[[ $arm_values == "aarch64|uefi.grub|-comp xz "* && $arm_values != *zstd* ]] ||
+  fail "aarch64 profile is UEFI-only with an xz squashfs" "$arm_values"
+x86_values=$(profile_values x86_64)
+[[ $x86_values == "x86_64|bios.syslinux uefi.grub|-comp zstd -Xcompression-level 19 -b 1M -action uncompressed@subpathname(var/cache/omarchy/mirror/offline)" ]] ||
+  fail "x86_64 profile is unchanged" "$x86_values"
+unset_values=$(
+  unset OMARCHY_ARCH
+  profile_values "" 2>/dev/null || true
+)
+[[ $unset_values == "x86_64|"* ]] || fail "profiledef defaults to x86_64 without OMARCHY_ARCH" "$unset_values"
+pass "profiledef per-arch bootmodes and squashfs compression"
+
+# ------------------------------------------------------------ pacman conf
+
+arm_conf=$ROOT/configs/pacman-online-arm.conf
+grep -Fxq 'Architecture = aarch64' "$arm_conf" || fail "ARM pacman config pins aarch64"
+for repo in core extra alarm aur omarchy; do
+  grep -Fxq "[$repo]" "$arm_conf" || fail "ARM pacman config has [$repo]"
+done
+! grep -v '^#' "$arm_conf" | grep -q 'arch-mact2\|file://' || fail "ARM pacman config has no T2 or local repos"
+pass "ARM pacman config"

--- a/test/unit/test_arm_limine.py
+++ b/test/unit/test_arm_limine.py
@@ -1,0 +1,107 @@
+#!/usr/bin/python
+#
+# The installer runs on the live ISO and must pick the Limine EFI binary and
+# kernel for the machine it is running on rather than assuming x86_64.
+
+import os
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "configs/airootfs/usr/share/omarchy-iso"))
+# phases_impl imports the archinstall adapter, which needs archinstall itself;
+# none of the helpers under test touch it.
+sys.modules.setdefault(
+    "orchestrator.archinstall_adapter", types.ModuleType("orchestrator.archinstall_adapter")
+)
+
+from orchestrator import context, phases_impl  # noqa: E402
+
+CONFIGURATOR = ROOT / "configs/airootfs/root/configurator"
+
+
+def run_configurator_snippet(machine: str, snippet: str) -> subprocess.CompletedProcess:
+    """Run a fragment of the configurator with uname reporting `machine`."""
+    with tempfile.TemporaryDirectory() as directory:
+        fake_uname = Path(directory) / "uname"
+        fake_uname.write_text(f"#!/bin/bash\necho {machine}\n")
+        fake_uname.chmod(0o755)
+        env = dict(os.environ, PATH=f"{directory}:{os.environ['PATH']}")
+        return subprocess.run(
+            ["bash", "-c", snippet], capture_output=True, text=True, env=env
+        )
+
+
+def configurator_block(start: str, end: str) -> str:
+    text = CONFIGURATOR.read_text()
+    begin = text.index(start)
+    return text[begin : text.index(end, begin) + len(end)]
+
+
+class LimineEfiNamesTest(unittest.TestCase):
+    def test_aarch64_uses_aa64_efi_binary(self):
+        for machine in ("aarch64", "arm64"):
+            with self.subTest(machine=machine):
+                self.assertEqual(
+                    phases_impl._limine_efi_names(machine),
+                    ("BOOTAA64.EFI", "limine_aa64.efi", "BOOTAA64.EFI"),
+                )
+
+    def test_x86_64_keeps_x64_efi_binary(self):
+        self.assertEqual(
+            phases_impl._limine_efi_names("x86_64"),
+            ("BOOTX64.EFI", "limine_x64.efi", "BOOTX64.EFI"),
+        )
+
+    def test_unknown_machine_is_refused(self):
+        with self.assertRaises(RuntimeError):
+            phases_impl._limine_efi_names("riscv64")
+
+    def test_running_machine_is_the_default(self):
+        fake = os.uname_result(("Linux", "host", "6.0", "#1", "aarch64"))
+        with patch.object(phases_impl.os, "uname", return_value=fake):
+            self.assertEqual(phases_impl._limine_efi_names()[1], "limine_aa64.efi")
+
+    def test_default_omarchy_install_leaves_efi_binary_to_the_machine(self):
+        # The configurator writes efi_binary explicitly; the fallback intent for
+        # a JSON without it must not pin x86_64 either.
+        default = context._default_omarchy_install({})
+        self.assertNotIn("efi_binary", default["boot"])
+        self.assertEqual(default["boot"]["esp_path"], "/EFI/limine")
+
+
+class ConfiguratorArchitectureTest(unittest.TestCase):
+    def test_limine_binary_follows_uname(self):
+        block = configurator_block('case "$(uname -m)" in', "esac")
+        snippet = block + '\nprintf "%s" "$LIMINE_EFI_BINARY"'
+        self.assertEqual(run_configurator_snippet("aarch64", snippet).stdout, "limine_aa64.efi")
+        self.assertEqual(run_configurator_snippet("x86_64", snippet).stdout, "limine_x64.efi")
+        unsupported = run_configurator_snippet("riscv64", snippet)
+        self.assertNotEqual(unsupported.returncode, 0)
+        self.assertIn("unsupported Limine EFI architecture", unsupported.stderr)
+
+    def test_configurator_json_names_the_selected_binary(self):
+        text = CONFIGURATOR.read_text()
+        self.assertNotIn('"efi_binary": "limine_x64.efi"', text)
+        self.assertEqual(text.count('"efi_binary": "$LIMINE_EFI_BINARY"'), 2)
+
+    def test_detect_kernel_picks_the_alarm_kernel_on_aarch64(self):
+        block = configurator_block("detect_kernel() {", "\n}\n")
+        snippet = "lspci() { return 1; }\n" + block + "\ndetect_kernel"
+        self.assertEqual(run_configurator_snippet("aarch64", snippet).stdout.strip(), "linux-aarch64")
+        self.assertEqual(run_configurator_snippet("x86_64", snippet).stdout.strip(), "linux")
+
+    def test_logo_animation_is_optional(self):
+        # ttfx is not packaged on Arch Linux ARM; both scripts must cope.
+        self.assertIn("if command -v ttfx >/dev/null; then", CONFIGURATOR.read_text())
+        dashboard = ROOT / "configs/airootfs/usr/local/bin/omarchy-install-dashboard"
+        self.assertIn("&& command -v ttfx >/dev/null; then", dashboard.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_keyboard.py
+++ b/test/unit/test_keyboard.py
@@ -5,6 +5,8 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -45,29 +47,57 @@ class KeyboardConfigurationTest(unittest.TestCase):
         (target / "etc/vconsole.conf").write_text(
             "KEYMAP=us\nFONT=default8x16\n"
         )
+        keymap = target / "usr/share/kbd/keymaps/i386/qwerty/us.map.gz"
+        keymap.parent.mkdir(parents=True)
+        keymap.touch()
         return target
+
+    def test_uses_target_keymap_catalog_without_host_localectl(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = self.target(directory)
+            keymap = target / "usr/share/kbd/keymaps/i386/qwerty/us.map.gz"
+            keymap.parent.mkdir(parents=True, exist_ok=True)
+            keymap.touch()
+
+            def run_firstboot(command):
+                self.assertEqual(command[0], "systemd-firstboot")
+                (target / "etc/vconsole.conf").write_text("KEYMAP=us\nXKBLAYOUT=us\n")
+                return CompletedProcess(command, 0, "", "")
+
+            with patch.object(KEYBOARD, "capture", side_effect=run_firstboot) as capture:
+                self.assertTrue(KEYBOARD.configure_keyboard(target, "us"))
+
+            capture.assert_called_once()
 
     def test_writes_keymap_and_xkb_settings_and_preserves_font(self):
         # XKBLAYOUT is load-bearing: omarchy's detect-keyboard-layout.sh copies
         # it into Hyprland's kb_layout on the installed system.
         with tempfile.TemporaryDirectory() as directory:
             target = self.target(directory)
-            self.assertTrue(KEYBOARD.configure_keyboard(target, "us"))
+
+            def run_firstboot(command):
+                (target / "etc/vconsole.conf").write_text(
+                    "KEYMAP=us\nXKBLAYOUT=us\n"
+                )
+                return CompletedProcess(command, 0, "", "")
+
+            with patch.object(KEYBOARD, "capture", side_effect=run_firstboot):
+                self.assertTrue(KEYBOARD.configure_keyboard(target, "us"))
             lines = (target / "etc/vconsole.conf").read_text().splitlines()
             self.assertIn("KEYMAP=us", lines)
             self.assertIn("XKBLAYOUT=us", lines)
             self.assertEqual(lines.count("FONT=default8x16"), 1)
 
-    def test_all_configurator_keymaps_are_known_to_localectl(self):
+    def test_all_configurator_keymaps_are_in_installed_kbd_catalog(self):
         if SUPPORTED_KEYMAPS is None:
             self.skipTest("no Omarchy runtime checkout to read the layout list from")
+        try:
+            installed = KEYBOARD._installed_keymaps(Path("/"))
+        except RuntimeError:
+            self.skipTest("no host kbd keymap catalog")
         for keymap in SUPPORTED_KEYMAPS:
-            with self.subTest(keymap=keymap), tempfile.TemporaryDirectory() as directory:
-                target = self.target(directory)
-                self.assertTrue(KEYBOARD.configure_keyboard(target, keymap))
-                lines = (target / "etc/vconsole.conf").read_text().splitlines()
-                self.assertIn(f"KEYMAP={keymap}", lines)
-                self.assertEqual(lines.count("FONT=default8x16"), 1)
+            with self.subTest(keymap=keymap):
+                self.assertIn(keymap.casefold(), installed)
 
     def test_unknown_and_empty_keymaps_match_archinstall_behavior(self):
         for keymap, expected in (("definitely-not-a-keymap", False), ("", True)):

--- a/test/unit/test_run_manifest.py
+++ b/test/unit/test_run_manifest.py
@@ -1,0 +1,291 @@
+"""Unit tests for test/run-manifest.py, the lane runner behind test/all.
+
+Every fixture is a throwaway script under a temp directory laid out like the
+repository, so the runner is driven exactly as test/all drives it. The process
+group cases matter most: a timed-out or cancelled test must take its children
+with it, and a test that exits 0 while leaving a background process behind is
+a failure, not a pass, because the next test would inherit it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import signal
+import sys
+import tempfile
+import time
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "test/run-manifest.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("run_manifest", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {MODULE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class RunManifestTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.module = load_module()
+
+    def make_script(self, root: Path, name: str, content: str) -> str:
+        relative = f"test/unit/{name}"
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("#!/bin/bash\nset -euo pipefail\n" + content)
+        return relative
+
+    def assert_process_exits(self, pid: int) -> None:
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                return
+            time.sleep(0.02)
+        self.fail(f"process {pid} survived test cancellation")
+
+    def test_timeout_terminates_the_entire_fixture_process_group(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            relative = self.make_script(
+                root,
+                "timeout-fixture-test.sh",
+                'sleep 60 &\nchild=$!\nprintf "%s\\n" "$child" > test/unit/child.pid\nwait "$child"\n',
+            )
+
+            result = self.module.execute(
+                root,
+                relative,
+                timeout_seconds=0.2,
+            )
+
+            self.assertEqual(result.status, "timed-out")
+            self.assertEqual(result.returncode, self.module.TIMEOUT_RETURNCODE)
+            child_pid = int((root / "test/unit/child.pid").read_text())
+            self.assert_process_exits(child_pid)
+
+    def test_timeout_escalates_to_kill_a_sigterm_resistant_descendant(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            relative = self.make_script(
+                root,
+                "resistant-fixture-test.sh",
+                "(\n"
+                "  trap '' TERM\n"
+                "  exec >/dev/null 2>&1\n"
+                "  while true; do sleep 60; done\n"
+                ") &\n"
+                "child=$!\n"
+                'printf "%s\\n" "$child" > test/unit/resistant.pid\n'
+                'wait "$child"\n',
+            )
+
+            result = self.module.execute(
+                root,
+                relative,
+                timeout_seconds=0.2,
+            )
+
+            self.assertEqual(result.status, "timed-out")
+            child_pid = int((root / "test/unit/resistant.pid").read_text())
+            self.assert_process_exits(child_pid)
+
+    def test_parallel_failure_cancels_a_running_sibling_process_group(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            slow = self.make_script(
+                root,
+                "slow-fixture-test.sh",
+                'sleep 60 &\nchild=$!\nprintf "%s\\n" "$child" > test/unit/sibling.pid\nwait "$child"\n',
+            )
+            failing = self.make_script(
+                root,
+                "failing-fixture-test.sh",
+                "for ((attempt=0; attempt<200; attempt++)); do\n"
+                "  [[ -s test/unit/sibling.pid ]] && exit 7\n"
+                "  sleep 0.01\n"
+                "done\n"
+                "exit 8\n",
+            )
+
+            results = self.module.run_parallel(
+                root,
+                [slow, failing],
+                jobs=2,
+                timeout_seconds=5.0,
+            )
+
+            self.assertEqual([result.path for result in results], [slow, failing])
+            self.assertEqual(results[0].status, "cancelled")
+            self.assertEqual(results[1].status, "failed")
+            sibling_pid = int((root / "test/unit/sibling.pid").read_text())
+            self.assert_process_exits(sibling_pid)
+
+    def test_successful_parent_cannot_leave_a_background_process(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            relative = self.make_script(
+                root,
+                "leaking-success-fixture-test.sh",
+                "(\n"
+                "  trap '' TERM\n"
+                "  exec </dev/null >/dev/null 2>&1\n"
+                "  while true; do sleep 60; done\n"
+                ") &\n"
+                "child=$!\n"
+                'printf "%s\n" "$child" > test/unit/leaked.pid\n'
+                "exit 0\n",
+            )
+
+            result = self.module.execute(root, relative, timeout_seconds=2.0)
+            leaked_pid = int((root / "test/unit/leaked.pid").read_text())
+            try:
+                self.assertEqual(result.status, "failed")
+                self.assertIn("left a process group running", result.stderr)
+                self.assert_process_exits(leaked_pid)
+            finally:
+                try:
+                    leaked_group = os.getpgid(leaked_pid)
+                except ProcessLookupError:
+                    pass
+                else:
+                    os.killpg(leaked_group, signal.SIGKILL)
+
+    def test_a_test_missing_from_both_manifests_is_an_error(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            listed = self.make_script(root, "listed-test.sh", "exit 0\n")
+            self.make_script(root, "forgotten-test.sh", "exit 0\n")
+
+            with self.assertRaisesRegex(self.module.ManifestError, "forgotten-test.sh"):
+                self.module.validate(root, [listed], [])
+
+    def test_a_manifest_entry_without_a_file_is_an_error(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            listed = self.make_script(root, "listed-test.sh", "exit 0\n")
+
+            with self.assertRaisesRegex(self.module.ManifestError, "gone-test.sh"):
+                self.module.validate(root, [listed], ["test/unit/gone-test.sh"])
+
+    def test_a_test_in_both_manifests_is_an_error(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            listed = self.make_script(root, "listed-test.sh", "exit 0\n")
+
+            with self.assertRaisesRegex(self.module.ManifestError, "duplicate"):
+                self.module.validate(root, [listed], [listed])
+
+    def test_the_checked_in_manifests_cover_every_unit_test(self) -> None:
+        parallel = self.module.read_manifest(ROOT / "test/parallel-safe.tests")
+        serial = self.module.read_manifest(ROOT / "test/serial.tests")
+
+        self.module.validate(ROOT, parallel, serial)
+
+    def test_ledger_is_ordered_and_contains_elapsed_result_and_worker_count(self) -> None:
+        parallel_results = [
+            self.module.Result("test/unit/b-test.sh", 0, "", "", 0.1254, "passed"),
+            self.module.Result("test/unit/a-test.sh", 1, "", "", 0.3756, "failed"),
+        ]
+        serial_results = [
+            self.module.Result("test/unit/c-test.sh", 130, "", "", 0.0, "cancelled")
+        ]
+        ledger = self.module.build_result_ledger(
+            run_id="run-1",
+            started_at="2026-08-29T00:00:00.000000Z",
+            completed_at="2026-08-29T00:00:01.000000Z",
+            requested_jobs=10,
+            parallel_worker_count=2,
+            timeout_seconds=300.0,
+            parallel_results=parallel_results,
+            serial_results=serial_results,
+        )
+
+        self.assertEqual(ledger["requested_worker_count"], 10)
+        self.assertEqual(ledger["parallel_worker_count"], 2)
+        self.assertEqual(ledger["schema_version"], 1)
+        self.assertEqual(ledger["run_id"], "run-1")
+        self.assertEqual(ledger["started_at"], "2026-08-29T00:00:00.000000Z")
+        self.assertEqual(ledger["completed_at"], "2026-08-29T00:00:01.000000Z")
+        self.assertEqual(ledger["result"], "failed")
+        self.assertEqual(
+            [record["path"] for record in ledger["tests"]],
+            ["test/unit/b-test.sh", "test/unit/a-test.sh", "test/unit/c-test.sh"],
+        )
+        self.assertEqual(ledger["tests"][0]["elapsed_seconds"], 0.125)
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ledger.json"
+            self.module.write_result_ledger(path, ledger)
+            self.assertEqual(json.loads(path.read_text()), ledger)
+
+    def test_result_ledger_lease_blocks_a_concurrent_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ledger.json"
+            first = self.module.acquire_result_ledger_lease(path, "run-1")
+            try:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "another test runner owns the result ledger",
+                ):
+                    self.module.acquire_result_ledger_lease(path, "run-2")
+            finally:
+                self.module.release_result_ledger_lease(first)
+
+            second = self.module.acquire_result_ledger_lease(path, "run-3")
+            self.module.release_result_ledger_lease(second)
+
+    def test_python_fixture_with_no_collected_tests_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            relative = "test/unit/test_empty_fixture.py"
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("VALUE = 1\n")
+
+            result = self.module.execute(root, relative, timeout_seconds=2.0)
+
+            self.assertEqual(result.status, "failed")
+            self.assertEqual(result.returncode, 3)
+            self.assertIn("no unittest cases collected", result.stderr)
+
+    def test_python_fixture_with_a_collected_test_runs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            relative = "test/unit/test_collected_fixture.py"
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                "import unittest\n\n"
+                "class CollectedTest(unittest.TestCase):\n"
+                "    def test_runs(self):\n"
+                "        self.assertTrue(True)\n"
+            )
+
+            result = self.module.execute(root, relative, timeout_seconds=2.0)
+
+            self.assertEqual(result.status, "passed", result.stderr)
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("Ran 1 test", result.stderr)
+
+    def test_non_finite_timeouts_are_rejected(self) -> None:
+        for value in ("nan", "inf", "-inf", "0", "-1"):
+            with self.subTest(value=value):
+                with self.assertRaises(Exception):
+                    self.module.positive_float(value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the `x86_64/pc` and `aarch64/generic` targets from `plans/aarch64-support.md`. `omarchy-iso-make --arch aarch64` builds a bootable generic ARM64 ISO in an Arch Linux ARM container. The default stays `x86_64`, and every new branch is gated on the architecture, so x86_64 builds are unchanged.

Stacked on #148 (the new tests need manifest entries). Only the last commit is this PR.

## What changed

**Architecture selection** moves out of `build-iso.sh` into two sourced files.
- `builder/architecture.sh` validates `OMARCHY_ARCH:OMARCHY_MEDIA_TARGET`, exports the platform, boot backend, live kernel names and the mkarchiso command, and prepares the releng profile for aarch64: `packages.aarch64`, a generated `linux-aarch64` preset, no microcode or memdisk hooks, GRUB pointed at `Image` and `initramfs-linux.img`.
- `builder/package-architecture.sh` picks the keyring, Node dist arch, pacman config and package lists per architecture, and filters x86-only packages (microcode, `tzupdate`) out of the shipped lists on aarch64, mapping `linux` to `linux-aarch64`.
- `build-iso.sh` stays one linear script and calls these. On x86_64 the new calls are no-ops.

**Build entry point.** `omarchy-iso-make` gains `--arch`. On aarch64 it runs the build under `--platform linux/arm64` in an Arch Linux ARM image, scopes the offline mirror cache per architecture (the x86_64 directory keeps its name) and picks up `*-aarch64.iso`. The sudo-docker fallback is kept.

**Profile.** `profiledef.sh` reads the arch from the environment, uses `uefi.grub` only on aarch64, and switches squashfs to xz there because the generic ARM kernel does not enable squashfs zstd. `builder/archiso-aarch64.patch` is applied to the submodule's `mkarchiso` for aarch64 builds.

**Installer made architecture-agnostic.** The configurator picks the limine EFI binary from `uname -m`, detects `linux-aarch64` as the kernel and guards `ttfx` behind `command -v`. The orchestrator derives the EFI binary names from the machine instead of hard-coding `limine_x64.efi`. Keyboard selection reads the kbd catalog from the target instead of running `localectl`, which needs PID 1.

**Test harness.** `omarchy-iso-test` boots aarch64 ISOs with `edk2-armvirt` on a `virt` machine (HVF on macOS, KVM on Linux) and infers the guest arch from the ISO name.

## What it does not do

- `configs/pacman-online-arm.conf` points `[omarchy]` at `pkgs.omarchy.org/$arch`. That tree does not exist for aarch64 yet (omacom/omarchy-pkgs#277, #199), so an aarch64 online install cannot complete until it is published. The offline mirror build path is unaffected.
- No Apple Silicon image. That is a separate PR once the generic target is in.
- `omarchy-iso-boot`, `omarchy-vm` and `omarchy-iso-release` are not arch-aware yet; the status table in `plans/aarch64-support.md` lists them.

## Testing

- New unit tests: `architecture-selector-test.sh` (5), `arm-profile-test.sh` (10), `test_arm_limine.py`; `test_keyboard.py` updated. All pass locally; `test/all` in CI.
- `builder/packages.aarch64-exclude` is the list of packages that do not resolve on aarch64 today, split into x86-only hardware support and not-yet-built; it is the per-arch package list question in concrete form.
- The archiso patch was verified to apply cleanly against the pinned archiso v87 `mkarchiso`.
- The x86_64 path is untouched by construction. A real aarch64 ISO was built from this branch on an Apple Silicon host and boots to the live login prompt under QEMU; details in the first comment.
