### PR TITLE
Generate cidata configs with omarchy-iso-configurator

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ The shipped ISO installs itself with no keyboard when it finds its configuration
 
 ### Configuration files
 
-These are the configurator's own output files, so the way to get a starting set is to run one interactive install and copy what it wrote into `/root`.
+These are the configurator's own output files. Generate them with:
+
+```bash
+./bin/omarchy-iso-configurator --output-dir cidata
+```
+
+The other way to get a starting set is to run one interactive install and copy what it wrote into `/root`.
 
 | File | Required | Purpose |
 |------|----------|---------|
@@ -65,8 +71,6 @@ When `tailscale_authkey` is present (one key, blank lines and `#` comments ignor
 ### Building the drive
 
 ```bash
-mkdir cidata
-cp user_configuration.json user_credentials.json authorized_keys cidata/
 genisoimage -output cidata.iso -volid cidata -joliet -rock cidata/
 ```
 
@@ -92,7 +96,14 @@ Encrypted autoinstalls are not fully unattended — the LUKS passphrase prompt s
 
 ## Testing the ISO
 
-Run `./bin/omarchy-iso-boot [release/omarchy.iso]`.
+Run `./bin/omarchy-iso-boot [release/omarchy.iso]`. To perform an unattended
+installation and provision SSH for the installed user, generate the
+configurator files and attach their directory:
+
+```bash
+./bin/omarchy-iso-configurator --output-dir cidata
+./bin/omarchy-iso-boot --cidata-dir cidata release/omarchy.iso
+```
 
 Run `./test/all` for the fast, VM-free tests under `test/unit/`, which cover cidata autoinstall loading and the orchestrator's phases without needing a built ISO.
 

--- a/bin/omarchy-iso-configurator
+++ b/bin/omarchy-iso-configurator
@@ -2,6 +2,49 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+configurator="$repo_root/configs/airootfs/root/configurator"
+output_dir=""
+output_requested=false
+
+usage() {
+  cat <<USAGE
+Usage: omarchy-iso-configurator [--output-dir DIR]
+
+Options:
+  --output-dir DIR  Interactively generate cidata config for omarchy-iso-boot VM
+  -h, --help        Show this help
+
+With no options, run the configurator preview.
+USAGE
+}
+
+fail() {
+  echo "omarchy-iso-configurator: $*" >&2
+  exit 1
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    --output-dir)
+      [[ $# -ge 2 ]] || fail "--output-dir requires a directory"
+      output_dir="$2"
+      output_requested=true
+      shift 2
+      ;;
+    --output-dir=*)
+      output_dir="${1#*=}"
+      output_requested=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unexpected argument: $1"
+      ;;
+  esac
+done
 
 if [[ -z "${OMARCHY_PATH:-}" ]]; then
   for candidate in "$repo_root/../omarchy-installer" "$repo_root/../omarchy" /usr/share/omarchy; do
@@ -12,5 +55,63 @@ if [[ -z "${OMARCHY_PATH:-}" ]]; then
   done
 fi
 
-# Do a dry-run of the configurator to show the flow without having to do a real installation
-exec bash "$repo_root/configs/airootfs/root/configurator" dry "$@"
+if ! $output_requested; then
+  exec bash "$configurator" dry
+fi
+
+[[ -n $output_dir ]] || fail "--output-dir requires a non-empty directory"
+[[ ! -e $output_dir || -d $output_dir ]] || fail "output path is not a directory: $output_dir"
+
+managed_files=(
+  user_configuration.json
+  user_credentials.json
+  user_full_name.txt
+  user_email_address.txt
+  user_encrypt_installation.txt
+)
+
+existing_files=()
+for file in "${managed_files[@]}"; do
+  [[ -e $output_dir/$file ]] && existing_files+=("$file")
+done
+
+if ((${#existing_files[@]})); then
+  printf 'The following files already exist in %s:\n' "$output_dir"
+  printf '  %s\n' "${existing_files[@]}"
+  if ! gum confirm --default=false "Replace these generated config files?"; then
+    echo "Canceled; existing files were left unchanged."
+    exit 1
+  fi
+fi
+
+umask 077
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/omarchy-cidata-config.XXXXXX")
+cleanup() {
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT
+
+# The configurator writes relative to its working directory. Stage everything
+# away from the destination so canceling or failing the wizard cannot leave a
+# partial cidata configuration behind.
+(
+  cd "$work_dir"
+  bash "$configurator" cidata
+)
+
+for file in "${managed_files[@]}"; do
+  [[ -f $work_dir/$file ]] || fail "configurator did not generate $file"
+done
+
+if [[ ! -d $output_dir ]]; then
+  install -d -m 0700 -- "$output_dir"
+fi
+[[ -d $output_dir ]] || fail "output path is not a directory: $output_dir"
+
+for file in "${managed_files[@]}"; do
+  install -m 0600 -- "$work_dir/$file" "$output_dir/$file"
+done
+
+echo
+echo "Generated cidata configuration in $output_dir"
+printf '  %s\n' "${managed_files[@]}"

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -7,6 +7,20 @@ OMARCHY_PATH="${OMARCHY_PATH:-/usr/share/omarchy}"
 OMARCHY_RUNTIME_PACKAGE="${OMARCHY_RUNTIME_PACKAGE:-omarchy}"
 OMARCHY_SETTINGS_PACKAGE="${OMARCHY_SETTINGS_PACKAGE:-omarchy-settings}"
 
+configurator_mode="${1:-install}"
+case "$configurator_mode" in
+  install|dry)
+    cidata_generation=false
+    ;;
+  cidata)
+    cidata_generation=true
+    ;;
+  *)
+    echo "ERROR: unknown configurator mode: $configurator_mode" >&2
+    exit 1
+    ;;
+esac
+
 LOGO_PATH="$OMARCHY_PATH/logo.txt"
 
 # The setup form — keyboard, account, hostname, and timezone questions, plus the
@@ -984,6 +998,45 @@ confirm_disk_overwrite() {
   done
 }
 
+confirm_cidata_generation() {
+  local mode="encrypted"
+  local affirmative confirm_status
+
+  while true; do
+    clear_logo
+    echo
+    say "Generate autoinstall config for a Omarchy VM created with bin/omarchy-iso-boot."
+
+    if [[ $mode == "encrypted" ]]; then
+      say --foreground 8 "Press Ctrl+C for unencrypted install."
+      affirmative="Yes, generate config"
+    else
+      affirmative="Yes, generate unencrypted config"
+    fi
+
+    echo
+    gum confirm --affirmative "$affirmative" --negative "Cancel" \
+      "Generate cidata configuration?"
+    confirm_status=$?
+
+    case $confirm_status in
+      0)
+        [[ $mode == "encrypted" ]] && encrypt_installation=true || encrypt_installation=false
+        return 0
+        ;;
+      1)
+        return 1
+        ;;
+      130)
+        [[ $mode == "encrypted" ]] && mode="unencrypted" || mode="encrypted"
+        ;;
+      *)
+        return "$confirm_status"
+        ;;
+    esac
+  done
+}
+
 # Decide what and how to install: sets install_target (full_disk|free_space),
 # install_target and encrypt_installation. Nothing is written to disk yet —
 # the user step runs between this and the execution below. (deferred provisioning never
@@ -1065,7 +1118,13 @@ if $defer_provisioning; then
   # first-boot OOBE (omarchy-provision-owner).
   hostname="omarchy"
   timezone="UTC"
+fi
 
+if $cidata_generation; then
+  disk="/dev/vda"
+  install_target="full_disk"
+  confirm_cidata_generation || exit $?
+elif $defer_provisioning; then
   # Jump straight to disk selection + overwrite confirmation (encrypted by
   # default, Ctrl+C toggles unencrypted). deferred provisioning is always a full-disk install.
   disk_form
@@ -1083,16 +1142,20 @@ clear
 write_user_files
 
 if [[ $install_target == "free_space" ]]; then
-  run_partition_execute "$@"
+  run_partition_execute "$configurator_mode"
 
-  if [[ ${1:-} == "dry" ]]; then
+  if [[ $configurator_mode == "dry" ]]; then
     print_dry_run_files
   fi
   exit 0
 fi
 
 # Setup partition layout
-disk_size=$(lsblk -bdno SIZE "$disk")
+if $cidata_generation; then
+  disk_size=$((40 * 1024 * 1024 * 1024))
+else
+  disk_size=$(lsblk -bdno SIZE "$disk")
+fi
 mib=$((1024 * 1024))
 gib=$((mib * 1024))
 disk_size_in_mib=$((disk_size / mib * mib)) # Rounds to nearest MiB
@@ -1104,7 +1167,11 @@ boot_partition_size=$((2 * gib))
 main_partition_start=$((boot_partition_size + boot_partition_start))
 main_partition_size=$((disk_size_in_mib - main_partition_start - gpt_backup_reserve))
 
-kernel_choice=$(detect_kernel)
+if $cidata_generation; then
+  kernel_choice="linux"
+else
+  kernel_choice=$(detect_kernel)
+fi
 
 if [[ $encrypt_installation == true ]]; then
   # Deferred-provisioning installs carry no password: the orchestrator generates a throwaway
@@ -1249,6 +1316,6 @@ cat <<-_EOF_ >user_configuration.json
 }
 _EOF_
 
-if [[ $1 == "dry" ]]; then
+if [[ $configurator_mode == "dry" ]]; then
   print_dry_run_files
 fi


### PR DESCRIPTION
## Summary

- add --output-dir to generate reusable cidata files through the existing interactive configurator
- target the standard 40 GiB /dev/vda disk created by omarchy-iso-boot without selecting a host disk
- stage generated files before publishing them, use private permissions, and confirm replacement of existing managed files
- retain the existing no-argument configurator preview and document the generation flow

Pairs with #154.

## Testing

- ./test/all