### PR TITLE
Fix omarchy-vm boot helper path

### DIFF
--- a/bin/omarchy-vm
+++ b/bin/omarchy-vm
@@ -126,7 +126,7 @@ boot_vm() {
 
   gum style --foreground 212 "✓ VM ready. Booting..."
 
-  exec omarchy-iso-boot "${boot_args[@]}" /dev/null reuse
+  exec "$SCRIPT_DIR/omarchy-iso-boot" "${boot_args[@]}" /dev/null reuse
 }
 
 command="${1:-}"


### PR DESCRIPTION
## Summary

- resolve `omarchy-iso-boot` relative to the `omarchy-vm` script directory

Before the fix:

```
> ./omarchy-vm boot                                                  
Copying VM 'test' to /tmp/omarchy-iso-boot.qcow2...
✓ VM ready. Booting...
./omarchy-vm: line 129: exec: omarchy-iso-boot: not found
```

## Testing

- `bash -n bin/omarchy-vm`
- `bin/omarchy-vm` boot should work