### PR TITLE
Preserve Apple EFI data when installing on T1 Macs

### DIFF
--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -419,6 +419,164 @@ detect_kernel() {
   fi
 }
 
+t1_missing_efi_stop() {
+  step "Apple system data is missing"
+  say "This Mac uses an Apple T1 chip, but Omarchy could not read the Apple hardware partition."
+  say "Without its machine-specific data, Omarchy cannot use:"
+  say "  • The Touch Bar, including Esc and the function-key row"
+  say "  • Touch ID"
+  say "  • The FaceTime camera"
+  say "  • The ambient-light sensor"
+  echo
+  say "Omarchy has not changed your disk. Restore the Apple data before installing:"
+  say "  1. Back up anything you need from the internal disk."
+  say "  2. Quit the Omarchy installer."
+  say "  3. Connect the Mac to power."
+  say "  4. Restart and immediately hold Option-Command-R to enter Internet Recovery."
+  say "  5. In Disk Utility, choose View → Show All Devices."
+  say "  6. Select the internal physical disk and erase it using APFS and GUID Partition Map."
+  say "  7. Quit Disk Utility and reinstall macOS."
+  say "  8. Let macOS finish installing and boot once, then retry Omarchy."
+  echo
+  say --foreground 1 "Erasing the physical disk deletes everything currently stored on it."
+  exit 1
+}
+
+t1_efi_inspection_stop() {
+  step "Apple EFI safety check could not finish"
+  say "Omarchy could not safely inspect every EFI partition on the selected disk."
+  say "Your disk has not been changed. Check the disk for filesystem errors, disconnect any unrelated damaged drive, and retry the installation."
+  say "Do not erase or replace an Apple EFI partition to work around this check."
+  exit 1
+}
+
+# A supported T1 machine may use Apple data from any attached disk. Only a
+# candidate on the selected target becomes a protected layout range; other
+# disks are read-only discovery sources and never constrain target geometry.
+t1_prepare_selected_disk() {
+  local scan_status
+  t1_install=false
+  if ! t1_supported_machine; then
+    t1_snapshot_disk=""
+    t1_target_snapshot_ready=false
+    t1_target_has_candidates=false
+    t1_efi_clear_snapshot
+    return 0
+  fi
+
+  if [[ $t1_snapshot_disk == "$disk" ]] && $t1_target_snapshot_ready; then
+    t1_install=true
+    return 0
+  fi
+
+  step "Checking Apple hardware data"
+  if t1_efi_any_candidate_available; then
+    :
+  else
+    scan_status=$?
+    (( scan_status == 2 )) && t1_efi_inspection_stop
+    t1_missing_efi_stop
+  fi
+  if t1_efi_capture_optional_snapshot "$disk" false; then
+    :
+  else
+    scan_status=$?
+    (( scan_status == 2 )) && t1_efi_inspection_stop
+    t1_missing_efi_stop
+  fi
+  t1_snapshot_disk="$disk"
+  t1_target_snapshot_ready=true
+  if (( ${#t1_efi_preserved_devices[@]} > 0 )); then
+    t1_target_has_candidates=true
+  else
+    t1_target_has_candidates=false
+  fi
+  t1_install=true
+}
+
+t1_revalidate_available_data() {
+  t1_efi_any_candidate_available ||
+    disk_abort_hook "Apple hardware data is no longer readable"
+  if (( ${#t1_efi_preserved_devices[@]} > 0 )); then
+    t1_efi_revalidate_snapshot "$disk" ||
+      disk_abort_hook "Apple hardware data changed during partitioning"
+  fi
+}
+
+t1_guard_destructive_partition() {
+  local number="$1" action="$2"
+  $t1_install || return 0
+  t1_efi_destructive_partition_is_safe "$disk" "$number" ||
+    disk_abort_hook "Refusing to $action because it could change preserved Apple hardware data"
+}
+
+# Plan Omarchy's dedicated 2 GiB ESP and root inside the largest contiguous
+# range left after all non-Apple partitions are removed. Nothing is written by
+# this function; it runs before the confirmation screen.
+t1_prepare_whole_disk_layout() {
+  local mib=$((1024 * 1024)) gib=$((1024 * 1024 * 1024))
+  local align=$mib efi_size=$((2 * gib)) minimum=$((32 * gib)) available pt_type
+
+  t1_efi_find_largest_safe_region "$disk" || return 1
+  EFI_START_B=$(( (t1_efi_safe_region_start + align - 1) / align * align ))
+  EFI_END_B=$((EFI_START_B + efi_size))
+  # parted's end coordinate is inclusive. Keep the same aligned gap used by
+  # the existing free-space path, and leave an aligned margin before the next
+  # preserved range (or the backup GPT area).
+  ROOT_START_B=$(( (EFI_END_B + 1 + align - 1) / align * align ))
+  ROOT_END_B=$(( (t1_efi_safe_region_end - align) / align * align ))
+  available=$((ROOT_END_B - EFI_START_B))
+
+  (( ROOT_END_B > ROOT_START_B && available >= minimum )) || return 1
+  t1_efi_destructive_range_is_safe "$EFI_START_B" "$EFI_END_B" || return 1
+  t1_efi_destructive_range_is_safe "$ROOT_START_B" "$ROOT_END_B" || return 1
+
+  if (( ${#t1_efi_preserved_devices[@]} > 0 )); then
+    needs_mklabel=false
+  else
+    pt_type=$(lsblk -dno PTTYPE "$disk" 2>/dev/null) || return 1
+    [[ ${pt_type,,} == gpt ]] && needs_mklabel=false || needs_mklabel=true
+  fi
+  protected_enable_fallback=true
+  esp_mount_in_target=/boot
+  kernel_choice=$(detect_kernel)
+  efi_part_num=""
+  root_part_num=""
+  efi_dev="<assigned at creation>"
+  root_partition_device="<assigned at creation>"
+  root_mapper="/dev/mapper/omarchy_root"
+  return 0
+}
+
+t1_delete_nonpreserved_partitions() {
+  local number
+
+  omarchy-iso-cleanup-disk "$disk" ||
+    disk_abort_hook "Could not release existing users of the install disk"
+  t1_efi_any_candidate_available ||
+    disk_abort_hook "Apple hardware data is no longer readable"
+  t1_efi_capture_optional_snapshot "$disk" ||
+    disk_abort_hook "Could not verify Apple hardware data on the install disk"
+  if (( ${#t1_efi_preserved_devices[@]} > 0 )); then
+    t1_target_has_candidates=true
+  else
+    t1_target_has_candidates=false
+  fi
+  t1_prepare_whole_disk_layout ||
+    disk_abort_hook "Could not create a safe layout around the Apple hardware partition(s)"
+
+  while IFS= read -r number; do
+    [[ -n $number ]] || continue
+    t1_efi_partition_number_is_preserved "$number" && continue
+    t1_guard_destructive_partition "$number" "delete partition $number"
+    disk_step "deleting partition $number" parted --script "$disk" rm "$number"
+  done < <(partition_numbers "$disk")
+
+  partprobe "$disk" 2>/dev/null || true
+  udevadm settle 2>/dev/null || true
+  sync
+}
+
 # wait_for_device lives in disk-partitioning.sh: it now reports failure, and
 # every caller here aborts on it.
 
@@ -431,25 +589,45 @@ disk_abort_hook() {
   umount /mnt/btrfs-root 2>/dev/null || true
   rmdir /mnt/btrfs-root 2>/dev/null || true
   cryptsetup close omarchy_root 2>/dev/null || true
-  rollback_created_parts "$disk"
+  rollback_created_parts "$disk" || true
   abort "$1"
 }
 
 # Save the configurator answers the installer consumes: git identity and
 # encryption choice as plain files, account details as archinstall credentials.
-# Deferred-provisioning installs defer the user to first boot: no credentials, and on encrypted
-# targets the orchestrator generates a throwaway LUKS passphrase itself.
+# Deferred-provisioning installs defer the user to first boot. The ordinary
+# full-disk path lets the orchestrator generate its temporary LUKS key; the T1
+# protected path must generate it here because this process formats LUKS.
 write_user_files() {
   echo "$full_name" >user_full_name.txt
   echo "$email_address" >user_email_address.txt
   printf '%s\n' "$encrypt_installation" >user_encrypt_installation.txt
 
   if $defer_provisioning; then
-    cat <<-_EOF_ >user_credentials.json
+    if $t1_install && [[ $encrypt_installation == true ]]; then
+      if [[ ${1:-} == dry ]]; then
+        password="<generated during installation>"
+      else
+        password=$(openssl rand -base64 32 | tr -d '\n') ||
+          abort "Could not generate the temporary disk-encryption key"
+        [[ -n $password ]] || abort "Could not generate the temporary disk-encryption key"
+      fi
+      local encryption_password_escaped
+      encryption_password_escaped=$(printf '%s' "$password" | jq -Rsa)
+      cat <<-_EOF_ >user_credentials.json
+{
+    "encryption_password": $encryption_password_escaped,
+    "users": []
+}
+_EOF_
+      chmod 600 user_credentials.json
+    else
+      cat <<-_EOF_ >user_credentials.json
 {
     "users": []
 }
 _EOF_
+    fi
     return
   fi
 
@@ -506,6 +684,14 @@ not_enough_space() {
   local available="${1:-0}"
   step "Not enough free space on $disk"
   say --foreground 1 "$disk has $(to_gb $available) of usable free space; Omarchy needs at least 32GB."
+  if $t1_install; then
+    say "Choose whole-disk installation or a different disk."
+    say "The partition editor is disabled on this T1 Mac so it cannot remove Apple hardware data."
+    echo
+    gum confirm --affirmative "Back" "Return to installation mode?" || true
+    return 1
+  fi
+
   say "Open the partition tool to free at least 32GB on $disk, then try again."
   echo
   if ! gum confirm --affirmative "Back" --negative "Open partition tool" "Return to installation mode?"; then
@@ -599,6 +785,13 @@ run_partition_decide() {
   ROOT_START_B=$(( (EFI_END_B + 1 + ALIGN - 1) / ALIGN * ALIGN ))
   ROOT_END_B=$((FREE_END_B / ALIGN * ALIGN))
 
+  if $t1_install; then
+    t1_efi_destructive_range_is_safe "$EFI_START_B" "$EFI_END_B" ||
+      abort "The selected free space overlaps preserved Apple hardware data"
+    t1_efi_destructive_range_is_safe "$ROOT_START_B" "$ROOT_END_B" ||
+      abort "The selected free space overlaps preserved Apple hardware data"
+  fi
+
   if (( ROOT_END_B <= ROOT_START_B )); then
     not_enough_space "$FREE_SIZE_B"
     return $?
@@ -663,6 +856,7 @@ run_partition_decide() {
   fi
 
   kernel_choice=$(detect_kernel)
+  protected_enable_fallback=false
 
   # Partition numbers are not knowable until parted assigns them (it fills the
   # lowest free GPT slot, and freeing space by deleting a partition leaves one
@@ -692,7 +886,20 @@ run_partition_execute() {
     say "[dry] encrypted=$encrypt_installation kernel=$kernel_choice"
   else
     step "Creating partitions on $disk"
+    if $t1_install && [[ $install_target == "free_space" ]]; then
+      t1_efi_any_candidate_available ||
+        disk_abort_hook "Apple hardware data is no longer readable"
+      t1_efi_capture_optional_snapshot "$disk" ||
+        disk_abort_hook "Could not verify Apple hardware data on the install disk"
+      t1_efi_destructive_range_is_safe "$EFI_START_B" "$EFI_END_B" ||
+        disk_abort_hook "The selected free space overlaps preserved Apple hardware data"
+      t1_efi_destructive_range_is_safe "$ROOT_START_B" "$ROOT_END_B" ||
+        disk_abort_hook "The selected free space overlaps preserved Apple hardware data"
+    fi
     if $needs_mklabel; then
+      if $t1_install && (( ${#t1_efi_preserved_devices[@]} > 0 )); then
+        disk_abort_hook "Refusing to replace a partition table that contains Apple hardware data"
+      fi
       disk_step "initializing GPT on $disk" parted --script "$disk" mklabel gpt
       partprobe "$disk" 2>/dev/null || true
       sleep 1
@@ -709,6 +916,7 @@ run_partition_execute() {
       disk_abort_hook "Could not create the root partition on $disk"
     root_part_num="$created_partition_number"
 
+    t1_guard_destructive_partition "$efi_part_num" "flag the new EFI partition"
     disk_step "flagging partition $efi_part_num as ESP" \
       parted --script "$disk" set "$efi_part_num" esp on
 
@@ -725,7 +933,9 @@ run_partition_execute() {
 
     # Both partitions are ours and brand new, but the space they occupy may
     # carry signatures from whatever was deleted to free it.
+    t1_guard_destructive_partition "$efi_part_num" "clear the new EFI partition"
     disk_step "clearing stale signatures on $efi_dev" wipefs -af "$efi_dev"
+    t1_guard_destructive_partition "$root_part_num" "clear the new root partition"
     disk_step "clearing stale signatures on $root_partition_device" wipefs -af "$root_partition_device"
 
     if [[ "$encrypt_installation" == "true" ]]; then
@@ -733,6 +943,7 @@ run_partition_execute() {
       # Kept as pipes rather than routed through disk_step: the passphrase must
       # not become an argv the process table can show. Folding stderr into
       # stdout still lands any error in the install log.
+      t1_guard_destructive_partition "$root_part_num" "format the encrypted root partition"
       if ! printf "%s" "$password" |
         cryptsetup luksFormat --type luks2 --batch-mode "$root_partition_device" - 2>&1; then
         disk_abort_hook "Formatting LUKS2 on $root_partition_device failed"
@@ -747,6 +958,7 @@ run_partition_execute() {
     fi
 
     step "Creating Btrfs filesystem and subvolumes"
+    t1_guard_destructive_partition "$root_part_num" "format the root filesystem"
     disk_step "creating the Btrfs filesystem on $root_mapper" \
       mkfs.btrfs -f -L OMARCHY "$root_mapper"
     wait_for_device "$root_mapper" || disk_abort_hook "Root device $root_mapper never appeared"
@@ -769,6 +981,7 @@ run_partition_execute() {
     disk_step "mounting the package cache" \
       mount -o noatime,compress=zstd,subvol=@pkg "$root_mapper" /mnt/var/cache/pacman/pkg
 
+    t1_guard_destructive_partition "$efi_part_num" "format the new EFI filesystem"
     disk_step "creating the ESP filesystem on $efi_dev" mkfs.fat -F32 -n OMARCHY_EFI "$efi_dev"
     disk_step "mounting the ESP" mount "$efi_dev" /mnt"$esp_mount_in_target"
 
@@ -779,6 +992,13 @@ run_partition_execute() {
       disk_abort_hook "Target /mnt is not mounted; not starting the installer"
     mountpoint -q "/mnt$esp_mount_in_target" ||
       disk_abort_hook "ESP is not mounted at /mnt$esp_mount_in_target"
+
+    # This is the last disk-integrity check before handing the mounted target
+    # to the orchestrator. It covers the full raw contents and GPT identity of
+    # every preserved Apple source.
+    if $t1_install; then
+      t1_revalidate_available_data
+    fi
   fi
 
   local luks_uuid_json="null" luks_uuid
@@ -801,12 +1021,13 @@ run_partition_execute() {
     "custom_commands": [],
     "omarchy_install": {
         "mode": "protected",
+        "defer_provisioning": $defer_provisioning,
         "target_mount": "/mnt",
         "boot": {
             "esp_mount": "$esp_mount_in_target",
             "esp_path": "/EFI/limine",
             "efi_binary": "limine_x64.efi",
-            "enable_fallback": false
+            "enable_fallback": $protected_enable_fallback
         },
         "storage": {
             "esp_device": "$efi_dev",
@@ -895,6 +1116,12 @@ disk_form() {
 # STEP 4: INSTALL MODE
 
 open_partition_tool() {
+  if $t1_install; then
+    step "Partition editor unavailable"
+    say "The partition editor is disabled on this T1 Mac so it cannot remove Apple hardware data."
+    return 0
+  fi
+
   step "Partition tool for $disk"
   gum style "Create unallocated free space for Omarchy, then write changes and quit."
   gum style --foreground 8 "Do not create an Omarchy partition here — leave the target area as Free space."
@@ -953,9 +1180,20 @@ confirm_disk_overwrite() {
   while true; do
     clear_logo
     echo
-    say "Everything will be overwritten. There is no recovery possible."
+    if $t1_install; then
+      if $t1_target_has_candidates; then
+        say "All data except the preserved Apple hardware partition(s) will be erased."
+      else
+        say "All data on the selected disk will be erased. Apple hardware data on other disks will be left untouched."
+      fi
+      say "Omarchy will use its own separate 2GB EFI partition."
+    else
+      say "Everything will be overwritten. There is no recovery possible."
+    fi
 
-    if [[ $mode == "encrypted" ]]; then
+    if $t1_install; then
+      affirmative="Yes, install"
+    elif [[ $mode == "encrypted" ]]; then
       say --foreground 8 "Press Ctrl+C for unencrypted install."
       affirmative="Yes, install"
     else
@@ -968,14 +1206,20 @@ confirm_disk_overwrite() {
 
     case $confirm_status in
       0)
-        [[ $mode == "encrypted" ]] && encrypt_installation=true || encrypt_installation=false
+        if $t1_install || [[ $mode == "encrypted" ]]; then
+          encrypt_installation=true
+        else
+          encrypt_installation=false
+        fi
         return 0
         ;;
       1)
         return 1
         ;;
       130)
-        [[ $mode == "encrypted" ]] && mode="unencrypted" || mode="encrypted"
+        if ! $t1_install; then
+          [[ $mode == "encrypted" ]] && mode="unencrypted" || mode="encrypted"
+        fi
         ;;
       *)
         abort
@@ -993,6 +1237,8 @@ select_installation() {
   local full_disk_only
 
   while true; do
+    t1_prepare_selected_disk
+
     if requires_full_disk_install; then
       full_disk_only=true
     else
@@ -1009,7 +1255,17 @@ select_installation() {
 
     case "$install_mode" in
       "Full disk install")
+        if $t1_install && ! t1_prepare_whole_disk_layout; then
+          step "Not enough safe disk space"
+          say "Omarchy needs at least 32GB outside the preserved Apple hardware partition(s)."
+          disk_form
+          continue
+        fi
         if confirm_disk_overwrite; then
+          if $t1_install; then
+            t1_prepare_whole_disk_layout ||
+              abort "Could not create a safe layout around the Apple hardware partition(s)"
+          fi
           install_target="full_disk"
           return 0
         fi
@@ -1030,10 +1286,21 @@ select_installation() {
   done
 }
 
+# Unit tests source the functions above without starting the interactive
+# installer. This has no effect when the configurator is executed normally.
+if [[ ${OMARCHY_CONFIGURATOR_LIBRARY_ONLY:-false} == true ]]; then
+  return 0
+fi
+
 # STEP 1: KEYBOARD (Ctrl+C here arms deferred provisioning and jumps to disk selection)
 
 defer_provisioning=false
 install_target="full_disk"
+t1_install=false
+t1_snapshot_disk=""
+t1_target_snapshot_ready=false
+t1_target_has_candidates=false
+protected_enable_fallback=false
 
 # Let the live VT reach its settled width before the first screen so the logo
 # isn't measured against the transient 80-column boot console.
@@ -1069,9 +1336,21 @@ if $defer_provisioning; then
   # Jump straight to disk selection + overwrite confirmation (encrypted by
   # default, Ctrl+C toggles unencrypted). deferred provisioning is always a full-disk install.
   disk_form
+  t1_prepare_selected_disk
+  if $t1_install && ! t1_prepare_whole_disk_layout; then
+    abort "Omarchy needs at least 32GB outside the preserved Apple hardware partition(s)"
+  fi
   until confirm_disk_overwrite; do
     disk_form
+    t1_prepare_selected_disk
+    if $t1_install && ! t1_prepare_whole_disk_layout; then
+      abort "Omarchy needs at least 32GB outside the preserved Apple hardware partition(s)"
+    fi
   done
+  if $t1_install; then
+    t1_prepare_whole_disk_layout ||
+      abort "Could not create a safe layout around the Apple hardware partition(s)"
+  fi
   install_target="full_disk"
 else
   disk_form
@@ -1080,9 +1359,13 @@ fi
 
 clear
 
-write_user_files
+write_user_files "$@"
 
-if [[ $install_target == "free_space" ]]; then
+if [[ $install_target == "free_space" ]] || { $t1_install && [[ $install_target == "full_disk" ]]; }; then
+  if $t1_install && [[ $install_target == "full_disk" ]] && [[ ${1:-} != "dry" ]]; then
+    step "Preparing disk while preserving Apple hardware data"
+    t1_delete_nonpreserved_partitions
+  fi
   run_partition_execute "$@"
 
   if [[ ${1:-} == "dry" ]]; then

--- a/configs/airootfs/usr/share/omarchy-iso/disk-partitioning.sh
+++ b/configs/airootfs/usr/share/omarchy-iso/disk-partitioning.sh
@@ -17,6 +17,370 @@ created_parts=()
 # would run it in a subshell and lose the created_parts bookkeeping.
 created_partition_number=""
 
+# A T1 Mac cannot recover its Touch Bar and biometric calibration from a
+# generic install image. Keep every Apple EFI source found on the selected
+# disk intact until the installed system can match the data to its hardware.
+# These arrays exist only for the lifetime of the installer process. Nothing
+# below prints their partition UUIDs or hashes.
+t1_efi_candidate_devices=()
+t1_efi_candidate_numbers=()
+t1_efi_preserved_devices=()
+t1_efi_preserved_numbers=()
+t1_efi_preserved_starts=()
+t1_efi_preserved_sizes=()
+t1_efi_preserved_partuuids=()
+t1_efi_preserved_hashes=()
+
+T1_ESP_PARTTYPE="c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
+
+t1_supported_machine() {
+  local vendor_file="${T1_DMI_VENDOR_FILE:-/sys/class/dmi/id/sys_vendor}"
+  local product_file="${T1_DMI_PRODUCT_FILE:-/sys/class/dmi/id/product_name}"
+  local vendor product
+
+  [[ -r $vendor_file && -r $product_file ]] || return 1
+  vendor=$(<"$vendor_file")
+  product=$(<"$product_file")
+  [[ $vendor == "Apple Inc." ]] || return 1
+
+  case "$product" in
+    MacBookPro13,2 | MacBookPro13,3 | MacBookPro14,2 | MacBookPro14,3) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+t1_efi_clear_snapshot() {
+  t1_efi_candidate_devices=()
+  t1_efi_candidate_numbers=()
+  t1_efi_preserved_devices=()
+  t1_efi_preserved_numbers=()
+  t1_efi_preserved_starts=()
+  t1_efi_preserved_sizes=()
+  t1_efi_preserved_partuuids=()
+  t1_efi_preserved_hashes=()
+}
+
+_t1_efi_partition_devices() {
+  local disk="$1" listing
+  listing=$(lsblk -lnpo PATH,TYPE "$disk" 2>/dev/null) || return 1
+  awk '$2 == "part" { print $1 }' <<<"$listing"
+}
+
+_t1_efi_whole_disks() {
+  local listing
+  listing=$(lsblk -dnpo PATH,TYPE 2>/dev/null) || return 1
+  awk '$2 == "disk" { print $1 }' <<<"$listing"
+}
+
+_t1_efi_is_esp() {
+  local parttype filesystem
+  # Separate fields so an empty type cannot be mistaken for the filesystem.
+  parttype=$(lsblk -dnro PARTTYPE "$1" 2>/dev/null) || return 2
+  [[ -n $parttype ]] || return 2
+  [[ ${parttype,,} == "$T1_ESP_PARTTYPE" ]] || return 1
+  filesystem=$(lsblk -dnro FSTYPE "$1" 2>/dev/null) || return 2
+  case ${filesystem,,} in
+    fat | fat12 | fat16 | fat32 | msdos | vfat) return 0 ;;
+    *) return 2 ;;
+  esac
+}
+
+# Inspect an already-mounted ESP in place; this covers the installer-created
+# Omarchy ESP without trying to mount the same FAT filesystem a second time.
+# Otherwise mount the ESP separately and read-only. Only the yes/no result
+# leaves this function.
+_t1_efi_find_apple_tree() {
+  find "$1" -mindepth 1 -maxdepth 1 -type d -iname efi \
+    -exec find '{}' -mindepth 1 -maxdepth 1 -type d -iname apple -print -quit \;
+}
+
+_t1_efi_contains_apple_tree() {
+  local part="$1" existing_mount="" mountpoint match="" result=1 status
+
+  if existing_mount=$(findmnt -rn -S "$part" -o TARGET 2>/dev/null); then
+    [[ -n $existing_mount && $existing_mount != *$'\n'* && $existing_mount == /* ]] || return 2
+    if match=$(_t1_efi_find_apple_tree "$existing_mount" 2>/dev/null); then
+      [[ -n $match ]] && return 0
+      return 1
+    fi
+    return 2
+  else
+    status=$?
+    (( status == 1 )) || return 2
+  fi
+
+  mountpoint=$(mktemp -d "${T1_EFI_MOUNT_PARENT:-/run}/t1-efi.XXXXXX") || return 2
+
+  if mount -o ro,nosuid,nodev,noexec -- "$part" "$mountpoint" >/dev/null 2>&1; then
+    if match=$(_t1_efi_find_apple_tree "$mountpoint" 2>/dev/null); then
+      [[ -n $match ]] && result=0
+    else
+      result=2
+    fi
+    umount -- "$mountpoint" >/dev/null 2>&1 || result=2
+  else
+    result=2
+  fi
+  rmdir -- "$mountpoint" >/dev/null 2>&1 || result=2
+
+  return "$result"
+}
+
+# Populate the candidate arrays with every readable ESP on disk containing an
+# EFI/APPLE directory. A completed scan with no candidates is still success;
+# callers use the array length to distinguish that from a scan failure.
+t1_efi_discover_candidates() {
+  local disk="$1" parts part number probe_status
+  t1_efi_candidate_devices=()
+  t1_efi_candidate_numbers=()
+
+  parts=$(_t1_efi_partition_devices "$disk") || return 2
+  while IFS= read -r part; do
+    [[ -n $part ]] || continue
+    if _t1_efi_is_esp "$part"; then
+      :
+    else
+      probe_status=$?
+      (( probe_status == 1 )) && continue
+      return 2
+    fi
+    if _t1_efi_contains_apple_tree "$part"; then
+      :
+    else
+      probe_status=$?
+      (( probe_status == 1 )) && continue
+      return 2
+    fi
+    number=$(lsblk -dnro PARTN "$part" 2>/dev/null) || return 2
+    [[ $number =~ ^[0-9]+$ ]] || return 2
+    t1_efi_candidate_devices+=("$part")
+    t1_efi_candidate_numbers+=("$number")
+  done <<<"$parts"
+}
+
+# A supported T1 Mac may keep its Apple data on a disk other than the install
+# target. Check every attached whole disk, but retain no cross-disk geometry:
+# only candidates on the selected target may constrain its partition layout.
+t1_efi_any_candidate_available() {
+  local disks disk found=false inspection_failed=false status
+  disks=$(_t1_efi_whole_disks) || return 2
+
+  while IFS= read -r disk; do
+    [[ -n $disk ]] || continue
+    if t1_efi_discover_candidates "$disk"; then
+      (( ${#t1_efi_candidate_devices[@]} > 0 )) && found=true
+    else
+      status=$?
+      (( status == 2 )) && inspection_failed=true
+    fi
+  done <<<"$disks"
+
+  $found && return 0
+  $inspection_failed && return 2
+  return 1
+}
+
+# Set t1_efi_geometry_start and t1_efi_geometry_size from the on-disk GPT.
+# Both are bytes; the occupied interval is [start, start + size).
+_t1_efi_read_geometry() {
+  local disk="$1" number="$2" row
+  t1_efi_geometry_start=""
+  t1_efi_geometry_size=""
+  row=$(parted -ms "$disk" unit B print 2>/dev/null |
+    awk -F: -v n="$number" '$1 == n { print $2 ":" $4; exit }') || return 1
+  [[ $row == *:* ]] || return 1
+  IFS=: read -r t1_efi_geometry_start t1_efi_geometry_size <<<"$row"
+  t1_efi_geometry_start=${t1_efi_geometry_start%B}
+  t1_efi_geometry_size=${t1_efi_geometry_size%B}
+  [[ $t1_efi_geometry_start =~ ^[0-9]+$ && $t1_efi_geometry_size =~ ^[1-9][0-9]*$ ]]
+}
+
+_t1_efi_read_partuuid() {
+  local value
+  value=$(blkid -s PARTUUID -o value -- "$1" 2>/dev/null) || return 1
+  [[ -n $value ]] || return 1
+  t1_efi_partuuid="$value"
+}
+
+_t1_efi_hash_partition() {
+  local output digest
+  output=$(sha256sum -- "$1" 2>/dev/null) || return 1
+  digest=${output%%[[:space:]]*}
+  [[ $digest =~ ^[0-9a-fA-F]{64}$ ]] || return 1
+  t1_efi_partition_hash=${digest,,}
+}
+
+# Capture the immutable facts needed to plan preservation. The default full
+# snapshot hashes each raw partition; a false second argument defers that
+# expensive proof until immediately before mutation.
+t1_efi_capture_optional_snapshot() {
+  local disk="$1" include_hash="${2:-true}" i part number status
+  local hash_started_us="" hash_finished_us hash_elapsed_ms
+  [[ $include_hash == true || $include_hash == false ]] || return 1
+  t1_efi_clear_snapshot
+  if t1_efi_discover_candidates "$disk"; then
+    :
+  else
+    status=$?
+    return "$status"
+  fi
+  [[ $include_hash == true ]] && hash_started_us=${EPOCHREALTIME/./}
+
+  for i in "${!t1_efi_candidate_devices[@]}"; do
+    part=${t1_efi_candidate_devices[$i]}
+    number=${t1_efi_candidate_numbers[$i]}
+    _t1_efi_read_geometry "$disk" "$number" || { t1_efi_clear_snapshot; return 1; }
+    _t1_efi_read_partuuid "$part" || { t1_efi_clear_snapshot; return 1; }
+    if [[ $include_hash == true ]]; then
+      _t1_efi_hash_partition "$part" || { t1_efi_clear_snapshot; return 1; }
+    else
+      t1_efi_partition_hash=""
+    fi
+
+    t1_efi_preserved_devices+=("$part")
+    t1_efi_preserved_numbers+=("$number")
+    t1_efi_preserved_starts+=("$t1_efi_geometry_start")
+    t1_efi_preserved_sizes+=("$t1_efi_geometry_size")
+    t1_efi_preserved_partuuids+=("$t1_efi_partuuid")
+    t1_efi_preserved_hashes+=("$t1_efi_partition_hash")
+  done
+
+  if [[ $include_hash == true ]] && (( ${#t1_efi_preserved_devices[@]} > 0 )); then
+    hash_finished_us=${EPOCHREALTIME/./}
+    hash_elapsed_ms=$(((10#$hash_finished_us - 10#$hash_started_us) / 1000))
+    printf 'Apple EFI digest snapshot completed in %d ms.\n' "$hash_elapsed_ms"
+  fi
+}
+
+t1_efi_capture_snapshot() {
+  t1_efi_capture_optional_snapshot "$@" || return 1
+  (( ${#t1_efi_preserved_devices[@]} > 0 ))
+}
+
+# Return success only when [start, end) avoids every preserved byte range.
+t1_efi_destructive_range_is_safe() {
+  local start="$1" end="$2" i preserved_start preserved_end
+  [[ $start =~ ^[0-9]+$ && $end =~ ^[0-9]+$ ]] || return 1
+  (( end > start )) || return 1
+
+  for i in "${!t1_efi_preserved_starts[@]}"; do
+    preserved_start=${t1_efi_preserved_starts[$i]}
+    preserved_end=$((preserved_start + t1_efi_preserved_sizes[$i]))
+    (( start < preserved_end && end > preserved_start )) && return 1
+  done
+  return 0
+}
+
+t1_efi_destructive_partition_is_safe() {
+  local disk="$1" number="$2"
+  _t1_efi_read_geometry "$disk" "$number" || return 1
+  t1_efi_destructive_range_is_safe \
+    "$t1_efi_geometry_start" "$((t1_efi_geometry_start + t1_efi_geometry_size))"
+}
+
+t1_efi_partition_number_is_preserved() {
+  local number="$1" preserved
+  for preserved in "${t1_efi_preserved_numbers[@]}"; do
+    [[ $number == "$preserved" ]] && return 0
+  done
+  return 1
+}
+
+# Find the largest byte range that remains after every preserved Apple ESP is
+# treated as immovable. Non-preserved partitions do not constrain this plan:
+# the T1 whole-disk flow deletes those before creating Omarchy's partitions.
+# The first and last MiB stay reserved for GPT metadata and alignment.
+t1_efi_find_largest_safe_region() {
+  local disk="$1" disk_size mib lower upper cursor start size end
+  local best_start="" best_end="" best_size=0
+
+  t1_efi_safe_region_start=""
+  t1_efi_safe_region_end=""
+  t1_efi_safe_region_size=""
+  disk_size=$(lsblk -bdno SIZE "$disk" 2>/dev/null) || return 1
+  [[ $disk_size =~ ^[1-9][0-9]*$ ]] || return 1
+  mib=$((1024 * 1024))
+  lower=$mib
+  upper=$((disk_size / mib * mib - mib))
+  (( upper > lower )) || return 1
+  cursor=$lower
+
+  while read -r start size; do
+    [[ $start =~ ^[0-9]+$ && $size =~ ^[1-9][0-9]*$ ]] || return 1
+    end=$((start + size))
+    (( end <= lower )) && continue
+    (( start >= upper )) && break
+    (( start < lower )) && start=$lower
+    (( end > upper )) && end=$upper
+
+    if (( start > cursor && start - cursor > best_size )); then
+      best_start=$cursor
+      best_end=$start
+      best_size=$((start - cursor))
+    fi
+    (( end > cursor )) && cursor=$end
+  done < <(
+    for i in "${!t1_efi_preserved_starts[@]}"; do
+      printf '%s %s\n' "${t1_efi_preserved_starts[$i]}" "${t1_efi_preserved_sizes[$i]}"
+    done | sort -n -k1,1
+  )
+
+  if (( upper > cursor && upper - cursor > best_size )); then
+    best_start=$cursor
+    best_end=$upper
+    best_size=$((upper - cursor))
+  fi
+
+  (( best_size > 0 )) || return 1
+  t1_efi_destructive_range_is_safe "$best_start" "$best_end" || return 1
+  t1_efi_safe_region_start=$best_start
+  t1_efi_safe_region_end=$best_end
+  t1_efi_safe_region_size=$best_size
+}
+
+# Re-read GPT geometry and the raw partition after partitioning. Locate each
+# source by its PARTUUID rather than assuming its partition number stayed the
+# same. Call this both immediately before destructive work and after the new
+# layout has been created.
+t1_efi_revalidate_snapshot() {
+  local disk="$1" parts i expected_uuid expected_start expected_size
+  local expected_hash part current_uuid number matches
+  local hash_started_us=${EPOCHREALTIME/./} hash_finished_us hash_elapsed_ms
+  (( ${#t1_efi_preserved_devices[@]} > 0 )) || return 1
+  parts=$(_t1_efi_partition_devices "$disk") || return 1
+
+  for i in "${!t1_efi_preserved_devices[@]}"; do
+    expected_uuid=${t1_efi_preserved_partuuids[$i]}
+    expected_start=${t1_efi_preserved_starts[$i]}
+    expected_size=${t1_efi_preserved_sizes[$i]}
+    expected_hash=${t1_efi_preserved_hashes[$i]}
+    matches=0
+
+    while IFS= read -r part; do
+      [[ -n $part ]] || continue
+      _t1_efi_read_partuuid "$part" || continue
+      current_uuid=$t1_efi_partuuid
+      [[ $current_uuid == "$expected_uuid" ]] || continue
+      matches=$((matches + 1))
+      (( matches == 1 )) || return 1
+      _t1_efi_is_esp "$part" || return 1
+      number=$(lsblk -dnro PARTN "$part" 2>/dev/null) || return 1
+      [[ $number =~ ^[0-9]+$ ]] || return 1
+      _t1_efi_read_geometry "$disk" "$number" || return 1
+      [[ $t1_efi_geometry_start == "$expected_start" ]] || return 1
+      [[ $t1_efi_geometry_size == "$expected_size" ]] || return 1
+      _t1_efi_hash_partition "$part" || return 1
+      [[ $t1_efi_partition_hash == "$expected_hash" ]] || return 1
+    done <<<"$parts"
+
+    (( matches == 1 )) || return 1
+  done
+
+  hash_finished_us=${EPOCHREALTIME/./}
+  hash_elapsed_ms=$(((10#$hash_finished_us - 10#$hash_started_us) / 1000))
+  printf 'Apple EFI digest revalidation completed in %d ms.\n' "$hash_elapsed_ms"
+}
+
 # Compute partition device path, handling NVMe/mmcblk's pN naming.
 partition_path() {
   local _disk="$1" _num="$2"
@@ -86,6 +450,10 @@ create_partition() {
 
   created_partition_number=""
 
+  if (( ${#t1_efi_preserved_starts[@]} > 0 )); then
+    t1_efi_destructive_range_is_safe "$start" "$end" || return 1
+  fi
+
   # Lexicographic sort on both sides: comm needs its inputs ordered the same
   # way it compares them, and `sort -n` (1, 2, 10) is not that order.
   before=$(partition_numbers "$disk" | sort)
@@ -110,6 +478,9 @@ create_partition() {
   tolerance=$((1024 * 1024))
   (( actual >= want - tolerance && actual <= want + tolerance )) || return 1
 
+  if (( ${#t1_efi_preserved_starts[@]} > 0 )); then
+    t1_efi_destructive_partition_is_safe "$disk" "$num" || return 1
+  fi
   parted --script "$disk" name "$num" "$name" || true
 
   created_parts+=("$num")
@@ -121,11 +492,22 @@ create_partition() {
 # space occupied by orphans, and the retry reports "not enough free space"
 # with no way to connect that to what just happened.
 rollback_created_parts() {
-  local disk="$1" n
+  local disk="$1" n status=0
+  local retained=()
   (( ${#created_parts[@]} > 0 )) || return 0
   for n in $(printf '%s\n' "${created_parts[@]}" | sort -rn); do
-    parted --script "$disk" rm "$n" >/dev/null 2>&1 || true
+    if (( ${#t1_efi_preserved_starts[@]} > 0 )) &&
+      ! t1_efi_destructive_partition_is_safe "$disk" "$n"; then
+      retained+=("$n")
+      status=1
+      continue
+    fi
+    if ! parted --script "$disk" rm "$n" >/dev/null 2>&1; then
+      retained+=("$n")
+      status=1
+    fi
   done
   partprobe "$disk" 2>/dev/null || true
-  created_parts=()
+  created_parts=("${retained[@]}")
+  return "$status"
 }

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -36,6 +36,7 @@ from . import archinstall_adapter as arch
 from .command import capture, capture_identifier, require_text
 from .context import InstallContext
 from .keyboard import configure_keyboard
+from .t1_efi import validate_t1_efi_preservation
 from .ui import error, info
 
 
@@ -176,6 +177,10 @@ def _early_packages() -> list[str]:
 # ─────────────────────────────────────────────────────────────────────────────
 
 def prepare_live(ctx: InstallContext) -> None:
+    # This must run before cleanup or archinstall sees the configuration.
+    # It also protects unattended/cidata inputs that bypass the wizard.
+    validate_t1_efi_preservation(ctx)
+
     if ctx.is_protected:
         info("› protected mode: skipping whole-disk cleanup")
     else:
@@ -221,6 +226,10 @@ def arch_install_system(ctx: InstallContext) -> None:
     a pre-mounted target, and Omarchy derives boot/fstab details from that same
     input.
     """
+    # Recheck both the plan and live Apple data at the filesystem-operation
+    # boundary rather than trusting the earlier probe.
+    validate_t1_efi_preservation(ctx)
+
     handler = ctx.state["arch_config_handler"]
     mirror_handler = ctx.state["mirror_handler"]
     config = handler.config

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/t1_efi.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/t1_efi.py
@@ -1,0 +1,338 @@
+"""Fail-closed Apple EFI protection for T1 Macs.
+
+The configurator owns partitioning for preservation-aware installs. This
+module is the unattended/orchestrator backstop: every attached disk is checked
+read-only, and a destructive plan is accepted only when all readable Apple EFI
+sources are on disks the plan will not modify.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .command import capture
+
+
+SUPPORTED_T1_MODELS = frozenset({
+    "MacBookPro13,2",
+    "MacBookPro13,3",
+    "MacBookPro14,2",
+    "MacBookPro14,3",
+})
+
+_DMI_ROOT = Path("/sys/class/dmi/id")
+_FAT_FILESYSTEMS = frozenset({"fat", "fat12", "fat16", "fat32", "msdos", "vfat"})
+_ESP_PARTTYPE = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
+
+
+@dataclass(frozen=True)
+class _InstallPlan:
+    target_disk: str
+    omarchy_esp: str | None
+    destructive: bool
+
+
+def validate_t1_efi_preservation(ctx: Any) -> None:
+    """Reject unsafe T1 plans before any installer-owned disk operation.
+
+    No serial number, UUID, hash, or other unique machine value is read or
+    logged.  The DMI model is used only to decide whether this guard applies.
+    """
+    if not _is_supported_t1_mac():
+        return
+
+    plan = _read_install_plan(ctx)
+    sources = _discover_apple_efi_sources(ctx.state_dir, plan.target_disk)
+    if not any(sources.values()):
+        raise _missing_apple_data_error()
+
+    canonical_target = os.path.realpath(plan.target_disk)
+    if canonical_target not in sources:
+        raise RuntimeError(
+            "Apple T1 safety check stopped installation before disk changes: "
+            "the install target is not one attached whole-disk device"
+        )
+    target_sources = sources[canonical_target]
+    if target_sources and plan.destructive:
+        raise RuntimeError(
+            "Apple T1 safety check stopped installation before disk changes: "
+            "the target disk contains Apple EFI data that this plan would not preserve"
+        )
+
+    if target_sources:
+        if plan.omarchy_esp is None:
+            raise RuntimeError(
+                "Apple T1 safety check stopped installation before disk changes: "
+                "Omarchy must use a separate EFI partition"
+            )
+        if os.path.realpath(plan.omarchy_esp) in target_sources:
+            raise RuntimeError(
+                "Apple T1 safety check stopped installation before disk changes: "
+                "Omarchy must use a separate EFI partition"
+            )
+
+
+def _is_supported_t1_mac() -> bool:
+    try:
+        vendor = (_DMI_ROOT / "sys_vendor").read_text().strip()
+        model = (_DMI_ROOT / "product_name").read_text().strip()
+    except OSError:
+        return False
+    return vendor == "Apple Inc." and model in SUPPORTED_T1_MODELS
+
+
+def _read_install_plan(ctx: Any) -> _InstallPlan:
+    disk_config = ctx.user_configuration.get("disk_config") or {}
+    modifications = disk_config.get("device_modifications") or []
+    wipe_devices = [
+        modification.get("device")
+        for modification in modifications
+        if isinstance(modification, dict) and bool(modification.get("wipe"))
+    ]
+
+    if ctx.mode == "full_disk" and disk_config.get("config_type") == "default_layout":
+        if (
+            len(modifications) == 1
+            and len(wipe_devices) == 1
+            and isinstance(wipe_devices[0], str)
+            and wipe_devices[0]
+        ):
+            return _InstallPlan(
+                target_disk=os.path.realpath(wipe_devices[0]),
+                omarchy_esp=None,
+                destructive=True,
+            )
+
+    if (
+        ctx.mode == "protected"
+        and disk_config.get("config_type") == "pre_mounted_config"
+        and not wipe_devices
+    ):
+        storage = ctx.omarchy_install.get("storage") or {}
+        omarchy_esp = storage.get("esp_device")
+        if isinstance(omarchy_esp, str) and omarchy_esp:
+            return _InstallPlan(
+                target_disk=_parent_disk(omarchy_esp),
+                omarchy_esp=omarchy_esp,
+                destructive=False,
+            )
+
+    raise RuntimeError(
+        "Apple T1 safety check stopped installation before disk changes: "
+        "the install plan does not identify one safely handled target disk"
+    )
+
+
+def _discover_apple_efi_sources(
+    state_dir: Path, target_disk: str,
+) -> dict[str, set[str]]:
+    sources: dict[str, set[str]] = {}
+    canonical_target = os.path.realpath(target_disk)
+    for disk in _whole_disks():
+        canonical_disk = os.path.realpath(disk)
+        sources[canonical_disk] = set()
+        target = canonical_disk == canonical_target
+        for partition in _fat_partitions(disk, strict=target):
+            contents = _inspect_partition(partition, state_dir)
+            if contents == "unreadable":
+                if target:
+                    raise _inspection_error()
+                continue
+            if contents == "apple":
+                sources[canonical_disk].add(os.path.realpath(partition))
+    return sources
+
+
+def _whole_disks() -> list[str]:
+    try:
+        result = capture(["lsblk", "--json", "--paths", "--output", "PATH,TYPE"])
+    except OSError:
+        raise _inspection_error() from None
+    if result.returncode != 0:
+        raise _inspection_error()
+    try:
+        payload = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError):
+        raise _inspection_error() from None
+
+    disks = []
+    for node in _walk_blockdevices(payload.get("blockdevices")):
+        path = node.get("path")
+        if node.get("type") == "disk" and isinstance(path, str) and path.startswith("/dev/"):
+            disks.append(path)
+    if not disks:
+        raise _inspection_error()
+    return disks
+
+
+def _parent_disk(partition: str) -> str:
+    try:
+        result = capture(["lsblk", "-npo", "PKNAME", "--", partition])
+    except OSError:
+        raise _inspection_error() from None
+    parent = result.stdout.strip() if result.returncode == 0 else ""
+    if not parent.startswith("/dev/") or "\n" in parent:
+        raise _inspection_error()
+    return parent
+
+
+def _fat_partitions(parent: str, *, strict: bool = True) -> list[str]:
+    try:
+        result = capture([
+            "lsblk", "--json", "--paths", "--output", "PATH,TYPE,FSTYPE,PARTTYPE", "--", parent,
+        ])
+    except OSError:
+        raise _inspection_error() from None
+    if result.returncode != 0:
+        raise _inspection_error()
+    try:
+        payload = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError):
+        raise _inspection_error() from None
+
+    partitions: list[str] = []
+    for node in _walk_blockdevices(payload.get("blockdevices")):
+        path = node.get("path")
+        fs_type = node.get("fstype")
+        part_type = node.get("parttype")
+        if node.get("type") != "part":
+            continue
+        if not isinstance(part_type, str) or not part_type.strip():
+            if strict:
+                raise _inspection_error()
+            continue
+        if part_type.casefold() != _ESP_PARTTYPE:
+            continue
+        if (
+            not isinstance(path, str)
+            or not path.startswith("/dev/")
+            or not isinstance(fs_type, str)
+            or fs_type.casefold() not in _FAT_FILESYSTEMS
+        ):
+            if strict:
+                raise _inspection_error()
+            continue
+        partitions.append(path)
+    return partitions
+
+
+def _walk_blockdevices(nodes: Any):
+    if not isinstance(nodes, list):
+        return
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        yield node
+        yield from _walk_blockdevices(node.get("children"))
+
+
+def _inspect_partition(device: str, state_dir: Path) -> str:
+    """Return ``apple``, ``other``, or ``unreadable`` without logging device data."""
+    mounted_contents = _inspect_existing_mount(device)
+    if mounted_contents is not None:
+        return mounted_contents
+
+    state_dir.mkdir(parents=True, exist_ok=True)
+    mountpoint = Path(tempfile.mkdtemp(prefix=".apple-efi-check-", dir=state_dir))
+    mounted = False
+    try:
+        try:
+            result = subprocess.run(
+                ["mount", "-o", "ro,nodev,nosuid,noexec", "--", device, str(mountpoint)],
+                check=False,
+                capture_output=True,
+            )
+        except OSError:
+            return "unreadable"
+        if result.returncode != 0:
+            return "unreadable"
+        mounted = True
+        try:
+            return "apple" if _contains_apple_directory(mountpoint) else "other"
+        except OSError:
+            return "unreadable"
+    finally:
+        if mounted:
+            result = subprocess.run(
+                ["umount", "--", str(mountpoint)],
+                check=False,
+                capture_output=True,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(
+                    "Apple T1 safety check could not finish its read-only EFI check; "
+                    "installation stopped before disk changes"
+                )
+        try:
+            mountpoint.rmdir()
+        except OSError:
+            # Never recursively remove a probe directory: if unmount failed,
+            # doing so could modify the filesystem mounted beneath it.
+            pass
+
+
+def _inspect_existing_mount(device: str) -> str | None:
+    """Inspect one existing mount, avoiding a second mount of the same ESP."""
+    try:
+        result = capture(["findmnt", "--json", "--source", device, "--output", "TARGET"])
+    except OSError:
+        return "unreadable"
+    if result.returncode == 1:
+        return None
+    if result.returncode != 0:
+        return "unreadable"
+    try:
+        payload = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError):
+        return "unreadable"
+    filesystems = payload.get("filesystems")
+    if not isinstance(filesystems, list) or len(filesystems) != 1:
+        return "unreadable"
+    target = filesystems[0].get("target")
+    if not isinstance(target, str) or not target.startswith("/"):
+        return "unreadable"
+    try:
+        return "apple" if _contains_apple_directory(Path(target)) else "other"
+    except OSError:
+        return "unreadable"
+
+
+def _contains_apple_directory(root: Path) -> bool:
+    efi = _casefolded_directory(root, "efi")
+    return efi is not None and _casefolded_directory(efi, "apple") is not None
+
+
+def _casefolded_directory(parent: Path, name: str) -> Path | None:
+    for child in parent.iterdir():
+        if child.name.casefold() == name and child.is_dir():
+            return child
+    return None
+
+
+def _inspection_error() -> RuntimeError:
+    return RuntimeError(
+        "Apple T1 safety check could not safely inspect every EFI partition on "
+        "the install target, so installation stopped before disk changes. Check "
+        "the disk for filesystem errors and retry; do not erase an Apple EFI "
+        "partition to bypass this check"
+    )
+
+
+def _missing_apple_data_error() -> RuntimeError:
+    return RuntimeError(
+        "Apple system data is missing or unreadable, so installation stopped "
+        "before disk changes. Without this data, Omarchy cannot use the Touch "
+        "Bar (including Esc and the function-key row), Touch ID, the FaceTime "
+        "camera, or the ambient-light sensor. Back up anything needed from the "
+        "internal disk, connect the Mac to power, and quit the installer. Restart "
+        "while holding Option-Command-R. In Disk Utility choose View > Show All "
+        "Devices, select the internal physical disk, and erase it as APFS with GUID "
+        "Partition Map. This erases everything on that disk. Reinstall macOS, let "
+        "it boot successfully once, then retry Omarchy"
+    )

--- a/test/t1-efi-vm
+++ b/test/t1-efi-vm
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Exercise production preservation helpers against real GPT/FAT block devices
+# in a disposable QEMU guest. No host root, mounts, disks, or network are used.
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+QEMU=${QEMU:-qemu-system-x86_64}
+KERNEL_VERSION=${KERNEL_VERSION:-$(uname -r)}
+KERNEL_IMAGE=${KERNEL_IMAGE:-/usr/lib/modules/$KERNEL_VERSION/vmlinuz}
+[[ -r $KERNEL_IMAGE ]] || { echo "Kernel image is not readable: $KERNEL_IMAGE" >&2; exit 1; }
+command -v "$QEMU" >/dev/null || { echo "QEMU is not available: $QEMU" >&2; exit 1; }
+mkdir -p "$ROOT/test-runs"
+RUN_DIR=$(mktemp -d "$ROOT/test-runs/t1-efi-vm.XXXXXX")
+GUEST_ROOT="$RUN_DIR/root"
+mkdir -p "$GUEST_ROOT"/{usr/bin,usr/lib,dev,proc,sys,run,tmp,probe,etc,fixture}
+ln -s usr/bin "$GUEST_ROOT/bin"
+ln -s usr/bin "$GUEST_ROOT/sbin"
+ln -s usr/lib "$GUEST_ROOT/lib"
+ln -s usr/lib "$GUEST_ROOT/lib64"
+printf 'root:x:0:0:root:/root:/bin/bash\n' >"$GUEST_ROOT/etc/passwd"
+
+copy_binary() {
+  local binary library
+  binary=$(command -v "$1") || { echo "Missing guest build dependency: $1" >&2; exit 1; }
+  cp -L "$binary" "$GUEST_ROOT/usr/bin/$1"
+  while IFS= read -r library; do
+    cp --parents -L "$library" "$GUEST_ROOT"
+  done < <(ldd "$binary" | awk '$2 == "=>" && $3 ~ /^\// {print $3} $1 ~ /^\// {print $1}')
+}
+
+for command in bash mount umount lsblk blkid parted partprobe mkfs.fat mkfs.btrfs \
+  sha256sum find findmnt mkdir mktemp rmdir rm ln cat awk sed grep sort comm head tail cut \
+  sync sleep seq stty tr timeout blockdev swapoff udevadm kmod wipefs lspci \
+  cryptsetup dmsetup python3; do
+  copy_binary "$command"
+done
+python_stdlib=$(python3 -c 'import sysconfig; print(sysconfig.get_path("stdlib"))')
+tar -C / --exclude=site-packages --exclude=__pycache__ --exclude=test \
+  -cf - "${python_stdlib#/}" | tar -C "$GUEST_ROOT" -xf -
+ln -s kmod "$GUEST_ROOT/usr/bin/modprobe"
+ln -s udevadm "$GUEST_ROOT/usr/bin/systemd-udevd"
+mkdir -p "$GUEST_ROOT/usr/lib/udev/rules.d"
+cp /usr/lib/udev/rules.d/{10-dm,13-dm-disk,60-persistent-storage,95-dm-notify}.rules \
+  "$GUEST_ROOT/usr/lib/udev/rules.d/"
+
+for module in virtio_pci virtio_blk virtio_rng vfat nls_cp437 nls_iso8859_1 btrfs dm_crypt xts; do
+  while read -r action file rest; do
+    [[ $action == insmod ]] || continue
+    cp --parents -L "$file" "$GUEST_ROOT"
+  done < <(modprobe -S "$KERNEL_VERSION" --show-depends "$module")
+done
+cp /usr/lib/modules/"$KERNEL_VERSION"/modules.{builtin,builtin.modinfo,order} \
+  "$GUEST_ROOT/usr/lib/modules/$KERNEL_VERSION/"
+depmod -b "$GUEST_ROOT" "$KERNEL_VERSION"
+
+cp "$ROOT/configs/airootfs/root/configurator" "$GUEST_ROOT/fixture/"
+cp "$ROOT/configs/airootfs/usr/share/omarchy-iso/disk-partitioning.sh" "$GUEST_ROOT/fixture/"
+cp "$ROOT/configs/airootfs/usr/local/bin/omarchy-iso-cleanup-disk" "$GUEST_ROOT/usr/bin/"
+cp "$ROOT/test/vm/t1-efi-guest.sh" "$GUEST_ROOT/fixture/"
+cp "$ROOT/test/vm/t1-efi-guard.py" "$GUEST_ROOT/fixture/"
+mkdir -p "$GUEST_ROOT/fixture/orchestrator"
+cp "$ROOT/configs/airootfs/usr/share/omarchy-iso/orchestrator/"{__init__,command,t1_efi}.py \
+  "$GUEST_ROOT/fixture/orchestrator/"
+touch "$GUEST_ROOT/fixture/setup-form.sh"
+printf 'Omarchy\n' >"$GUEST_ROOT/fixture/logo.txt"
+cat >"$GUEST_ROOT/init" <<'INIT'
+#!/bin/bash
+export PATH=/usr/bin
+mount -t devtmpfs devtmpfs /dev
+exec </dev/console >/dev/console 2>&1
+mount -t proc proc /proc
+ln -s /proc/self/fd /dev/fd
+mount -t sysfs sysfs /sys
+mount -t tmpfs tmpfs /run
+for module in virtio_pci virtio_blk virtio_rng vfat nls_cp437 nls_iso8859_1 btrfs dm_crypt xts; do
+  modprobe "$module" || exit 1
+done
+systemd-udevd --daemon
+udevadm trigger --subsystem-match=block
+udevadm settle
+export OMARCHY_T1_VM_TEST=1
+if bash /fixture/t1-efi-guest.sh; then
+  echo 'T1_EFI_VM_EXIT=0'
+else
+  echo "T1_EFI_VM_EXIT=$?"
+fi
+sync
+echo b >/proc/sysrq-trigger
+while true; do sleep 1; done
+INIT
+chmod +x "$GUEST_ROOT/init"
+(cd "$GUEST_ROOT" && find . -print0 | cpio --null -o -H newc --owner=0:0 2>/dev/null) | gzip -1 >"$RUN_DIR/initramfs.gz"
+truncate -s 40G "$RUN_DIR/target.raw"
+truncate -s 40G "$RUN_DIR/external.raw"
+qemu_args=(
+  -nodefaults -no-reboot -nographic -monitor none -serial stdio
+  -m 768 -smp 2
+  -kernel "$KERNEL_IMAGE" -initrd "$RUN_DIR/initramfs.gz"
+  -append 'console=ttyS0 rdinit=/init panic=-1 quiet'
+  -smbios 'type=1,manufacturer=Apple Inc.,product=MacBookPro13,,3'
+  -drive "file=$RUN_DIR/target.raw,format=raw,if=none,id=target"
+  -device virtio-blk-pci,drive=target,serial=T1_TEST_DISK_A
+  -drive "file=$RUN_DIR/external.raw,format=raw,if=none,id=external"
+  -device virtio-blk-pci,drive=external,serial=T1_TEST_DISK_B
+  -object rng-random,id=entropy,filename=/dev/urandom
+  -device virtio-rng-pci,rng=entropy
+)
+if [[ -r /dev/kvm && -w /dev/kvm ]]; then
+  qemu_args+=(-machine q35,accel=kvm -cpu host)
+else
+  qemu_args+=(-machine q35,accel=tcg -cpu max)
+fi
+[[ -z ${QEMU_FIRMWARE_PATH:-} ]] || qemu_args+=(-L "$QEMU_FIRMWARE_PATH")
+printf 'Running isolated preservation VM. Evidence: %s\n' "$RUN_DIR/serial.log"
+timeout 600 "$QEMU" "${qemu_args[@]}" | tee "$RUN_DIR/serial.log"
+grep -qx 'T1_EFI_VM_EXIT=0' <(tr -d '\r' <"$RUN_DIR/serial.log")
+grep -qx 'T1_EFI_VM_PASS' <(tr -d '\r' <"$RUN_DIR/serial.log")

--- a/test/unit/t1-configurator-contract-test.sh
+++ b/test/unit/t1-configurator-contract-test.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+set -uo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+CONFIGURATOR="$ROOT/configs/airootfs/root/configurator"
+LIB="$ROOT/configs/airootfs/usr/share/omarchy-iso/disk-partitioning.sh"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/omarchy" "$WORK/output"
+printf 'Omarchy\n' >"$WORK/omarchy/logo.txt"
+: >"$WORK/setup-form.sh"
+
+OMARCHY_PATH="$WORK/omarchy"
+SETUP_FORM="$WORK/setup-form.sh"
+DISK_PARTITIONING="$LIB"
+OMARCHY_CONFIGURATOR_LIBRARY_ONLY=true
+# shellcheck source=/dev/null
+source "$CONFIGURATOR"
+
+failures=0
+pass() { printf '  ok   %s\n' "$1"; }
+fail() { printf '  FAIL %s\n' "$1"; failures=$((failures + 1)); }
+check() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ $actual == "$expected" ]]; then pass "$label"; else
+    printf '  FAIL %s: expected %s, got %s\n' "$label" "$expected" "$actual"
+    failures=$((failures + 1))
+  fi
+}
+
+echo "==> missing Apple data is a plain hard stop"
+clear_logo() { :; }
+say() { :; }
+step() { :; }
+if (t1_missing_efi_stop) >/dev/null 2>&1; then
+  fail "recovery screen exits instead of continuing"
+else
+  pass "recovery screen exits instead of continuing"
+fi
+
+echo "==> unreadable EFI data has a distinct hard stop"
+say() { printf '%s\n' "$*"; }
+inspection_output=$(t1_efi_inspection_stop 2>&1 || true)
+if [[ $inspection_output == *"could not safely inspect every EFI partition"* &&
+  $inspection_output != *"reinstall macOS"* ]]; then
+  pass "inspection failure does not prescribe reinstalling macOS"
+else
+  fail "inspection failure does not prescribe reinstalling macOS"
+fi
+say() { :; }
+
+echo "==> T1 whole-disk confirmation forces encryption"
+clear_logo() { :; }
+say() { :; }
+gum() { return 0; }
+t1_install=true
+t1_target_has_candidates=true
+encrypt_installation=false
+disk=/dev/mock
+confirm_disk_overwrite
+check "T1 whole-disk confirmation forces encryption" "true" "$encrypt_installation"
+gum_calls=0
+gum() {
+  gum_calls=$((gum_calls + 1))
+  (( gum_calls == 1 )) && return 130
+  return 0
+}
+encrypt_installation=false
+confirm_disk_overwrite
+check "Ctrl+C cannot disable T1 whole-disk encryption" "true" "$encrypt_installation"
+
+echo "==> an external Apple source permits a protected target"
+t1_supported_machine() { return 0; }
+t1_efi_any_candidate_available() { return 0; }
+t1_efi_capture_optional_snapshot() { t1_efi_clear_snapshot; }
+step() { :; }
+disk=/dev/external-target
+t1_snapshot_disk=""
+t1_target_snapshot_ready=false
+t1_prepare_selected_disk
+check "T1 protection remains active" "true" "$t1_install"
+check "target-local preservation set may be empty" "false" "$t1_target_has_candidates"
+check "selected target snapshot is cached" "true" "$t1_target_snapshot_ready"
+
+echo "==> T1 whole-disk plan keeps a separate 2 GiB ESP"
+t1_efi_find_largest_safe_region() {
+  t1_efi_safe_region_start=$((1024 * 1024))
+  t1_efi_safe_region_end=$((80 * 1024 * 1024 * 1024))
+}
+t1_efi_destructive_range_is_safe() { return 0; }
+MOCK_PTTYPE=gpt
+lsblk() { printf '%s\n' "$MOCK_PTTYPE"; }
+encrypt_installation=true
+t1_prepare_whole_disk_layout
+check "Omarchy ESP is exactly 2 GiB" "$((2 * 1024 * 1024 * 1024))" "$((EFI_END_B - EFI_START_B))"
+check "whole-disk handoff enables fallback boot" "true" "$protected_enable_fallback"
+if (unset encrypt_installation; t1_prepare_whole_disk_layout); then
+  pass "whole-disk planning works before the encryption choice"
+else
+  fail "whole-disk planning works before the encryption choice"
+fi
+if (( ROOT_START_B > EFI_END_B && ROOT_END_B < t1_efi_safe_region_end )); then
+  pass "root remains strictly inside the safe range"
+else
+  fail "root remains strictly inside the safe range"
+fi
+
+echo "==> a candidate-free external target can be initialized as GPT"
+t1_efi_clear_snapshot
+t1_target_has_candidates=false
+MOCK_PTTYPE=""
+t1_prepare_whole_disk_layout
+check "blank target requests a GPT label" "true" "$needs_mklabel"
+MOCK_PTTYPE=dos
+t1_prepare_whole_disk_layout
+check "MBR target requests a GPT label" "true" "$needs_mklabel"
+MOCK_PTTYPE=gpt
+t1_prepare_whole_disk_layout
+check "GPT target keeps its partition table" "false" "$needs_mklabel"
+
+echo "==> whole-disk deletion skips every preserved partition"
+deleted=()
+partition_numbers() { printf '%s\n' 1 2 3 4; }
+t1_efi_revalidate_snapshot() { return 0; }
+t1_efi_any_candidate_available() { return 0; }
+t1_efi_capture_optional_snapshot() { return 0; }
+t1_efi_partition_number_is_preserved() { [[ $1 == 1 || $1 == 3 ]]; }
+t1_guard_destructive_partition() { return 0; }
+cleanup_calls=0
+omarchy-iso-cleanup-disk() { cleanup_calls=$((cleanup_calls + 1)); }
+disk_step() {
+  shift
+  if [[ ${1:-} == parted && ${2:-} == --script && ${4:-} == rm ]]; then
+    deleted+=("${5:-}")
+  fi
+}
+partprobe() { :; }
+udevadm() { :; }
+sync() { :; }
+t1_delete_nonpreserved_partitions
+check "whole-disk deletion releases existing holders first" "1" "$cleanup_calls"
+check "only non-preserved partitions are deleted" "2 4" "${deleted[*]}"
+
+echo "==> deferred protected install stages one temporary key"
+cd "$WORK/output"
+defer_provisioning=true
+t1_install=true
+encrypt_installation=true
+full_name=""
+email_address=""
+password=""
+write_user_files
+staged_password=$(jq -r .encryption_password user_credentials.json)
+check "staged key matches formatter input" "$password" "$staged_password"
+if (( ${#staged_password} >= 32 )); then
+  pass "staged key has adequate generated length"
+else
+  fail "staged key has adequate generated length"
+fi
+check "credentials are root-only" "600" "$(stat -c %a user_credentials.json)"
+
+echo "==> protected handoff carries T1 mode flags"
+say() { :; }
+needs_mklabel=false
+kernel_choice=linux
+esp_mount_in_target=/boot
+efi_dev=/dev/mock2
+root_partition_device=/dev/mock3
+root_mapper=/dev/mapper/omarchy_root
+protected_enable_fallback=true
+hostname=omarchy
+timezone=UTC
+keyboard=us
+run_partition_execute dry
+check "handoff uses protected mode" "protected" "$(jq -r .omarchy_install.mode user_configuration.json)"
+check "handoff defers provisioning" "true" "$(jq -r .omarchy_install.defer_provisioning user_configuration.json)"
+check "T1 whole disk enables fallback boot" "true" "$(jq -r .omarchy_install.boot.enable_fallback user_configuration.json)"
+
+protected_enable_fallback=false
+defer_provisioning=false
+run_partition_execute dry
+check "free-space handoff disables fallback boot" "false" "$(jq -r .omarchy_install.boot.enable_fallback user_configuration.json)"
+
+if (( failures > 0 )); then
+  printf '\n%d check(s) failed\n' "$failures"
+  exit 1
+fi
+printf '\nall checks passed\n'

--- a/test/unit/t1-efi-preservation-test.sh
+++ b/test/unit/t1-efi-preservation-test.sh
@@ -1,0 +1,311 @@
+#!/bin/bash
+
+set -uo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)
+LIB="$ROOT/configs/airootfs/usr/share/omarchy-iso/disk-partitioning.sh"
+
+# shellcheck source=../../configs/airootfs/usr/share/omarchy-iso/disk-partitioning.sh
+source "$LIB"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+T1_EFI_MOUNT_PARENT="$WORK"
+failures=0
+
+pass() { printf '  ok   %s\n' "$1"; }
+fail() { printf '  FAIL %s\n' "$1"; failures=$((failures + 1)); }
+
+expect_success() {
+  local label="$1"
+  shift
+  if "$@"; then pass "$label"; else fail "$label"; fi
+}
+
+expect_failure() {
+  local label="$1"
+  shift
+  if "$@"; then fail "$label"; else pass "$label"; fi
+}
+
+check() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ $actual == "$expected" ]]; then pass "$label"; else
+    printf '  FAIL %s: expected %s, got %s\n' "$label" "$expected" "$actual"
+    failures=$((failures + 1))
+  fi
+}
+
+vendor_file="$WORK/vendor"
+product_file="$WORK/product"
+T1_DMI_VENDOR_FILE="$vendor_file"
+T1_DMI_PRODUCT_FILE="$product_file"
+
+echo "==> exact, non-unique T1 model detection"
+printf 'Apple Inc.\n' >"$vendor_file"
+for model in MacBookPro13,2 MacBookPro13,3 MacBookPro14,2 MacBookPro14,3; do
+  printf '%s\n' "$model" >"$product_file"
+  expect_success "accepts $model" t1_supported_machine
+done
+printf 'MacBookPro14,1\n' >"$product_file"
+expect_failure "rejects a non-T1 model" t1_supported_machine
+printf 'Not Apple\n' >"$vendor_file"
+printf 'MacBookPro13,3\n' >"$product_file"
+expect_failure "requires the exact vendor" t1_supported_machine
+
+# The remaining tests use command doubles so they need neither root nor a real
+# disk. They intentionally expose secrets in their fake output; the helpers
+# must capture those values without forwarding them to the test's stdout.
+MOCK_LAYOUT=initial
+MOCK_TREE=mixed-case
+MOCK_MOUNT_OPTIONS=""
+MOCK_MOUNT_FAILURE_PART=""
+MOCK_MOUNTED_PART=""
+MOCK_MOUNTED_ROOT=""
+MOCK_MOUNT_CALLS_FILE="$WORK/mount-calls"
+: >"$MOCK_MOUNT_CALLS_FILE"
+MOCK_REMOVED_PARTITIONS=()
+MOCK_HASH_ONE=$(printf '1%.0s' {1..64})
+MOCK_HASH_TWO=$(printf '2%.0s' {1..64})
+MOCK_HASH_CALLS_FILE="$WORK/hash-calls"
+: >"$MOCK_HASH_CALLS_FILE"
+MOCK_DISK_SIZE=$((100 * 1024 * 1024 * 1024))
+MOCK_ESP_TWO_FILESYSTEM=vfat
+MOCK_ESP_TWO_PARTTYPE="$T1_ESP_PARTTYPE"
+
+lsblk() {
+  local args="$*" target="${*: -1}"
+  if [[ $args == *"-bdno SIZE"* ]]; then
+    printf '%s\n' "$MOCK_DISK_SIZE"
+  elif [[ $args == *"PATH,TYPE"* ]]; then
+    printf '/dev/mock disk\n/dev/mock1 part\n/dev/mock2 part\n/dev/mock3 part\n'
+  elif [[ $args == *"PARTTYPE"* ]]; then
+    case "$target" in
+      /dev/mock1) printf '%s\n' "$T1_ESP_PARTTYPE" ;;
+      /dev/mock2) printf '%s\n' "$MOCK_ESP_TWO_PARTTYPE" ;;
+      /dev/mock3) printf '0fc63daf-8483-4772-8e79-3d69d8477de4\n' ;;
+      *) return 1 ;;
+    esac
+  elif [[ $args == *"FSTYPE"* ]]; then
+    case "$target" in
+      /dev/mock1) printf 'vfat\n' ;;
+      /dev/mock2) printf '%s\n' "$MOCK_ESP_TWO_FILESYSTEM" ;;
+      /dev/mock3) printf 'ext4\n' ;;
+      *) return 1 ;;
+    esac
+  elif [[ $args == *"PARTN"* ]]; then
+    printf '%s\n' "${target#/dev/mock}"
+  else
+    return 1
+  fi
+}
+
+mount() {
+  MOCK_MOUNT_OPTIONS="$2"
+  local part="$4" target="$5"
+  printf x >>"$MOCK_MOUNT_CALLS_FILE"
+  [[ $part != "$MOCK_MOUNT_FAILURE_PART" ]] || return 1
+  [[ $part == /dev/mock1 || $part == /dev/mock2 ]] || return 1
+  if [[ $part == /dev/mock1 ]]; then
+    if [[ $MOCK_TREE == mixed-case ]]; then
+      mkdir -p "$target/eFi/aPpLe/EMBEDDEDOS"
+    else
+      mkdir -p "$target/EFI/OTHER"
+    fi
+  else
+    mkdir -p "$target/EFI/APPLE"
+  fi
+}
+
+findmnt() {
+  local previous="" argument source=""
+  for argument in "$@"; do
+    [[ $previous == "-S" ]] && source=$argument
+    previous=$argument
+  done
+  if [[ -n $MOCK_MOUNTED_PART && $source == "$MOCK_MOUNTED_PART" ]]; then
+    printf '%s\n' "$MOCK_MOUNTED_ROOT"
+    return 0
+  fi
+  return 1
+}
+
+umount() {
+  find "$2" -mindepth 1 -delete
+}
+
+parted() {
+  if [[ $* == *" rm "* ]]; then
+    MOCK_REMOVED_PARTITIONS+=("${*: -1}")
+    return 0
+  fi
+  if [[ $MOCK_LAYOUT == initial ]]; then
+    printf 'BYT;\n/dev/mock:100000B:scsi:512:512:gpt:Mock:;\n'
+    printf '1:1000B:1999B:1000B:fat32:Apple:boot, esp;\n'
+    printf '2:4000B:5999B:2000B:fat32:Apple copy:boot, esp;\n'
+    printf '3:7000B:8999B:2000B:ext4:Other:;\n'
+  elif [[ $MOCK_LAYOUT == moved ]]; then
+    printf 'BYT;\n/dev/mock:100000B:scsi:512:512:gpt:Mock:;\n'
+    printf '1:1001B:2000B:1000B:fat32:Apple:boot, esp;\n'
+    printf '2:4000B:5999B:2000B:fat32:Apple copy:boot, esp;\n'
+  else
+    return 1
+  fi
+}
+
+blkid() {
+  local target="${*: -1}"
+  case "$target" in
+    /dev/mock1) printf 'APPLE-PART-ONE\n' ;;
+    /dev/mock2) printf 'APPLE-PART-TWO\n' ;;
+    /dev/mock3) printf 'OTHER-PART\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+sha256sum() {
+  local target="${*: -1}"
+  printf x >>"$MOCK_HASH_CALLS_FILE"
+  case "$target" in
+    /dev/mock1) printf '%s  %s\n' "$MOCK_HASH_ONE" "$target" ;;
+    /dev/mock2) printf '%s  %s\n' "$MOCK_HASH_TWO" "$target" ;;
+    *) return 1 ;;
+  esac
+}
+
+echo "==> read-only, case-insensitive discovery"
+expect_success "candidate scan succeeds" t1_efi_discover_candidates /dev/mock
+check "finds both Apple ESPs" "/dev/mock1 /dev/mock2" "${t1_efi_candidate_devices[*]}"
+check "records their partition numbers" "1 2" "${t1_efi_candidate_numbers[*]}"
+check "mount is read-only and hardened" "ro,nosuid,nodev,noexec" "$MOCK_MOUNT_OPTIONS"
+: >"$MOCK_MOUNT_CALLS_FILE"
+MOCK_MOUNTED_PART=/dev/mock2
+MOCK_MOUNTED_ROOT="$WORK/mounted-esp"
+mkdir -p "$MOCK_MOUNTED_ROOT/EFI/limine"
+expect_success "an already-mounted new Omarchy ESP does not abort discovery" \
+  t1_efi_discover_candidates /dev/mock
+check "the mounted non-Apple ESP is not a source" "/dev/mock1" "${t1_efi_candidate_devices[*]}"
+check "the mounted ESP is not mounted a second time" "1" "$(wc -c <"$MOCK_MOUNT_CALLS_FILE")"
+MOCK_MOUNTED_ROOT="$WORK/mounted[esp]"
+mkdir -p "$MOCK_MOUNTED_ROOT/eFi/aPpLe"
+expect_success "an existing mount with pattern characters finds its Apple tree" \
+  _t1_efi_contains_apple_tree /dev/mock2
+check "the pattern-named existing mount is not mounted again" "1" "$(wc -c <"$MOCK_MOUNT_CALLS_FILE")"
+MOCK_MOUNTED_PART=""
+MOCK_MOUNTED_ROOT=""
+MOCK_ESP_TWO_PARTTYPE=""
+expect_failure "missing partition type aborts discovery even when FAT is readable" t1_efi_discover_candidates /dev/mock
+MOCK_ESP_TWO_PARTTYPE="$T1_ESP_PARTTYPE"
+MOCK_ESP_TWO_FILESYSTEM=ext4
+expect_failure "rejects a non-FAT partition with the ESP type" _t1_efi_is_esp /dev/mock2
+expect_failure "a non-FAT ESP aborts the complete scan" t1_efi_discover_candidates /dev/mock
+MOCK_ESP_TWO_FILESYSTEM=vfat
+MOCK_MOUNT_FAILURE_PART=/dev/mock2
+expect_failure "a probe error aborts the complete scan" t1_efi_discover_candidates /dev/mock
+MOCK_MOUNT_FAILURE_PART=""
+
+echo "==> ephemeral preservation snapshot"
+snapshot_log="$WORK/snapshot-output"
+expect_success "lightweight planning snapshot succeeds" t1_efi_capture_snapshot /dev/mock false
+check "planning snapshot performs no full hash" "0" "$(wc -c <"$MOCK_HASH_CALLS_FILE")"
+if t1_efi_capture_snapshot /dev/mock >"$snapshot_log" 2>&1; then
+  pass "snapshot succeeds"
+else
+  fail "snapshot succeeds"
+fi
+snapshot_output=$(<"$snapshot_log")
+if [[ $snapshot_output =~ ^Apple\ EFI\ digest\ snapshot\ completed\ in\ [0-9]+\ ms\.$ ]] &&
+  [[ $snapshot_output != *APPLE-PART* && $snapshot_output != *"$MOCK_HASH_ONE"* ]]; then
+  pass "snapshot logs only elapsed digest time"
+else
+  fail "snapshot logs only elapsed digest time"
+fi
+check "captures multiple sources" "2" "${#t1_efi_preserved_devices[@]}"
+check "captures byte starts" "1000 4000" "${t1_efi_preserved_starts[*]}"
+check "captures byte sizes" "1000 2000" "${t1_efi_preserved_sizes[*]}"
+check "captures PARTUUIDs in memory" "APPLE-PART-ONE APPLE-PART-TWO" "${t1_efi_preserved_partuuids[*]}"
+check "captures full raw hashes in memory" "$MOCK_HASH_ONE $MOCK_HASH_TWO" "${t1_efi_preserved_hashes[*]}"
+check "full snapshot hashes each preserved source once" "2" "$(wc -c <"$MOCK_HASH_CALLS_FILE")"
+
+echo "==> destructive range guard"
+expect_failure "rejects an equal preserved range" t1_efi_destructive_range_is_safe 1000 2000
+expect_failure "rejects a partial overlap" t1_efi_destructive_range_is_safe 500 1500
+expect_failure "rejects a containing range" t1_efi_destructive_range_is_safe 0 10000
+expect_success "accepts a range ending at the boundary" t1_efi_destructive_range_is_safe 0 1000
+expect_success "accepts a range starting at the boundary" t1_efi_destructive_range_is_safe 2000 4000
+expect_failure "rejects deleting a preserved partition" t1_efi_destructive_partition_is_safe /dev/mock 1
+expect_success "allows deleting a separate partition" t1_efi_destructive_partition_is_safe /dev/mock 3
+
+echo "==> rollback guards every removal"
+created_parts=(1 3)
+expect_failure "rollback reports a partition that is no longer safe" rollback_created_parts /dev/mock
+check "rollback removes only the still-safe created partition" "3" "${MOCK_REMOVED_PARTITIONS[*]}"
+check "rollback retains the refused partition for diagnosis" "1" "${created_parts[*]}"
+created_parts=()
+
+echo "==> whole-disk safe-region planning"
+mib=$((1024 * 1024))
+gib=$((1024 * mib))
+t1_efi_preserved_starts=("$mib" "$((50 * gib))")
+t1_efi_preserved_sizes=("$((200 * mib))" "$((100 * mib))")
+expect_success "finds a region around multiple preserved ESPs" t1_efi_find_largest_safe_region /dev/mock
+check "chooses the largest contiguous safe start" "$((50 * gib + 100 * mib))" "$t1_efi_safe_region_start"
+check "reserves the final MiB for GPT" "$((100 * gib - mib))" "$t1_efi_safe_region_end"
+expect_success "planned region is outside preserved data" \
+  t1_efi_destructive_range_is_safe "$t1_efi_safe_region_start" "$t1_efi_safe_region_end"
+
+# Restore the captured mock geometry for the snapshot validation checks below.
+t1_efi_preserved_starts=(1000 4000)
+t1_efi_preserved_sizes=(1000 2000)
+
+echo "==> pre/post snapshot validation"
+expect_success "unchanged sources revalidate" t1_efi_revalidate_snapshot /dev/mock
+MOCK_LAYOUT=moved
+expect_failure "changed geometry fails validation" t1_efi_revalidate_snapshot /dev/mock
+MOCK_LAYOUT=initial
+MOCK_HASH_ONE=$(printf 'a%.0s' {1..64})
+expect_failure "changed raw content fails validation" t1_efi_revalidate_snapshot /dev/mock
+
+echo "==> missing Apple tree"
+MOCK_TREE=missing
+# Hide the second ESP so neither readable ESP has EFI/APPLE.
+_t1_efi_partition_devices() { printf '/dev/mock1\n/dev/mock3\n'; }
+expect_success "empty candidate scan itself succeeds" t1_efi_discover_candidates /dev/mock
+check "no candidates when the tree is absent" "0" "${#t1_efi_candidate_devices[@]}"
+expect_failure "snapshot refuses an empty source set" t1_efi_capture_snapshot /dev/mock
+
+echo "==> candidates on a different attached disk"
+GLOBAL_SCANS=()
+GLOBAL_SOURCE_PRESENT=true
+_t1_efi_whole_disks() { printf '/dev/target\n/dev/internal\n/dev/backup\n'; }
+t1_efi_discover_candidates() {
+  GLOBAL_SCANS+=("$1")
+  t1_efi_candidate_devices=()
+  t1_efi_candidate_numbers=()
+  if $GLOBAL_SOURCE_PRESENT && [[ $1 == /dev/internal ]]; then
+    t1_efi_candidate_devices=(/dev/internal1)
+    t1_efi_candidate_numbers=(1)
+  fi
+}
+expect_success "finds Apple data away from the install target" t1_efi_any_candidate_available
+check "checks every attached whole disk" "/dev/target /dev/internal /dev/backup" "${GLOBAL_SCANS[*]}"
+GLOBAL_SOURCE_PRESENT=false
+expect_failure "reports missing only when no attached disk has a candidate" t1_efi_any_candidate_available
+
+t1_efi_clear_snapshot
+expect_success "a target with no local candidate has a valid empty snapshot" \
+  t1_efi_capture_optional_snapshot /dev/target false
+expect_failure "the strict snapshot still requires a target-local candidate" \
+  t1_efi_capture_snapshot /dev/target false
+t1_efi_preserved_starts=()
+t1_efi_preserved_sizes=()
+expect_success "an external source does not constrain target layout" \
+  t1_efi_find_largest_safe_region /dev/mock
+check "unconstrained target starts after primary GPT" "$mib" "$t1_efi_safe_region_start"
+check "unconstrained target reserves backup GPT space" "$((100 * gib - mib))" "$t1_efi_safe_region_end"
+
+if (( failures > 0 )); then
+  printf '\n%d check(s) failed\n' "$failures"
+  exit 1
+fi
+printf '\nall checks passed\n'

--- a/test/unit/test_t1_efi_guard.py
+++ b/test/unit/test_t1_efi_guard.py
@@ -1,0 +1,334 @@
+"""T1 Apple-EFI safety checks for interactive and unattended installs."""
+
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "configs/airootfs/usr/share/omarchy-iso"))
+
+sys.modules.setdefault(
+    "orchestrator.archinstall_adapter", types.ModuleType("orchestrator.archinstall_adapter")
+)
+
+from orchestrator import phases_impl, t1_efi  # noqa: E402
+
+
+def make_ctx(tmp: Path, *, mode="protected", config_type=None, wipe=None):
+    if config_type is None:
+        config_type = "pre_mounted_config" if mode == "protected" else "default_layout"
+    if wipe is None:
+        wipe = mode == "full_disk"
+    modifications = [{"device": "/dev/target", "wipe": True}] if wipe else []
+    return types.SimpleNamespace(
+        mode=mode,
+        is_protected=mode == "protected",
+        target=tmp / "mnt",
+        state_dir=tmp / "state",
+        state={},
+        user_configuration={"disk_config": {
+            "config_type": config_type,
+            "device_modifications": modifications,
+        }},
+        omarchy_install={"mode": mode, "storage": {"esp_device": "/dev/target2"}},
+    )
+
+
+class T1PreservationPlanTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def validate(self, ctx, sources, *, supported=True):
+        with (
+            mock.patch.object(t1_efi, "_is_supported_t1_mac", return_value=supported),
+            mock.patch.object(t1_efi, "_parent_disk", return_value="/dev/target"),
+            mock.patch.object(
+                t1_efi, "_discover_apple_efi_sources", return_value=sources,
+            ) as discover,
+        ):
+            t1_efi.validate_t1_efi_preservation(ctx)
+            return discover
+
+    def test_non_t1_full_disk_plan_is_unchanged(self):
+        ctx = make_ctx(self.root, mode="full_disk")
+        discover = self.validate(ctx, {}, supported=False)
+        discover.assert_not_called()
+
+    def test_t1_full_disk_target_with_apple_data_hard_stops(self):
+        ctx = make_ctx(self.root, mode="full_disk")
+        with self.assertRaises(RuntimeError):
+            self.validate(ctx, {"/dev/target": {"/dev/target1"}})
+
+    def test_t1_full_disk_target_is_valid_with_apple_data_on_another_disk(self):
+        ctx = make_ctx(self.root, mode="full_disk")
+        self.validate(ctx, {
+            "/dev/target": set(),
+            "/dev/internal": {"/dev/internal1"},
+        })
+
+    def test_t1_without_any_readable_apple_source_hard_stops(self):
+        ctx = make_ctx(self.root, mode="full_disk")
+        with self.assertRaises(RuntimeError):
+            self.validate(ctx, {})
+
+    def test_t1_target_must_be_an_attached_whole_disk(self):
+        ctx = make_ctx(self.root, mode="full_disk")
+        with self.assertRaises(RuntimeError):
+            self.validate(ctx, {"/dev/internal": {"/dev/internal1"}})
+
+    def test_t1_mode_label_cannot_hide_default_layout(self):
+        ctx = make_ctx(self.root, mode="protected", config_type="default_layout")
+        with self.assertRaises(RuntimeError):
+            self.validate(ctx, {"/dev/internal": {"/dev/internal1"}})
+
+    def test_t1_pre_mounted_plan_cannot_retain_a_wipe_operation(self):
+        ctx = make_ctx(self.root, wipe=True)
+        with self.assertRaises(RuntimeError):
+            self.validate(ctx, {"/dev/internal": {"/dev/internal1"}})
+
+    def test_t1_protected_target_with_distinct_preserved_data_is_valid(self):
+        ctx = make_ctx(self.root)
+        self.validate(ctx, {"/dev/target": {"/dev/target1"}})
+
+    def test_t1_protected_target_with_only_external_data_is_valid(self):
+        ctx = make_ctx(self.root)
+        self.validate(ctx, {
+            "/dev/target": set(),
+            "/dev/internal": {"/dev/internal1"},
+        })
+
+    def test_t1_protected_target_cannot_reuse_apple_esp_for_omarchy(self):
+        ctx = make_ctx(self.root)
+        with self.assertRaises(RuntimeError):
+            self.validate(ctx, {"/dev/target": {"/dev/target2"}})
+
+    def test_each_boundary_rescans_plan_and_live_data(self):
+        ctx = make_ctx(self.root)
+        first = self.validate(ctx, {"/dev/target": {"/dev/target1"}})
+        first.assert_called_once_with(ctx.state_dir, "/dev/target")
+        second = self.validate(ctx, {"/dev/target": {"/dev/target1"}})
+        second.assert_called_once_with(ctx.state_dir, "/dev/target")
+        ctx.user_configuration["disk_config"]["device_modifications"] = [{"wipe": True}]
+        with self.assertRaises(RuntimeError):
+            self.validate(ctx, {"/dev/target": {"/dev/target1"}})
+
+
+class T1ModelDetectionTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.dmi = Path(self.tmp.name)
+
+    def detected(self, vendor, model):
+        (self.dmi / "sys_vendor").write_text(vendor)
+        (self.dmi / "product_name").write_text(model)
+        with mock.patch.object(t1_efi, "_DMI_ROOT", self.dmi):
+            return t1_efi._is_supported_t1_mac()
+
+    def test_exact_supported_apple_model_is_detected(self):
+        self.assertTrue(self.detected("Apple Inc.\n", "MacBookPro13,3\n"))
+
+    def test_other_apple_model_is_not_detected(self):
+        self.assertFalse(self.detected("Apple Inc.\n", "MacBookPro15,1\n"))
+
+    def test_model_name_without_apple_vendor_is_not_detected(self):
+        self.assertFalse(self.detected("Example Vendor\n", "MacBookPro13,3\n"))
+
+
+class T1AppleEfiProbeTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def test_apple_path_match_is_case_insensitive(self):
+        (self.root / "efi" / "Apple").mkdir(parents=True)
+        self.assertTrue(t1_efi._contains_apple_directory(self.root))
+
+    def test_whole_disk_inventory_excludes_partitions_and_mappers(self):
+        payload = {"blockdevices": [
+            {"path": "/dev/mapper/root", "type": "crypt"},
+            {"path": "/dev/internal", "type": "disk", "children": [
+                {"path": "/dev/internal1", "type": "part"},
+            ]},
+            {"path": "/dev/loop0", "type": "loop"},
+        ]}
+        result = CompletedProcess([], 0, stdout=json.dumps(payload), stderr="")
+        with mock.patch.object(t1_efi, "capture", return_value=result):
+            self.assertEqual(t1_efi._whole_disks(), ["/dev/internal"])
+
+    def test_fat_partition_list_is_limited_to_parts(self):
+        payload = {"blockdevices": [{
+            "path": "/dev/fake",
+            "type": "disk",
+            "fstype": None,
+            "children": [
+                {
+                    "path": "/dev/fake1",
+                    "type": "part",
+                    "fstype": "vfat",
+                    "parttype": t1_efi._ESP_PARTTYPE,
+                },
+                {
+                    "path": "/dev/fake2",
+                    "type": "part",
+                    "fstype": "btrfs",
+                    "parttype": "not-an-esp",
+                },
+                {
+                    "path": "/dev/fake3",
+                    "type": "part",
+                    "fstype": "vfat",
+                    "parttype": "not-an-esp",
+                },
+            ],
+        }]}
+        result = CompletedProcess([], 0, stdout=json.dumps(payload), stderr="")
+        with mock.patch.object(t1_efi, "capture", return_value=result):
+            self.assertEqual(t1_efi._fat_partitions("/dev/fake"), ["/dev/fake1"])
+
+    def test_esp_with_unreadable_filesystem_hard_stops_inventory(self):
+        payload = {"blockdevices": [{
+            "path": "/dev/fake1",
+            "type": "part",
+            "fstype": None,
+            "parttype": t1_efi._ESP_PARTTYPE,
+        }]}
+        result = CompletedProcess([], 0, stdout=json.dumps(payload), stderr="")
+        with mock.patch.object(t1_efi, "capture", return_value=result):
+            with self.assertRaisesRegex(RuntimeError, "could not safely inspect"):
+                t1_efi._fat_partitions("/dev/fake")
+
+    def test_missing_partition_type_stops_target_inventory(self):
+        for part_type in (None, "", " "):
+            with self.subTest(part_type=part_type):
+                payload = {"blockdevices": [{
+                    "path": "/dev/fake1", "type": "part",
+                    "fstype": "vfat", "parttype": part_type,
+                }]}
+                result = CompletedProcess([], 0, stdout=json.dumps(payload), stderr="")
+                with mock.patch.object(t1_efi, "capture", return_value=result):
+                    with self.assertRaisesRegex(RuntimeError, "could not safely inspect"):
+                        t1_efi._fat_partitions("/dev/fake")
+                    self.assertEqual(t1_efi._fat_partitions("/dev/fake", strict=False), [])
+
+    def test_already_mounted_new_omarchy_esp_is_inspected_without_remount(self):
+        mounted = self.root / "target-esp"
+        (mounted / "EFI" / "limine").mkdir(parents=True)
+        findmnt = CompletedProcess(
+            [], 0,
+            stdout=json.dumps({"filesystems": [{"target": str(mounted)}]}),
+            stderr="",
+        )
+        with (
+            mock.patch.object(t1_efi, "capture", return_value=findmnt),
+            mock.patch.object(t1_efi.subprocess, "run") as run,
+        ):
+            self.assertEqual(
+                t1_efi._inspect_partition("/dev/target2", self.root / "state"),
+                "other",
+            )
+            run.assert_not_called()
+
+    def test_sources_are_discovered_across_attached_whole_disks(self):
+        contents = {
+            "/dev/target1": "other",
+            "/dev/internal1": "apple",
+            "/dev/internal2": "apple",
+        }
+        with (
+            mock.patch.object(
+                t1_efi, "_whole_disks", return_value=["/dev/target", "/dev/internal"],
+            ),
+            mock.patch.object(
+                t1_efi,
+                "_fat_partitions",
+                side_effect=lambda disk, **_kwargs: {
+                    "/dev/target": ["/dev/target1"],
+                    "/dev/internal": ["/dev/internal1", "/dev/internal2"],
+                }[disk],
+            ),
+            mock.patch.object(t1_efi, "_inspect_partition", side_effect=contents.get),
+        ):
+            self.assertEqual(
+                t1_efi._discover_apple_efi_sources(self.root, "/dev/target"),
+                {
+                    "/dev/target": set(),
+                    "/dev/internal": {"/dev/internal1", "/dev/internal2"},
+                },
+            )
+
+    def test_unreadable_target_efi_probe_hard_stops_complete_discovery(self):
+        contents = {"/dev/target1": "unreadable", "/dev/internal1": "apple"}
+        with (
+            mock.patch.object(
+                t1_efi, "_whole_disks", return_value=["/dev/target", "/dev/internal"],
+            ),
+            mock.patch.object(
+                t1_efi,
+                "_fat_partitions",
+                side_effect=lambda disk, **_kwargs: {
+                    "/dev/target": ["/dev/target1"],
+                    "/dev/internal": ["/dev/internal1"],
+                }[disk],
+            ),
+            mock.patch.object(t1_efi, "_inspect_partition", side_effect=contents.get),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "could not safely inspect"):
+                t1_efi._discover_apple_efi_sources(self.root, "/dev/target")
+
+    def test_unreadable_off_target_efi_does_not_hide_readable_source(self):
+        contents = {"/dev/extra1": "unreadable", "/dev/internal1": "apple"}
+        with (
+            mock.patch.object(
+                t1_efi,
+                "_whole_disks",
+                return_value=["/dev/target", "/dev/extra", "/dev/internal"],
+            ),
+            mock.patch.object(
+                t1_efi,
+                "_fat_partitions",
+                side_effect=lambda disk, **_kwargs: {
+                    "/dev/target": [],
+                    "/dev/extra": ["/dev/extra1"],
+                    "/dev/internal": ["/dev/internal1"],
+                }[disk],
+            ),
+            mock.patch.object(t1_efi, "_inspect_partition", side_effect=contents.get),
+        ):
+            self.assertEqual(
+                t1_efi._discover_apple_efi_sources(self.root, "/dev/target"),
+                {
+                    "/dev/target": set(),
+                    "/dev/extra": set(),
+                    "/dev/internal": {"/dev/internal1"},
+                },
+            )
+
+
+class FilesystemBoundaryTest(unittest.TestCase):
+    def test_guard_runs_before_archinstall_filesystem_operations(self):
+        ctx = types.SimpleNamespace(state={})
+        with (
+            mock.patch.object(
+                phases_impl,
+                "validate_t1_efi_preservation",
+                side_effect=RuntimeError("unsafe"),
+            ),
+            mock.patch.object(
+                phases_impl.arch, "perform_filesystem_operations", create=True,
+            ) as mutate,
+        ):
+            with self.assertRaises(RuntimeError):
+                phases_impl.arch_install_system(ctx)
+            mutate.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/vm/README.md
+++ b/test/vm/README.md
@@ -1,0 +1,11 @@
+# T1 EFI VM test
+
+Run `./test/t1-efi-vm` on Arch with QEMU, a readable kernel and matching modules, Python, cpio, gzip, tar, kmod, systemd, util-linux, parted, dosfstools, btrfs-progs, cryptsetup, and pciutils.
+
+The runner needs no root privileges. It boots an initramfs with two synthetic disks, without host disk access, shared directories, USB passthrough, or networking. Logs and disposable images remain in `test-runs/t1-efi-vm.*/`. Missing completion markers or a ten-minute timeout fail the test.
+
+Override `QEMU`, `QEMU_FIRMWARE_PATH`, `KERNEL_VERSION`, or `KERNEL_IMAGE` when their defaults do not match your host.
+
+The guest checks production partitioning helpers and the unattended-install guard with real GPT/FAT/LUKS2/Btrfs operations: multiple Apple ESPs, separate install disk, format guards, rollback, damaged metadata, and missing data. Preserved GPT entries, PARTUUIDs, and raw ESP hashes must remain identical.
+
+This does **not** validate a complete ISO install, bootloader, remaining orchestrator phases, T1 hardware, or calibration import. Encryption uses a test-only KDF. Run `./test/all` for unit coverage.

--- a/test/vm/t1-efi-guard.py
+++ b/test/vm/t1-efi-guard.py
@@ -1,0 +1,55 @@
+"""Run the production unattended-install guard against this VM's real disks."""
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from orchestrator.t1_efi import _is_supported_t1_mac, validate_t1_efi_preservation
+
+
+assert os.environ.get("OMARCHY_T1_VM_TEST") == "1"
+assert Path("/sys/class/block/vda/serial").read_text().strip() == "T1_TEST_DISK_A"
+assert _is_supported_t1_mac(), "model gate must execute the T1 checks"
+
+
+def context(*, disk=None, esp=None):
+    if esp:
+        config = {"config_type": "pre_mounted_config"}
+    else:
+        config = {
+            "config_type": "default_layout",
+            "device_modifications": [{"device": disk, "wipe": True}],
+        }
+    return SimpleNamespace(
+        mode="protected" if esp else "full_disk",
+        state_dir=Path("/run/t1-guard"),
+        user_configuration={"disk_config": config},
+        omarchy_install={"storage": {"esp_device": esp}},
+    )
+
+
+def rejects(plan, reason):
+    try:
+        validate_t1_efi_preservation(plan)
+    except RuntimeError as error:
+        assert reason in str(error), f"unexpected rejection: {error}"
+    else:
+        raise AssertionError("unsafe plan accepted")
+
+
+stage = sys.argv[1]
+if stage == "layouts":
+    rejects(context(disk="/dev/vda"), "target disk contains Apple EFI data")
+    rejects(context(esp="/dev/vda1"), "separate EFI partition")
+    validate_t1_efi_preservation(context(esp=sys.argv[2]))
+    validate_t1_efi_preservation(context(disk="/dev/vdb"))
+elif stage == "damaged":
+    rejects(context(disk="/dev/vda"), "could not safely inspect")
+elif stage == "missing":
+    rejects(context(disk="/dev/vdb"), "Apple system data is missing")
+else:
+    raise AssertionError("unknown fixture stage")
+
+assert not list(Path("/run/t1-guard").glob(".apple-efi-check-*")), "probe mount leaked"
+print(f"ok - unattended T1 guard: {stage}")

--- a/test/vm/t1-efi-guest.sh
+++ b/test/vm/t1-efi-guest.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Runs only inside test/t1-efi-vm's disposable, disk-isolated guest.
+set -eEu
+trap 'printf "not ok - line %s: %s\n" "$LINENO" "$BASH_COMMAND" >&2' ERR
+
+[[ ${OMARCHY_T1_VM_TEST:-} == 1 && $$ != 1 ]]
+[[ $(cat /sys/class/dmi/id/product_name) == MacBookPro13,3 ]]
+[[ $(cat /sys/class/block/vda/serial) == T1_TEST_DISK_A ]]
+[[ $(cat /sys/class/block/vdb/serial) == T1_TEST_DISK_B ]]
+
+export OMARCHY_PATH=/fixture SETUP_FORM=/fixture/setup-form.sh
+export DISK_PARTITIONING=/fixture/disk-partitioning.sh
+export OMARCHY_CONFIGURATOR_LIBRARY_ONLY=true
+# The UI is not driven here; load the production partitioning functions.
+set +e
+source /fixture/configurator
+set -euo pipefail
+
+pass() { printf 'ok - %s\n' "$1"; }
+reject() {
+  if "$@"; then
+    printf 'not ok - unsafe operation accepted: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+seed_apple_esp() {
+  local partition=$1
+  mkfs.fat -F32 "$partition" >/dev/null
+  mount "$partition" /probe
+  mkdir -p /probe/eFi/aPpLe/EMBEDDEDOS/FDRData
+  printf 'SYNTHETIC TEST DATA ONLY\n' >/probe/eFi/aPpLe/EMBEDDEDOS/FDRData/fixture
+  umount /probe
+  udevadm trigger --action=change "$partition"
+  udevadm settle
+}
+
+disk=/dev/vda
+t1_install=true
+parted -s "$disk" mklabel gpt \
+  mkpart primary fat32 1MiB 65MiB set 1 esp on \
+  mkpart primary fat32 66MiB 130MiB set 2 esp on \
+  mkpart primary ext4 131MiB 100%
+partprobe "$disk"
+wait_for_device /dev/vda3
+seed_apple_esp /dev/vda1
+seed_apple_esp /dev/vda2
+t1_supported_machine
+t1_efi_capture_snapshot "$disk"
+[[ ${#t1_efi_preserved_devices[@]} == 2 ]]
+pass 'real FAT/GPT discovery finds both mixed-case Apple trees'
+
+# Retain an independent receipt, outside the snapshot the production deletion
+# routine refreshes. UUID, byte extent and raw content must all stay identical.
+before_geometry=$(parted -ms "$disk" unit B print | sed -n '3,4p')
+before_uuids=$(blkid -s PARTUUID -o value /dev/vda1 /dev/vda2)
+before_hashes=$(sha256sum /dev/vda1 /dev/vda2)
+reject t1_efi_destructive_partition_is_safe "$disk" 1
+reject create_partition "$disk" 1048576 2097152 fat32 unsafe
+
+t1_delete_nonpreserved_partitions
+[[ $(partition_numbers "$disk") == $'1\n2' ]]
+create_partition "$disk" "$EFI_START_B" "$EFI_END_B" fat32 OMARCHY
+efi_part_num=$created_partition_number
+efi_dev=$(partition_path "$disk" "$efi_part_num")
+wait_for_device "$efi_dev"
+t1_guard_destructive_partition "$efi_part_num" format
+parted -s "$disk" set "$efi_part_num" esp on
+mkfs.fat -F32 "$efi_dev" >/dev/null
+create_partition "$disk" "$ROOT_START_B" "$ROOT_END_B" btrfs ROOT
+root_part_num=$created_partition_number
+root_dev=$(partition_path "$disk" "$root_part_num")
+wait_for_device "$root_dev"
+t1_guard_destructive_partition "$root_part_num" format
+# A cheap test-only KDF keeps this small guest fast. The assertion concerns
+# partition writes and preservation, not production password/KDF policy.
+printf 'synthetic-vm-key\n' >/run/luks-key
+cryptsetup luksFormat --type luks2 --batch-mode --pbkdf pbkdf2 --iter-time 10 \
+  --key-file /run/luks-key "$root_dev"
+cryptsetup open --key-file /run/luks-key "$root_dev" t1-test-root
+mkfs.btrfs -f /dev/mapper/t1-test-root >/dev/null
+cryptsetup close t1-test-root
+cryptsetup isLuks --type luks2 "$root_dev"
+sync
+t1_efi_revalidate_snapshot "$disk"
+[[ $(parted -ms "$disk" unit B print | sed -n '3,4p') == "$before_geometry" ]]
+[[ $(blkid -s PARTUUID -o value /dev/vda1 /dev/vda2) == "$before_uuids" ]]
+[[ $(sha256sum /dev/vda1 /dev/vda2) == "$before_hashes" ]]
+pass 'delete/create/format preserves both Apple ESPs byte-for-byte and keeps their GPT identity'
+
+mount "$efi_dev" /probe
+t1_efi_discover_candidates "$disk"
+[[ ${#t1_efi_candidate_devices[@]} == 2 ]]
+umount /probe
+pass 'a mounted separate Omarchy ESP does not break subsequent discovery'
+python3 /fixture/t1-efi-guard.py layouts "$efi_dev"
+[[ $(sha256sum /dev/vda1 /dev/vda2) == "$before_hashes" ]]
+
+rollback_created_parts "$disk"
+[[ $(partition_numbers "$disk") == $'1\n2' ]]
+t1_efi_revalidate_snapshot "$disk"
+pass 'rollback deletes only the newly created partitions'
+
+# Real external-disk installation: the Apple data remains on vda, while vdb
+# can use the normal protected layout without a local Apple source.
+disk=/dev/vdb
+t1_efi_any_candidate_available
+t1_efi_capture_optional_snapshot "$disk"
+[[ ${#t1_efi_preserved_devices[@]} == 0 ]]
+t1_prepare_whole_disk_layout
+[[ $needs_mklabel == true ]]
+parted -s "$disk" mklabel gpt
+create_partition "$disk" "$EFI_START_B" "$EFI_END_B" fat32 OMARCHY
+mkfs.fat -F32 "$(partition_path "$disk" "$created_partition_number")" >/dev/null
+[[ $(sha256sum /dev/vda1 /dev/vda2) == "$before_hashes" ]]
+pass 'an external install target leaves the original Apple disk unchanged'
+
+# Prove unreadable target ESPs fail inspection before an install is attempted.
+disk=/dev/vda
+wipefs -a /dev/vda2 >/dev/null
+udevadm trigger --action=change /dev/vda2
+udevadm settle
+reject t1_efi_capture_optional_snapshot "$disk"
+python3 /fixture/t1-efi-guard.py damaged
+pass 'an ESP with a damaged filesystem stops preservation planning'
+
+# Remove synthetic Apple directories to exercise the missing-data hard stop.
+seed_apple_esp /dev/vda2
+for partition in /dev/vda1 /dev/vda2; do
+  mount "$partition" /probe
+  rm -r /probe/eFi
+  umount /probe
+done
+reject t1_efi_any_candidate_available
+python3 /fixture/t1-efi-guard.py missing
+pass 'readable ESPs without Apple data cannot pass the availability gate'
+printf 'T1_EFI_VM_PASS\n'


### PR DESCRIPTION
# Preserve Apple EFI data when installing on T1 Macs

On the four supported T1 MacBook Pro models, whole-disk setup preserves every detected Apple EFI source and creates a separate Omarchy ESP and encrypted root. It checks preserved partition geometry, PARTUUIDs, and raw contents before accepting the layout. Rollback removes only partitions created by this run.

The orchestrator also checks unattended plans before cleanup and filesystem operations. Missing Apple data, unreadable target ESPs, missing partition types, and unsafe layouts stop installation before those operations.

Validation: the unit suite passes, including 87 Python tests. An unprivileged VM exercises real GPT, FAT, LUKS2, and Btrfs operations with multiple Apple ESPs and a separate install disk; preserved data remains unchanged through formatting and rollback.

Stock systemd may add `/loader/random-seed` to an Apple ESP during boot. Post-boot acceptance checks partition geometry, PARTUUIDs, and original file contents, including the complete Apple tree. The installer's stricter raw-content checks remain in place before reboot. A fresh stock-systemd ISO passed full installation, encrypted boot, discovery before and after boot, and all original-file checks on both Apple ESPs. Only `/loader/random-seed` was added.

Before shipping: verify physical T1 activation and calibration import. No systemd patch or custom systemd package is required by this proposal.
