### PR TITLE
Map broadcom-wl to broadcom-wl-dkms in the offline mirror list

### DIFF
--- a/builder/build-iso.sh
+++ b/builder/build-iso.sh
@@ -200,6 +200,16 @@ mapfile -t all_packages < <(
   } | sort -u
 )
 
+# Arch dropped the prebuilt broadcom-wl on 2026-09-02 and rebuilt broadcom-wl-dkms
+# with replaces=(broadcom-wl). A replaces entry only helps upgrades of an already
+# installed package; as an explicit pacman target the old name now fails with
+# "target not found". Published Omarchy runtime packages that predate the rename
+# still list it in omarchy-other.packages, so map it here until every channel
+# ships a runtime that names broadcom-wl-dkms itself.
+mapfile -t all_packages < <(
+  printf '%s\n' "${all_packages[@]}" | sed 's/^broadcom-wl$/broadcom-wl-dkms/' | sort -u
+)
+
 # With --local-source we already built these omarchy* packages directly into
 # the mirror; strip them from the pacman -Syw list so it doesn't try to fetch
 # the published versions on top.


### PR DESCRIPTION
Arch removed the prebuilt `broadcom-wl` package on 2026-09-02 and rebuilt `broadcom-wl-dkms` with `replaces=(broadcom-wl)`. A replaces entry only helps upgrades of an installed package, so as an explicit `pacman -Syw` target the old name now fails with `target not found: broadcom-wl`, which broke the offline mirror download in every ISO build.

The Omarchy runtime package list is fixed separately (omacom/omarchy). This rewrites the name at build time so builds against already-published runtime packages keep working until every channel ships a runtime that names `broadcom-wl-dkms` itself.