### PR TITLE
Claim the removable boot path on the free-space ESP

### DIFF
--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -791,6 +791,13 @@ run_partition_execute() {
     luks_uuid_json="\"$luks_uuid\""
   fi
 
+  # enable_fallback writes the loader to EFI/BOOT/BOOTX64.EFI as well as
+  # EFI/limine. That path is only ever claimed on the Omarchy ESP, which
+  # run_partition_execute just created, wipefs'd and mkfs.fat'd in free
+  # space; the Windows ESP is never mounted here. Firmware that drops or
+  # ignores the "Limine" NVRAM entry (some AMI/MSI boards) still finds the
+  # install through the removable-media path, which is the only route left
+  # when a boot variable does not survive.
   cat <<-_EOF_ >user_configuration.json
 {
     "app_config": null,
@@ -806,7 +813,7 @@ run_partition_execute() {
             "esp_mount": "$esp_mount_in_target",
             "esp_path": "/EFI/limine",
             "efi_binary": "limine_x64.efi",
-            "enable_fallback": false
+            "enable_fallback": true
         },
         "storage": {
             "esp_device": "$efi_dev",

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/context.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/context.py
@@ -185,7 +185,9 @@ def _default_omarchy_install(user_configuration: dict) -> dict[str, Any]:
             "esp_mount": "/boot",
             "esp_path": "/EFI/limine",
             "efi_binary": "limine_x64.efi",
-            "enable_fallback": mode == "full_disk",
+            # Both modes install to an Omarchy-owned ESP, so the removable
+            # path is ours to claim in either. See _boot_intent.
+            "enable_fallback": True,
         },
         "storage": {},
     }

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -756,7 +756,15 @@ def _boot_intent(ctx: InstallContext) -> dict:
     boot.setdefault("esp_mount", "/boot")
     boot.setdefault("esp_path", "/EFI/limine")
     boot.setdefault("efi_binary", "limine_x64.efi")
-    boot.setdefault("enable_fallback", not ctx.is_protected)
+    # Protected installs used to default this off, from a time when a
+    # free-space install could adopt the Windows ESP and claiming
+    # EFI/BOOT/BOOTX64.EFI there would have displaced the Windows loader.
+    # The configurator stopped adopting that ESP in "Always create our own
+    # ESP" (ef3b0e4): protected mode now formats a dedicated FAT32 ESP in
+    # free space, where the removable path is unused and ours to claim. It
+    # is also the only path left when firmware refuses or discards the
+    # "Limine" boot variable, so both modes take it.
+    boot.setdefault("enable_fallback", True)
     return boot
 
 
@@ -1682,15 +1690,59 @@ def validate_boot(ctx: InstallContext) -> None:
         if not any(uki.exists() and uki.stat().st_size for uki in ukis):
             raise RuntimeError(f"{' / '.join(str(uki) for uki in ukis)} missing or empty")
 
-        post = _read_efibootmgr()
-        if not _find_label_entries(post["entries"], "Limine"):
-            raise RuntimeError("no 'Limine' entry registered in efibootmgr")
+        _validate_uefi_boot_routes(esp_mount)
 
     if ctx.is_protected:
         _validate_pre_mounted_filesystems(ctx)
 
     if ctx.defer_provisioning:
         _validate_provisioning_state(ctx)
+
+
+def _validate_uefi_boot_routes(esp_mount: Path) -> None:
+    """Check the two ways firmware can reach this install, and insist on one.
+
+    The named "Limine" boot variable is the route we prefer and the one
+    _register_limine_efi_entry created and read back. The removable path
+    EFI/BOOT/BOOTX64.EFI is the one every UEFI implementation tries when
+    nothing in NVRAM matches, and limine-install deploys it from
+    ENABLE_LIMINE_FALLBACK during finalize_limine_boot.
+
+    Either alone boots the machine, so neither is fatal by itself. Losing
+    both is: that install reboots into whatever else is on the disk with no
+    way back. Firmware that takes the variable at registration and discards
+    it before the install ends is the case worth naming, because nothing
+    else in the install notices.
+    """
+    fallback_binary = esp_mount / "EFI" / "BOOT" / "BOOTX64.EFI"
+    has_fallback = fallback_binary.exists() and fallback_binary.stat().st_size > 0
+    has_entry = bool(_find_label_entries(_read_efibootmgr()["entries"], "Limine"))
+
+    if not has_entry and not has_fallback:
+        raise RuntimeError(
+            "no bootable route to this install: efibootmgr has no 'Limine' entry "
+            f"and {fallback_binary} is missing or empty"
+        )
+
+    if not has_entry:
+        error(
+            "Warning: this firmware discarded the 'Limine' UEFI boot entry during "
+            f"the install. Omarchy still boots from {fallback_binary.name} on its "
+            "own EFI partition. If the machine starts another OS instead, pick the "
+            "Omarchy disk from the firmware boot menu (F11, F12 or Esc on most "
+            "boards), then move it to the top of the firmware's own boot priority "
+            "list. Some AMI/MSI boards ignore the UEFI BootOrder and honour only "
+            "that list."
+        )
+        return
+
+    if not has_fallback:
+        error(
+            f"Warning: {fallback_binary} was not deployed, so this install depends "
+            "on the 'Limine' UEFI boot entry alone. It boots now. If firmware "
+            "later clears NVRAM, reinstall the loader from a live session with "
+            "'limine-install --fallback'."
+        )
 
 
 def _validate_provisioning_state(ctx: InstallContext) -> None:

--- a/test/unit/test_protected_boot_fallback.py
+++ b/test/unit/test_protected_boot_fallback.py
@@ -1,0 +1,199 @@
+"""Unit tests for the removable-media boot route on free-space installs.
+
+A free-space (protected) install puts Omarchy on a dedicated ESP that the
+configurator creates, wipes and formats in free space. Nothing else on the
+disk uses that partition's EFI/BOOT/BOOTX64.EFI, so Omarchy claims it and
+keeps a boot route that survives firmware refusing or discarding the
+"Limine" NVRAM entry.
+
+Covers the install intent that turns the fallback on, the
+ENABLE_LIMINE_FALLBACK line it produces in /etc/default/limine, and
+validate_boot's handling of each combination of the two routes.
+"""
+
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "configs/airootfs/usr/share/omarchy-iso"))
+
+sys.modules.setdefault(
+    "orchestrator.archinstall_adapter", types.ModuleType("orchestrator.archinstall_adapter")
+)
+
+from orchestrator import phases_impl  # noqa: E402
+from orchestrator.context import InstallContext, _default_omarchy_install  # noqa: E402
+
+
+def make_ctx(tmp: Path, omarchy_install: dict) -> InstallContext:
+    return InstallContext(
+        config_path=tmp / "user_configuration.json",
+        creds_path=tmp / "user_credentials.json",
+        full_name="Test User",
+        email="test@example.com",
+        encrypt=False,
+        authorized_keys_path=None,
+        tailscale_authkey_path=None,
+        user_configuration={"disk_config": {"config_type": "pre_mounted_config"}},
+        user_credentials={"users": [{"username": "test"}]},
+        arch_config_path=tmp / "arch_configuration.json",
+        omarchy_install=omarchy_install,
+        target=tmp / "target",
+        omarchy_path=tmp / "omarchy",
+    )
+
+
+PROTECTED_INSTALL = {
+    "mode": "protected",
+    "target_mount": "/mnt",
+    "boot": {
+        "esp_mount": "/boot",
+        "esp_path": "/EFI/limine",
+        "efi_binary": "limine_x64.efi",
+    },
+    "storage": {
+        "esp_device": "/dev/nvme0n1p6",
+        "root_device": "/dev/nvme0n1p7",
+        "root_mapper": "/dev/nvme0n1p7",
+        "luks_uuid": None,
+        "kernel": "linux",
+    },
+}
+
+
+class BootIntentTest(unittest.TestCase):
+    """The fallback is on for a free-space install, not only a full-disk one."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name)
+
+    def test_protected_install_enables_the_fallback_by_default(self):
+        ctx = make_ctx(self.dir, json.loads(json.dumps(PROTECTED_INSTALL)))
+        self.assertTrue(ctx.is_protected)
+        self.assertTrue(phases_impl._boot_intent(ctx)["enable_fallback"])
+
+    def test_full_disk_install_still_enables_the_fallback(self):
+        ctx = make_ctx(self.dir, {"mode": "full_disk", "boot": {}, "storage": {}})
+        self.assertFalse(ctx.is_protected)
+        self.assertTrue(phases_impl._boot_intent(ctx)["enable_fallback"])
+
+    def test_explicit_false_is_still_honoured(self):
+        install = json.loads(json.dumps(PROTECTED_INSTALL))
+        install["boot"]["enable_fallback"] = False
+        ctx = make_ctx(self.dir, install)
+        self.assertFalse(phases_impl._boot_intent(ctx)["enable_fallback"])
+
+    def test_pre_mounted_config_without_omarchy_install_enables_the_fallback(self):
+        default = _default_omarchy_install({"disk_config": {"config_type": "pre_mounted_config"}})
+        self.assertEqual(default["mode"], "protected")
+        self.assertTrue(default["boot"]["enable_fallback"])
+
+
+class LimineDefaultsTest(unittest.TestCase):
+    """The intent has to reach /etc/default/limine, which limine-install reads."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dir = Path(self.tmp.name)
+
+        templates = self.dir / "omarchy" / "default" / "limine"
+        templates.mkdir(parents=True)
+        (templates / "default.conf").write_text(
+            'ESP_PATH="/boot"\n\nKERNEL_CMDLINE[default]+="@@CMDLINE@@"\n'
+        )
+        (templates / "limine.conf").write_text("# limine.conf\n")
+
+        (self.dir / "target" / "boot").mkdir(parents=True)
+
+    def write_defaults(self, install):
+        ctx = make_ctx(self.dir, install)
+        with mock.patch.object(phases_impl, "_blkid_uuid", return_value="dead-beef"), \
+             mock.patch.object(phases_impl.arch, "has_uefi", return_value=True, create=True):
+            phases_impl._write_pre_mounted_limine_defaults(ctx)
+        return (ctx.target / "etc" / "default" / "limine").read_text()
+
+    def test_protected_install_writes_enable_limine_fallback_yes(self):
+        text = self.write_defaults(json.loads(json.dumps(PROTECTED_INSTALL)))
+        self.assertIn("ENABLE_LIMINE_FALLBACK=yes", text)
+        self.assertNotIn("ENABLE_LIMINE_FALLBACK=no", text)
+
+    def test_explicit_false_writes_no(self):
+        install = json.loads(json.dumps(PROTECTED_INSTALL))
+        install["boot"]["enable_fallback"] = False
+        self.assertIn("ENABLE_LIMINE_FALLBACK=no", self.write_defaults(install))
+
+
+class BootRouteValidationTest(unittest.TestCase):
+    """Either route boots the machine; losing both is what must stop the install."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.esp = Path(self.tmp.name) / "esp"
+        self.esp.mkdir(parents=True)
+
+    def write_fallback(self, contents=b"MZ"):
+        path = self.esp / "EFI" / "BOOT" / "BOOTX64.EFI"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(contents)
+        return path
+
+    def validate(self, entries):
+        state = {"entries": entries, "order": list(entries), "raw": ""}
+        with mock.patch.object(phases_impl, "_read_efibootmgr", return_value=state), \
+             mock.patch.object(phases_impl, "error") as warn:
+            phases_impl._validate_uefi_boot_routes(self.esp)
+        return warn
+
+    def test_both_routes_present_is_silent(self):
+        self.write_fallback()
+        warn = self.validate({"0002": "Limine", "0000": "Windows Boot Manager"})
+        warn.assert_not_called()
+
+    def test_discarded_boot_entry_warns_and_names_the_firmware_menu(self):
+        self.write_fallback()
+        warn = self.validate({"0000": "Windows Boot Manager"})
+        warn.assert_called_once()
+        message = warn.call_args[0][0]
+        self.assertIn("discarded", message)
+        self.assertIn("BOOTX64.EFI", message)
+        self.assertIn("boot priority", message)
+
+    def test_missing_fallback_warns_but_does_not_stop_a_registered_install(self):
+        warn = self.validate({"0002": "Limine"})
+        warn.assert_called_once()
+        self.assertIn("BOOTX64.EFI", warn.call_args[0][0])
+
+    def test_empty_fallback_file_does_not_count_as_a_route(self):
+        self.write_fallback(b"")
+        warn = self.validate({"0002": "Limine"})
+        warn.assert_called_once()
+
+    def test_no_route_at_all_stops_the_install(self):
+        state = {"entries": {"0000": "Windows Boot Manager"}, "order": ["0000"], "raw": ""}
+        with mock.patch.object(phases_impl, "_read_efibootmgr", return_value=state):
+            with self.assertRaises(RuntimeError) as caught:
+                phases_impl._validate_uefi_boot_routes(self.esp)
+        self.assertIn("no bootable route", str(caught.exception))
+
+
+class ConfiguratorTest(unittest.TestCase):
+    """The configurator emits the JSON the orchestrator reads, so check it too."""
+
+    def test_free_space_install_config_enables_the_fallback(self):
+        configurator = Path(__file__).resolve().parents[2] / "configs/airootfs/root/configurator"
+        body = configurator.read_text()
+        protected = body[body.index('"mode": "protected"'):]
+        boot_block = protected[protected.index('"boot": {'):protected.index("},", protected.index('"boot": {'))]
+        self.assertIn('"enable_fallback": true', boot_block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A free-space install alongside Windows 11 on an MSI Cubi NUC (AMI firmware) completed, reported success, and left no way to reach Omarchy. The firmware boot menu and a normal restart both went to Windows.

The partitions were all correct. `/dev/nvme0n1p6` was the dedicated Omarchy ESP with Limine under `EFI/limine`, and `/dev/nvme0n1p7` the LUKS root. What was missing was any boot route the firmware would take:

```text
BootCurrent: 0001
BootOrder: 0000,0001
Boot0000* Windows Boot Manager  \EFI\Microsoft\Boot\bootmgfw.efi
Boot0001* UEFI: SanDisk Cruzer Glide
```

No Limine entry. Copying the loader to `EFI/BOOT/BOOTX64.EFI` on that same Omarchy ESP and re-creating the entry made the machine boot, so the install itself was fine. It had nothing the firmware would look at.

## Why the fallback path was off

Free-space installs turn it off on purpose. de0f013 wrote the rule and the reason:

```python
# Free-space installs may share a Windows ESP. Never claim EFI/BOOT as a
# fallback loader in that mode; use the explicit NVRAM entry instead.
default_text = re.sub(r'^ENABLE_LIMINE_FALLBACK=.*$', 'ENABLE_LIMINE_FALLBACK=no', ...)
```

Sound at the time. Claiming `EFI/BOOT/BOOTX64.EFI` on a shared Windows ESP would have displaced the Windows loader.

Eight days later ef3b0e4, "Always create our own ESP", deleted ESP sharing. `run_partition_execute` now creates a partition in free space, runs `wipefs -af` over it and `mkfs.fat -F32` on it, and mounts the Windows ESP nowhere. The premise was gone; the guard stayed. c50d0bc then lifted it into `omarchy_install.boot.enable_fallback` as a plain `false`, and the comment explaining it did not come along.

So the mode most likely to meet crowded or uncooperative NVRAM, and the one where another OS owns the default boot target, is the only mode that declines the path every UEFI implementation tries when nothing in NVRAM matches. Full-disk installs have `ENABLE_LIMINE_FALLBACK=yes` from `omarchy-defaults.conf` and are unaffected.

## What changed

`enable_fallback` is now true for free-space installs, matching full-disk, in the configurator and in both orchestrator defaults. `limine-install` writes `EFI/BOOT/BOOTX64.EFI` alongside `EFI/limine/limine_x64.efi` during `finalize_limine_boot`, and refreshes both on later `limine-update` runs.

`validate_boot` checked only that a "Limine" entry existed in efibootmgr and aborted otherwise. It now looks at both routes. Either alone boots the machine, so neither is fatal by itself, and losing both stops the install with a message that says so. The interesting case is firmware that accepts the entry at registration, passes the read-back in `_register_limine_efi_entry`, and drops it before the install ends. Nothing used to notice. It now warns and points at the firmware boot menu, because some AMI/MSI boards ignore `BootOrder` and honour only their own priority list.

## When the firmware refuses the write

[@JarnDev](https://github.com/omacom-io/omarchy-iso/pull/158#issuecomment-5651806655) pointed out that the first round covered only half of #127. It handled firmware that accepts the entry and discards it later. Firmware that refuses the `--create` outright still aborted the install.

`_register_limine_efi_entry` ran `efibootmgr --create` with `check=True`, from `_configure_limine_boot` inside `arch_install_system`. That is phase 3 of 14. `finalize_limine_boot`, which runs `limine-update` and writes `EFI/BOOT/BOOTX64.EFI`, is phase 7, and `validate_boot` is phase 13. So a machine whose variable store is full raised `CalledProcessError` while the only route that needs no NVRAM was still four phases away, and the new two-route check never got to run.

Registration failures now warn and continue. Three cases:

`--create` exits non-zero. The warning carries efibootmgr's stderr, so `No space left on device` travels with the failure. `BootOrder` is left alone.

`--create` exits 0 and the read-back finds no entry. Same firmware behaviour reported through a different exit code, so it gets the same treatment rather than the `RuntimeError` it used to get.

The `BootOrder` rewrite is refused. This one is a separate NVRAM write and was also `check=True`. The entry exists in this case, so a refusal costs Omarchy its place at the front of the list and not its boot route. It warns and points at the firmware boot menu.

`validate_boot` is left as the single place that decides whether an install is reachable. An install that arrives there with neither route still stops, with a message that says which routes are missing.

On the log: efibootmgr's stderr did already reach the support log, because the dashboard starts the installer with `> >(sanitize_child_output >>"$LOG_FILE") 2>&1`. What it never reached was the failure itself, since `CalledProcessError` carries argv and an exit status and nothing else. That is why #127's traceback names the command and not the reason. The warning now carries both.

### One case this makes worse, and why it is the right trade

An install with `enable_fallback` explicitly set to `false` and a refused `--create` has no route at all. It used to fail at phase 3; it now fails at `validate_boot`, phase 13, after the rest of the install has run. Nothing ships that combination: the configurator writes `true`, both orchestrator defaults are `true`, and full-disk installs inherit `ENABLE_LIMINE_FALLBACK=yes` from `omarchy-defaults.conf`. Getting there takes a hand-edited `user_configuration.json`. Threading the fallback intent down into `_register_limine_efi_entry` would let it fail fast again, at the cost of a parameter through two call sites; say the word and I will add it.

## The Windows ESP is not touched

The fallback lands on the partition `run_partition_execute` created and formatted minutes earlier, so `EFI/BOOT/BOOTX64.EFI` there is empty and unclaimed. Nothing mounts, reads or writes the Windows ESP, and no existing EFI entry is deleted or reordered beyond the `BootOrder` rewrite that was already there. The full-disk path is unchanged.

## On BootOrder

On the machine that prompted this, a valid `Boot0002* Omarchy` with `BootOrder: 0002,0000,0001` still booted Windows on a normal restart, while F11 booted Omarchy. MSI Setup's persistent boot list offered Windows Boot Manager and not Omarchy. I did not find a standards-compliant way to override that from the installer, and the alternative would be editing Windows Boot Manager, which this should not do. It is reported instead. limine-entry-tool's own README documents the same class of board and gives the same remedy, adjusting the boot order in firmware setup.

## Validation

`./test/all` on Arch, which is where the harness runs (Arch's `python` package ships no stdlib `test` module, so the repo's `test` namespace package resolves; on Debian or a pyenv build the stdlib one shadows it and discovery fails before any test runs):

| | tests | result |
|---|---|---|
| quattro | 63 | 2 errors, 1 skipped |
| this branch | 79 | 2 errors, 1 skipped |

Both errors are `test_keyboard.py` calling `localectl` in a container with no systemd as PID 1, present before this change and unrelated to it. All shell tests pass on both. The `this branch` row is the earlier Arch run's count moved from 75 to 79; the second commit's four tests were added and measured on macOS, where the same 50 environment errors appear with and without the change, so the Arch error count is unchanged rather than re-run.

`test/unit/test_protected_boot_fallback.py` adds the 16. Twelve fail against quattro, including the one that matters:

```text
AssertionError: 'ENABLE_LIMINE_FALLBACK=yes' not found in
'ESP_PATH="/boot"\n\nKERNEL_CMDLINE[default]+="root=UUID=... "\nENABLE_LIMINE_FALLBACK=no\n'
```

They cover the install intent, the `/etc/default/limine` line it produces, the configurator JSON, and each combination of the two boot routes in `validate_boot`, including that an explicit `enable_fallback: false` is still honoured and that an empty loader file does not count as a route.

Four of them cover registration. The fake `subprocess.run` they use honours `check=`, so a test asserting "this does not abort the install" fails against a caller that still passes `check=True`. Three of the four do fail against quattro, each with the `CalledProcessError` from #127:

```text
subprocess.CalledProcessError: Command '['efibootmgr', '--create', '--disk', '/dev/nvme0n1',
'--part', '6', '--label', 'Limine', '--loader', '\\EFI\\limine\\limine_x64.EFI',
'--unicode', '--verbose']' returned non-zero exit status 1.
```

The fourth asserts a successful registration still writes `BootOrder` and stays quiet, which passes both ways and is there to catch a regression.

## Not verified

I have not run this end to end on the MSI machine or in a VM. `bin/omarchy-iso-test-windows-disk` already builds the right fixture, a GPT disk with a 512MiB ESP holding `EFI/Microsoft`, a data partition and 64GiB of free space, so whoever verifies this has the disk half ready. It is a standalone helper though, referenced by neither `test/integration` nor `bin/omarchy-iso-test`, and the automated scenarios in `test/integration.d/` run against a `full_disk` cidata install. Wiring a free-space scenario in means driving the configurator's interactive path rather than adding a file, and that plus an x86_64 ISO build and KVM is more than I could stand up here. The reasoning above is from the code and from limine-entry-tool's source, where `limine-update` runs `limine-install --no-efi-register`, the fallback block writes `${ESP_PATH}/EFI/BOOT/BOOTX64.EFI`, and registration is gated separately on `SKIP_UEFI` and `EFI_REGISTER`, so turning the fallback on does not disturb the NVRAM entry. Worth a real dual-boot install before it ships.

## Related

This now covers #127 in both directions, which was the point of @JarnDev's review.

The MSI case that opened this PR is the silent one: registration succeeds, the install reports success, and the entry is gone by the time the machine reboots. #127 is the loud one: `efibootmgr --create` is refused and the install dies at registration, reported on an HP ProBook, a Samsung Galaxy Book and an ASUS Zenbook. The first commit here handles the silent case by guaranteeing the removable route and accepting it in `validate_boot`. The second handles the loud one by letting the install reach that route instead of aborting before it exists.

#126 proposed catching the refusal and writing the fallback as a rescue. It was closed by its author shortly after opening, and the approach here differs: the fallback is not a rescue path written at the point of failure, it is deployed by `limine-install` on every UEFI install, so registration only has to stop aborting.

