### PR TITLE
Match the greeter on the part of the tagline that is not the pitch

### DIFF
--- a/bin/omarchy-iso-test
+++ b/bin/omarchy-iso-test
@@ -614,7 +614,7 @@ drive_configurator() {
   log "Driving the installer wizard"
 
   # A greeter (animated logo + tagline) opens the installer; Return begins.
-  wait_for_screen "Opinionated" 300
+  wait_for_screen "Linux by DHH" 300
   capture_console "success-installer-00-greeter"
   press ret
 
@@ -731,7 +731,7 @@ drive_provision_owner() {
   # layout — UK leaves every letter identical to US, so the typed password (sent
   # as raw keycodes) still matches the literal one the harness pipes to sudo.
   # A greeter (animated logo + tagline) opens first boot; Return begins.
-  wait_for_screen "Opinionated" 600
+  wait_for_screen "Linux by DHH" 600
   capture_console "success-provision-00-greeter"
   press ret
 
@@ -806,7 +806,7 @@ wait_for_install() {
     # Deferred-provisioning installs skip the celebration and reboot on their own
     # (no Reboot Now prompt); the first-boot greeter tagline appearing means the
     # install finished and rebooted into setup.
-    if $PROVISION && grep -qi "Opinionated" <<<"$text"; then
+    if $PROVISION && grep -qi "Linux by DHH" <<<"$text"; then
       log "Install finished and auto-rebooted into first-boot setup."
       capture_console "success-installer-15-autoreboot"
       return 0

--- a/test/integration.d/factory-reset-test.sh
+++ b/test/integration.d/factory-reset-test.sh
@@ -165,7 +165,7 @@ drive_first_boot() {
   # first-boot greeter on its own. A numeric default_entry pointing at a
   # moved entry parks Limine at the menu instead — catch that explicitly,
   # then boot the Omarchy entry by hand so the rest of the flow still runs.
-  if wait_for_screen "Opinionated" 120 2>/dev/null; then
+  if wait_for_screen "Linux by DHH" 120 2>/dev/null; then
     printf 'ok - %s\n' "the machine boots into first-boot setup unattended"
   else
     if ocr_screen | grep -qi "Omarchy Bootloader"; then
@@ -175,7 +175,7 @@ drive_first_boot() {
       log "Selecting the Omarchy entry manually to continue the run"
       press down; sleep 1; press down; sleep 1; press down; sleep 1
       press ret
-      wait_for_screen "Opinionated" 600
+      wait_for_screen "Linux by DHH" 600
     else
       echo "Neither the greeter nor the Limine menu appeared" >&2
       return 1


### PR DESCRIPTION
# PR 1 — Match the greeter on the part of the tagline that is not the pitch

**Branch:** `greeter-matcher` → `quattro`
**Size:** 2 files, 5 lines

## What is broken

The acceptance harness waits for the installer greeter by looking for the word
`Opinionated`. The tagline no longer contains it — since the tagline update it
reads *"Beautiful, Fun & Agentic Linux by DHH"*.

Every scenario the harness drives therefore dies on the first screen, five
minutes into a run that never gets any further:

```
Timed out after 300s waiting for screen: Opinionated
```

This affects all five call sites, in `bin/omarchy-iso-test` (3) and
`test/integration.d/factory-reset-test.sh` (2), so the whole acceptance suite
is currently non-functional on `quattro`, not just one scenario.

## The change

Match `Linux by DHH` instead.

That substring is common to the old wording and the new, it names the product
rather than describing it, and a tagline is marketing copy that will be
rewritten again. Matching the durable half means the next rewrite does not
break the tests.

## How it was verified

Observed directly, not reasoned about:

1. Booted the ISO under the harness and OCR'd the greeter. Tesseract reads it
   as `Beautiful, Fun & Agentic Linux by DHH` — confirming both that
   `Opinionated` is absent and that `Linux by DHH` survives OCR cleanly.
2. Before the fix: run failed at `wait_for_screen "Opinionated"` after 300s,
   with a single screenshot, `failure-installer-waiting-for-opinionated.png`.
3. After the fix: the same run cleared the greeter and drove the full wizard —
   keyboard, username, password, full name, email, hostname, timezone, review,
   disk selection — capturing 13 screenshots, all matching.

Found while bringing up an unrelated scenario; it is submitted separately
because it blocks every run of the suite and should not wait on a feature
review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated installation acceptance tests to recognize the current “Linux by DHH” installer greeter.
  * Updated factory-reset tests to detect the current first-boot screen during unattended startup and manual recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
