### PR TITLE
Build the ISO with podman when docker is not installed

### DIFF
--- a/bin/omarchy-iso-make
+++ b/bin/omarchy-iso-make
@@ -120,6 +120,36 @@ mkdir -p "$BUILD_RELEASE_PATH"
 OMARCHY_ISO_REF="${OMARCHY_ISO_REF:-quattro}"
 OMARCHY_MIRROR="${OMARCHY_MIRROR:-stable}"
 
+# The docker group is root-equivalent, so Omarchy operators stay out of it on
+# purpose. When the socket refuses the calling user, run the client through
+# sudo instead of requiring group membership.
+#
+# Podman accepts every argument this script passes and needs no daemon, but it
+# has to be ROOTFUL. Rootless was tried and does not work: pacstrap chowns the
+# device nodes it creates in the target, and in a user namespace that is not
+# permitted — the build dies on
+#
+#   fchownat() of /dev/vhost-vsock failed: Operation not permitted
+#
+# partway through package installation, long after it looks like it is working.
+# Rootless also cannot allocate a loop device, though that one does not matter
+# here: mkarchiso builds its EFI image with mtools rather than by mounting.
+if command -v docker &>/dev/null; then
+  CONTAINER=(docker)
+  if ! docker version &>/dev/null; then
+    CONTAINER=(sudo docker)
+  fi
+elif command -v podman &>/dev/null; then
+  if ((EUID == 0)); then
+    CONTAINER=(podman)
+  else
+    CONTAINER=(sudo podman)
+  fi
+else
+  echo "Error: this build needs docker or podman, and found neither." >&2
+  exit 1
+fi
+
 DOCKER_ARGS=(
   --rm
   --privileged
@@ -158,15 +188,7 @@ else
   DOCKER_ARGS+=(--pull=always)
 fi
 
-# The docker group is root-equivalent, so Omarchy operators stay out of it on
-# purpose. When the socket refuses the calling user, run the client through
-# sudo instead of requiring group membership.
-DOCKER=(docker)
-if ! docker version &>/dev/null; then
-  DOCKER=(sudo docker)
-fi
-
-"${DOCKER[@]}" run "${DOCKER_ARGS[@]}" archlinux/archlinux:latest /$BUILD_SCRIPT
+"${CONTAINER[@]}" run "${DOCKER_ARGS[@]}" docker.io/archlinux/archlinux:latest /$BUILD_SCRIPT
 
 latest_iso=$(\ls -t "$BUILD_RELEASE_PATH"/*.iso | head -n1)
 iso_ref="${latest_iso%.*}-$OMARCHY_ISO_REF.iso"


### PR DESCRIPTION
# PR 2 — Build the ISO with podman when docker is not installed

**Branch:** `podman-support` → `quattro`
**Size:** 1 file, 31 lines

## Why

`omarchy-iso-make` requires docker. On a developer machine running podman —
common on Arch, and the default container engine for anyone avoiding the
root-equivalent docker group — the build cannot run at all.

Every argument the script already passes is accepted by both engines, so the
work is choosing an engine, naming the image registry, and getting the output
ownership right.

## The three parts

**Engine selection.** Docker first, so the nightly gate is unaffected; podman
when docker is absent; a clear error when neither is present.

**Explicit registry.** `archlinux/archlinux:latest` becomes
`docker.io/archlinux/archlinux:latest`. Podman resolves an unqualified name
against its own search list, which may be unset or may not lead with Docker
Hub. Docker accepts the qualified name unchanged.

**Rootful podman, and this is the part with a story.** `build-iso.sh` ends with
`chown -R $HOST_UID /out`. Under docker, and under podman as root, a uid inside
the container is the same uid outside. Rootless podman maps the calling user to
root inside instead, so the same number resolves to one of that user's subuids
and the ISO comes out owned by an id its owner can neither read nor delete
without `podman unshare`.

## Why not rootless

Rootless was attempted first, on the theory that passing `HOST_UID=0` fixed the
only obstacle. It does fix the ownership problem, and the build still fails —
several minutes in, partway through package installation:

```
fchownat() of /dev/vhost-vsock failed: Operation not permitted
error: command failed to execute correctly
```

`pacstrap` chowns the device nodes it creates, which a user namespace does not
permit. The failure arrives late, after a long stretch of healthy-looking
output, so the reason is recorded in a comment rather than left for the next
person to rediscover the slow way.

Rootless podman additionally cannot allocate a loop device. That one turns out
not to matter: `mkarchiso` builds its EFI image with mtools (`mkfs.fat -C`,
`mmd`, `mcopy`) rather than by mounting, so no loop device is ever needed. Both
findings are in the comment, because "rootless is fine, loop devices are not
used" is exactly the reasoning that led to the failed attempt.

## How it was verified

A complete ISO was built on a podman-only host with no docker installed:

```
[mkarchiso] INFO: Done!
5.9G  /out/omarchy-2026.09.03-x86_64.iso
```

The resulting file is owned by the invoking user, readable without
intervention, and was subsequently booted in QEMU and driven through a full
install by `omarchy-iso-test`. Built twice this way.

