### PR TITLE
Build ISOs with Podman and test legacy migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ The first scenario is `factory-reset`: it proves `omarchy-system-factory-reset` 
 
 Artifacts — screenshots, the fixtured/staged/final `limine.conf`, the reset typescript, and the factory-reset log — land under `test-runs/<iso>-integration/runs/<timestamp>-<scenario>/`, and `--no-preview` skips the `imv` review just like the acceptance harness.
 
+The `podman-migration` scenario installs Docker only inside its disposable guest, creates legacy Redis and PostgreSQL data, proves unsupported workloads stop preflight, and checks volume metadata, writable layers, health checks, migration retries and running/stopped state after reboot:
+
+```bash
+./test/integration release/omarchy.iso podman-migration --no-preview
+```
+
 ## Signing the ISO
 
 Run `./bin/omarchy-iso-sign [release/omarchy.iso]`. The signing key is retrieved from the shared Omarchy vault with the 1Password CLI.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The first scenario is `factory-reset`: it proves `omarchy-system-factory-reset` 
 
 Artifacts — screenshots, the fixtured/staged/final `limine.conf`, the reset typescript, and the factory-reset log — land under `test-runs/<iso>-integration/runs/<timestamp>-<scenario>/`, and `--no-preview` skips the `imv` review just like the acceptance harness.
 
-The `podman-migration` scenario installs Docker only inside its disposable guest, creates legacy Redis and PostgreSQL data, proves unsupported workloads stop preflight, and checks volume metadata, writable layers, health checks, migration retries and running/stopped state after reboot:
+The `podman-migration` scenario installs Docker only inside its disposable guest and creates legacy Redis/PostgreSQL data plus a custom UID-1000 worker with a private named volume, resource limits, all capabilities dropped and no-new-privileges. Privileged/device container definitions must stop preflight before any ordinary workload changes. The scenario checks volume metadata, writable layers, health checks, rootless confinement, migration retries and running/stopped state after reboot:
 
 ```bash
 ./test/integration release/omarchy.iso podman-migration --no-preview

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The first scenario is `factory-reset`: it proves `omarchy-system-factory-reset` 
 
 Artifacts — screenshots, the fixtured/staged/final `limine.conf`, the reset typescript, and the factory-reset log — land under `test-runs/<iso>-integration/runs/<timestamp>-<scenario>/`, and `--no-preview` skips the `imv` review just like the acceptance harness.
 
-The `podman-migration` scenario installs Docker only inside its disposable guest and creates legacy Redis/PostgreSQL data plus a custom UID-1000 worker with a private named volume, resource limits, all capabilities dropped and no-new-privileges. Privileged/device container definitions must stop preflight before any ordinary workload changes. The scenario checks volume metadata, writable layers, health checks, rootless confinement, migration retries and running/stopped state after reboot:
+The `podman-migration` scenario installs Docker only inside its disposable guest and creates legacy Redis/PostgreSQL data plus a custom UID-1000 worker with a private named volume, resource limits, capability restrictions and no-new-privileges. Privileged/device container definitions must stop preflight before any ordinary workload changes. The scenario checks volume metadata, writable layers, health checks, rootless confinement, migration retries and running/stopped state after reboot:
 
 ```bash
 ./test/integration release/omarchy.iso podman-migration --no-preview

--- a/bin/omarchy-iso-make
+++ b/bin/omarchy-iso-make
@@ -120,7 +120,7 @@ mkdir -p "$BUILD_RELEASE_PATH"
 OMARCHY_ISO_REF="${OMARCHY_ISO_REF:-quattro}"
 OMARCHY_MIRROR="${OMARCHY_MIRROR:-stable}"
 
-DOCKER_ARGS=(
+PODMAN_ARGS=(
   --rm
   --privileged
   -e "OMARCHY_ISO_REF=$OMARCHY_ISO_REF"
@@ -136,14 +136,14 @@ DOCKER_ARGS=(
 )
 
 if [[ -n $LOCAL_OMARCHY_PATH ]]; then
-  DOCKER_ARGS+=(
+  PODMAN_ARGS+=(
     -v "$LOCAL_OMARCHY_PATH:/omarchy-source:ro"
     -v "$LOCAL_PKGS_PATH:/omarchy-pkgs:ro"
   )
 fi
 
 if [[ -d /var/cache/pacman/pkg ]]; then
-  DOCKER_ARGS+=(-v "/var/cache/pacman/pkg:/var/cache/pacman/pkg")
+  PODMAN_ARGS+=(-v "/var/cache/pacman/pkg:/var/cache/pacman/pkg")
 fi
 
 # Mount the build cache directory where packages are downloaded. Channels use
@@ -151,22 +151,16 @@ fi
 if [[ -z "$NO_CACHE" ]]; then
   OFFLINE_REPO_BUILD_CACHE_DIR="$HOME/.cache/omarchy/iso_${OMARCHY_MIRROR}/airootfs/var/cache/omarchy"
   mkdir -p "$OFFLINE_REPO_BUILD_CACHE_DIR"
-  DOCKER_ARGS+=(-v "$OFFLINE_REPO_BUILD_CACHE_DIR:/var/cache/airootfs/var/cache/omarchy")
+  PODMAN_ARGS+=(-v "$OFFLINE_REPO_BUILD_CACHE_DIR:/var/cache/airootfs/var/cache/omarchy")
 else
-  # The locally cached :latest image is a cache too — docker run never
+  # The locally cached :latest image is a cache too — podman run never
   # re-checks the registry for it, so refresh it when building cold.
-  DOCKER_ARGS+=(--pull=always)
+  PODMAN_ARGS+=(--pull=always)
 fi
 
-# The docker group is root-equivalent, so Omarchy operators stay out of it on
-# purpose. When the socket refuses the calling user, run the client through
-# sudo instead of requiring group membership.
-DOCKER=(docker)
-if ! docker version &>/dev/null; then
-  DOCKER=(sudo docker)
-fi
-
-"${DOCKER[@]}" run "${DOCKER_ARGS[@]}" archlinux/archlinux:latest /$BUILD_SCRIPT
+# Building the ISO needs real mount and device privileges. Keep those confined
+# to the builder container and authenticate through the visible build terminal.
+sudo podman run "${PODMAN_ARGS[@]}" docker.io/archlinux/archlinux:latest /$BUILD_SCRIPT
 
 latest_iso=$(\ls -t "$BUILD_RELEASE_PATH"/*.iso | head -n1)
 iso_ref="${latest_iso%.*}-$OMARCHY_ISO_REF.iso"

--- a/bin/omarchy-iso-release
+++ b/bin/omarchy-iso-release
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # A failed step must stop the release: without this, a make that dies (say,
-# docker permission denied) falls through to signing and uploading whatever
+# Podman permission denied) falls through to signing and uploading whatever
 # stale ISO release/ already holds, under the new release's name.
 set -e
 

--- a/bin/omarchy-iso-test
+++ b/bin/omarchy-iso-test
@@ -734,7 +734,7 @@ drive_provision_owner() {
   # layout — UK leaves every letter identical to US, so the typed password (sent
   # as raw keycodes) still matches the literal one the harness pipes to sudo.
   # A greeter (animated logo + tagline) opens first boot; Return begins.
-  wait_for_screen "Opinionated" 600
+  wait_for_screen "Beautiful.*Linux by DHH\|Press Return to Start Setup" 600
   capture_console "success-provision-00-greeter"
   press ret
 
@@ -809,7 +809,7 @@ wait_for_install() {
     # Deferred-provisioning installs skip the celebration and reboot on their own
     # (no Reboot Now prompt); the first-boot greeter tagline appearing means the
     # install finished and rebooted into setup.
-    if $PROVISION && grep -qi "Opinionated" <<<"$text"; then
+    if $PROVISION && grep -qi "Beautiful.*Linux by DHH\|Press Return to Start Setup" <<<"$text"; then
       log "Install finished and auto-rebooted into first-boot setup."
       capture_console "success-installer-15-autoreboot"
       return 0

--- a/bin/omarchy-iso-test
+++ b/bin/omarchy-iso-test
@@ -280,7 +280,10 @@ press() {
     json+="{\"type\":\"qcode\",\"data\":\"$part\"},"
   done
 
-  qmp "\"send-key\", \"arguments\": {\"keys\": [${json%,}]}" >/dev/null
+  qmp "\"send-key\", \"arguments\": {\"keys\": [${json%,}], \"hold-time\": 50}" >/dev/null
+  # QMP acknowledges before releasing the chord. Wait for release so the next
+  # shortcut cannot inherit Ctrl/Shift/Super from the previous one.
+  sleep 0.1
 }
 
 type_text() {
@@ -614,7 +617,7 @@ drive_configurator() {
   log "Driving the installer wizard"
 
   # A greeter (animated logo + tagline) opens the installer; Return begins.
-  wait_for_screen "Opinionated" 300
+  wait_for_screen "Beautiful.*Linux by DHH\|Press Return to Start Install" 300
   capture_console "success-installer-00-greeter"
   press ret
 
@@ -664,7 +667,7 @@ drive_configurator() {
   capture_console "success-installer-03-password"
   press ret
 
-  wait_for_screen "Must match" 60
+  wait_for_screen "match the password" 60
   type_text "$GUEST_PASSWORD"
   capture_console "success-installer-04-password-confirmation"
   press ret

--- a/builder/build-iso.sh
+++ b/builder/build-iso.sh
@@ -26,7 +26,7 @@ export OMARCHY_RUNTIME_PACKAGE OMARCHY_SETTINGS_PACKAGE OMARCHY_NVIM_PACKAGE
 # Packages installed into the Arch container used to build the ISO.
 pacman-key --init
 pacman --noconfirm -Sy archlinux-keyring
-# Full upgrade, not just -Sy: docker never re-pulls :latest once it's cached,
+# Full upgrade, not just -Sy: Podman never re-pulls :latest once it's cached,
 # so this container can be months behind the mirror it installs from. A plain
 # -Sy install is then a partial upgrade — new packages linked against a glibc
 # the container doesn't have yet.

--- a/test/integration.d/factory-reset-test.sh
+++ b/test/integration.d/factory-reset-test.sh
@@ -165,7 +165,7 @@ drive_first_boot() {
   # first-boot greeter on its own. A numeric default_entry pointing at a
   # moved entry parks Limine at the menu instead — catch that explicitly,
   # then boot the Omarchy entry by hand so the rest of the flow still runs.
-  if wait_for_screen "Opinionated" 120 2>/dev/null; then
+  if wait_for_screen "Beautiful.*Linux by DHH\|Press Return to Start Install" 120 2>/dev/null; then
     printf 'ok - %s\n' "the machine boots into first-boot setup unattended"
   else
     if ocr_screen | grep -qi "Omarchy Bootloader"; then
@@ -175,7 +175,7 @@ drive_first_boot() {
       log "Selecting the Omarchy entry manually to continue the run"
       press down; sleep 1; press down; sleep 1; press down; sleep 1
       press ret
-      wait_for_screen "Opinionated" 600
+      wait_for_screen "Beautiful.*Linux by DHH\|Press Return to Start Install" 600
     else
       echo "Neither the greeter nor the Limine menu appeared" >&2
       return 1

--- a/test/integration.d/factory-reset-test.sh
+++ b/test/integration.d/factory-reset-test.sh
@@ -165,7 +165,7 @@ drive_first_boot() {
   # first-boot greeter on its own. A numeric default_entry pointing at a
   # moved entry parks Limine at the menu instead — catch that explicitly,
   # then boot the Omarchy entry by hand so the rest of the flow still runs.
-  if wait_for_screen "Beautiful.*Linux by DHH\|Press Return to Start Install" 120 2>/dev/null; then
+  if wait_for_screen "Beautiful.*Linux by DHH\|Press Return to Start Setup" 120 2>/dev/null; then
     printf 'ok - %s\n' "the machine boots into first-boot setup unattended"
   else
     if ocr_screen | grep -qi "Omarchy Bootloader"; then
@@ -175,7 +175,7 @@ drive_first_boot() {
       log "Selecting the Omarchy entry manually to continue the run"
       press down; sleep 1; press down; sleep 1; press down; sleep 1
       press ret
-      wait_for_screen "Beautiful.*Linux by DHH\|Press Return to Start Install" 600
+      wait_for_screen "Beautiful.*Linux by DHH\|Press Return to Start Setup" 600
     else
       echo "Neither the greeter nor the Limine menu appeared" >&2
       return 1

--- a/test/integration.d/podman-migration-test.sh
+++ b/test/integration.d/podman-migration-test.sh
@@ -8,6 +8,17 @@ start_vm_from_base
 wait_for_ssh "$BOOT_TIMEOUT"
 ssh_sudo "printf '%s\n' '$GUEST_USER ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/90-container-test; chmod 440 /etc/sudoers.d/90-container-test"
 
+# Reproduce both legacy ufw-docker blocks from the recorded installed system.
+# Installing Docker alone on a fresh Podman ISO does not recreate this state.
+python3 - "$ROOT/manifests/fresh-4.json" <<'PY' | ssh_guest 'cat >/tmp/legacy-firewall.json'
+import json
+import sys
+
+with open(sys.argv[1]) as source:
+    files = json.load(source)['files']['system_config']
+json.dump({path: files[path]['text'] for path in ('/etc/ufw/after.rules', '/etc/ufw/after6.rules')}, sys.stdout)
+PY
+
 ssh_guest 'cat >/tmp/podman-migration-fixture.sh' <<'GUEST'
 #!/bin/bash
 set -euo pipefail
@@ -20,6 +31,15 @@ unset DOCKER_HOST
 sudo pacman -Sy --noconfirm
 omarchy-pkg-drop podman-docker
 omarchy-pkg-add docker
+sudo python3 - <<'PY'
+import json
+from pathlib import Path
+
+for path, contents in json.loads(Path('/tmp/legacy-firewall.json').read_text()).items():
+    Path(path).write_text(contents)
+PY
+sudo ufw reload
+sudo ip6tables-save | grep -q DOCKER-USER
 sudo systemctl start docker.socket
 sudo docker run -d --name redis --restart unless-stopped \
   -p 127.0.0.1:6379:6379 \
@@ -113,6 +133,14 @@ printf 'INTERRUPTED BATCH AND SOURCE RESTART SAFEGUARDS VERIFIED\n'
 
 CONTAINER_HOST=unix:///tmp/do-not-contact-podman.sock bash -euo pipefail "$OMARCHY_PATH/migrations/1788886195.sh"
 [[ $(pacman -Qq docker) == "podman-docker" ]]
+sudo python3 - <<'PY'
+import json
+from pathlib import Path
+
+for path, original in json.loads(Path('/tmp/legacy-firewall.json').read_text()).items():
+    assert '# BEGIN UFW AND DOCKER' not in Path(path).read_text()
+    assert Path(path + '.before-podman').read_text() == original
+PY
 [[ $(podman exec redis redis-cli GET migration-proof) == "preserved" ]]
 [[ $(podman exec redis cat /migration-proof) == "writable-layer" ]]
 [[ $(podman inspect postgres16 --format '{{.State.Running}}') == "false" ]]
@@ -173,7 +201,7 @@ check "guest rebooted" ssh_guest "test \"\$(cat /proc/sys/kernel/random/boot_id)
 check "running Redis resumed with data" ssh_guest 'for attempt in {1..30}; do [[ $(podman exec redis redis-cli GET migration-proof 2>/dev/null) == preserved ]] && exit 0; sleep 1; done; exit 1'
 check "deliberately stopped PostgreSQL remains stopped" ssh_guest "test \"\$(podman inspect postgres16 --format '{{.State.Running}}')\" = false"
 check "custom worker resumes as its original non-root user" ssh_guest "test \"\$(podman exec project-worker id -u)\" = 1000"
-check "Docker bridge and firewall chains are gone" ssh_sudo '! ip link show docker0 2>/dev/null && ! iptables-save | grep -q DOCKER'
+check "Docker bridge and IPv4/IPv6 firewall chains are gone" ssh_sudo '! ip link show docker0 2>/dev/null && ! iptables-save | grep -q DOCKER && ! ip6tables-save | grep -q DOCKER'
 check "rootless API responds after reboot" ssh_guest 'curl -fsS --max-time 10 --unix-socket "$XDG_RUNTIME_DIR/podman/podman.sock" http://localhost/_ping'
 capture_console success-podman-migration-reboot
 finish

--- a/test/integration.d/podman-migration-test.sh
+++ b/test/integration.d/podman-migration-test.sh
@@ -19,11 +19,11 @@ omarchy-pkg-drop podman-docker
 omarchy-pkg-add docker
 sudo systemctl start docker.socket
 sudo docker run -d --name redis --restart unless-stopped \
-  -p 127.0.0.1:6379:6379 -v migration-redis:/data \
+  -p 127.0.0.1:6379:6379 \
   --health-cmd 'redis-cli ping' --health-interval 1s --health-timeout 1s --health-retries 5 \
   docker.io/library/redis:7
 sudo docker run -d --name postgres16 --restart unless-stopped \
-  -p 127.0.0.1:5432:5432 -v migration-postgres:/var/lib/postgresql/data \
+  -p 127.0.0.1:5432:5432 \
   -e POSTGRES_PASSWORD=fixture-only docker.io/library/postgres:16
 for attempt in {1..60}; do
   sudo docker exec postgres16 pg_isready -U postgres && break
@@ -34,7 +34,10 @@ sudo docker exec redis redis-cli SET migration-proof preserved
 sudo docker exec redis sh -c 'echo writable-layer >/migration-proof'
 sudo docker stop postgres16
 
-volume=$(sudo docker volume inspect migration-postgres --format '{{.Mountpoint}}')
+# Stock installers rely on the image's anonymous VOLUME. Explicit -v/--mount
+# configuration is deliberately outside automatic migration's accepted scope.
+volume_name=$(sudo docker inspect postgres16 --format '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}')
+volume=$(sudo docker volume inspect "$volume_name" --format '{{.Mountpoint}}')
 sudo python3 - "$volume" <<'PY'
 from pathlib import Path
 import os,sys
@@ -64,7 +67,7 @@ for attempt in {1..30}; do
   sleep 1
 done
 [[ $(podman inspect redis --format '{{.State.Health.Status}}') == "healthy" ]]
-target=$(podman volume inspect omarchy-migrated-migration-postgres --format '{{.Mountpoint}}')
+target=$(podman volume inspect "omarchy-migrated-$volume_name" --format '{{.Mountpoint}}')
 podman unshare python3 - "$target" <<'PY'
 import os,sys
 from pathlib import Path

--- a/test/integration.d/podman-migration-test.sh
+++ b/test/integration.d/podman-migration-test.sh
@@ -15,6 +15,9 @@ set -euo pipefail
 export OMARCHY_PATH=/usr/share/omarchy
 export XDG_RUNTIME_DIR=/run/user/$(id -u)
 unset DOCKER_HOST
+# Fresh offline installs intentionally omit synchronized repository databases.
+# Refresh only this disposable fixture's indexes; keep the built runtime pinned.
+sudo pacman -Sy --noconfirm
 omarchy-pkg-drop podman-docker
 omarchy-pkg-add docker
 sudo systemctl start docker.socket

--- a/test/integration.d/podman-migration-test.sh
+++ b/test/integration.d/podman-migration-test.sh
@@ -39,7 +39,9 @@ for path, contents in json.loads(Path('/tmp/legacy-firewall.json').read_text()).
     Path(path).write_text(contents)
 PY
 sudo ufw reload
-sudo ip6tables-save | grep -q DOCKER-USER
+# Consume the complete dump: grep -q closes early and makes ip6tables-save
+# fail with SIGPIPE under pipefail when the rules exceed the pipe buffer.
+sudo ip6tables-save | grep DOCKER-USER >/dev/null
 sudo systemctl start docker.socket
 sudo docker run -d --name redis --restart unless-stopped \
   -p 127.0.0.1:6379:6379 \

--- a/test/integration.d/podman-migration-test.sh
+++ b/test/integration.d/podman-migration-test.sh
@@ -78,6 +78,39 @@ grep -q device-required /tmp/preflight.log
 ! podman container exists redis
 ! podman container exists project-worker
 sudo docker rm review-required device-required
+
+# Complete one transfer while Docker is still needed by the remaining batch.
+# Its old always policy must not revive a stale source after a daemon restart.
+# Uppercase and repeated dots are valid container names, but not image paths.
+sudo docker run -d --name Always..Worker --restart always docker.io/library/alpine:3 \
+  sh -c 'echo original >/retry-proof; trap "exit 0" TERM; while :; do sleep 1 & wait $!; done'
+retry_source=$(sudo docker inspect Always..Worker --format '{{.Id}}')
+python3 "$OMARCHY_PATH/default/podman/migrate-databases.py" Always..Worker
+[[ $(sudo docker inspect Always..Worker --format '{{.HostConfig.RestartPolicy.Name}}') == "no" ]]
+[[ $(podman inspect Always..Worker --format '{{.HostConfig.RestartPolicy.Name}}') == "always" ]]
+sudo systemctl restart docker
+[[ $(sudo docker inspect Always..Worker --format '{{.State.Running}}') == "false" ]]
+python3 "$OMARCHY_PATH/default/podman/migrate-databases.py" Always..Worker
+
+# Explicitly resuming the recovery copy invalidates its receipt, even when it
+# is stopped again. Never silently choose the stale target after new writes.
+sudo docker start Always..Worker
+sudo docker exec Always..Worker sh -c 'echo changed >/retry-proof'
+for source_state in running stopped; do
+  if [[ $source_state == "stopped" ]]; then sudo docker stop Always..Worker; fi
+  if python3 "$OMARCHY_PATH/default/podman/migrate-databases.py" Always..Worker >/tmp/retry.log 2>&1; then
+    echo 'Restarted Docker source incorrectly reused its old receipt' >&2; exit 1
+  fi
+  grep -q 'no completed transfer' /tmp/retry.log
+  [[ $(podman exec Always..Worker cat /retry-proof) == "original" ]]
+done
+# These conflicting copies are disposable test data; production leaves both
+# for review. Remove this fixture so the ordinary batch can proceed below.
+sudo docker rm Always..Worker
+podman rm -f Always..Worker
+rm "$HOME/.local/state/omarchy/podman-migration/$retry_source"
+printf 'INTERRUPTED BATCH AND SOURCE RESTART SAFEGUARDS VERIFIED\n'
+
 CONTAINER_HOST=unix:///tmp/do-not-contact-podman.sock bash -euo pipefail "$OMARCHY_PATH/migrations/1788886195.sh"
 [[ $(pacman -Qq docker) == "podman-docker" ]]
 [[ $(podman exec redis redis-cli GET migration-proof) == "preserved" ]]

--- a/test/integration.d/podman-migration-test.sh
+++ b/test/integration.d/podman-migration-test.sh
@@ -31,12 +31,33 @@ unset DOCKER_HOST
 sudo pacman -Sy --noconfirm
 omarchy-pkg-drop podman-docker
 omarchy-pkg-add docker
-# A Docker-dependent package must survive the engine/shim replacement.
+# ONCE must block migration even when it has not created any containers yet.
 omarchy-pkg-add once-bin
-if sudo pacman -Rns --noconfirm docker >/tmp/docker-dependency.log 2>&1; then
-  echo 'Docker removal unexpectedly ignored the ONCE dependency' >&2; exit 1
+if bash -euo pipefail "$OMARCHY_PATH/migrations/1788886195.sh" >/tmp/once-preflight.log 2>&1; then
+  echo 'ONCE incorrectly passed Podman migration' >&2; exit 1
 fi
-grep -q 'required by once-bin' /tmp/docker-dependency.log
+grep -q 'ONCE is installed' /tmp/once-preflight.log
+[[ $(pacman -Qq docker) == "docker" ]]
+pacman -Q once-bin
+omarchy-pkg-drop once-bin
+
+# Retain transaction coverage with a harmless CLI-dependent package instead
+# of claiming that the ONCE application's Docker API works through the shim.
+dependency_fixture=$(mktemp -d)
+cat >"$dependency_fixture/.PKGINFO" <<'PKGINFO'
+pkgname = omarchy-test-docker-client
+pkgver = 1-1
+pkgdesc = Disposable Docker CLI dependency fixture
+arch = any
+depend = docker
+PKGINFO
+bsdtar -czf "$dependency_fixture/client.pkg.tar.gz" -C "$dependency_fixture" .PKGINFO
+sudo pacman -U --noconfirm "$dependency_fixture/client.pkg.tar.gz"
+rm -r "$dependency_fixture"
+if sudo pacman -Rns --noconfirm docker >/tmp/docker-dependency.log 2>&1; then
+  echo 'Docker removal unexpectedly ignored the CLI dependency' >&2; exit 1
+fi
+grep -q 'required by omarchy-test-docker-client' /tmp/docker-dependency.log
 sudo python3 - <<'PY'
 import json
 from pathlib import Path
@@ -144,7 +165,7 @@ sudo -u "$USER" -H env -u XDG_RUNTIME_DIR -u DBUS_SESSION_BUS_ADDRESS \
   OMARCHY_PATH="$OMARCHY_PATH" PATH="$PATH" CONTAINER_HOST=unix:///tmp/do-not-contact-podman.sock \
   bash -euo pipefail "$OMARCHY_PATH/migrations/1788886195.sh"
 [[ $(pacman -Qq docker) == "podman-docker" ]]
-pacman -Q once-bin
+pacman -Q omarchy-test-docker-client
 [[ -z $(pacman -T docker) ]]
 sudo python3 - <<'PY'
 import json

--- a/test/integration.d/podman-migration-test.sh
+++ b/test/integration.d/podman-migration-test.sh
@@ -57,10 +57,11 @@ sudo docker volume create --label fixture=secure-migration project-state
 sudo docker run --rm -v project-state:/data docker.io/library/alpine:3 \
   sh -c 'chown 1000:1000 /data; chmod 0750 /data'
 sudo docker run -d --name project-worker --restart unless-stopped \
-  --user 1000:1000 --cap-drop ALL --security-opt no-new-privileges \
+  --user 1000:1000 --cap-drop NET_RAW --security-opt no-new-privileges \
   --cpus 0.5 --memory 128m --memory-swap 256m --pids-limit 64 --shm-size 128m \
   -e WORKER_MESSAGE=retained -v project-state:/data docker.io/library/alpine:3 \
   sh -c 'echo preserved >/data/proof; trap "exit 0" TERM; while :; do sleep 1 & wait $!; done'
+sudo docker exec project-worker sh -c 'grep -Eq "^CapEff:[[:space:]]+0+$" /proc/1/status'
 
 # Review-required records are never started, even in this disposable fixture.
 # Both must be reported while all ordinary source workloads stay running.
@@ -91,7 +92,7 @@ done
 [[ $(podman exec project-worker cat /data/proof) == "preserved" ]]
 [[ $(podman exec project-worker printenv WORKER_MESSAGE) == "retained" ]]
 [[ $(podman exec project-worker id -u) == "1000" ]]
-podman exec project-worker sh -c 'grep -Eq "^NoNewPrivs:[[:space:]]+1$" /proc/1/status; grep -Eq "^Seccomp:[[:space:]]+2$" /proc/1/status; grep -Eq "^CapBnd:[[:space:]]+0+$" /proc/1/status'
+podman exec project-worker sh -ec 'grep -Eq "^NoNewPrivs:[[:space:]]+1$" /proc/1/status; grep -Eq "^Seccomp:[[:space:]]+2$" /proc/1/status; for field in CapBnd CapEff CapAmb; do grep -Eq "^$field:[[:space:]]+0+$" /proc/1/status; done'
 [[ $(podman inspect project-worker --format '{{.HostConfig.Privileged}}') == "false" ]]
 [[ $(podman inspect project-worker --format '{{.HostConfig.Memory}}') == "134217728" ]]
 [[ $(podman inspect project-worker --format '{{.HostConfig.PidsLimit}}') == "64" ]]

--- a/test/integration.d/podman-migration-test.sh
+++ b/test/integration.d/podman-migration-test.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Real legacy Docker fixtures in a disposable ISO guest. Never run this script
+# directly on a development desktop: the harness owns the guest and its disk.
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/base-test.sh"
+base_image_ready || { echo "Run this through ./test/integration" >&2; exit 1; }
+start_vm_from_base
+wait_for_ssh "$BOOT_TIMEOUT"
+ssh_sudo "printf '%s\n' '$GUEST_USER ALL=(ALL) NOPASSWD: ALL' >/etc/sudoers.d/90-container-test; chmod 440 /etc/sudoers.d/90-container-test"
+
+ssh_guest 'cat >/tmp/podman-migration-fixture.sh' <<'GUEST'
+#!/bin/bash
+set -euo pipefail
+[[ $(hostname) == "omarchy-test" ]] || exit 1
+export OMARCHY_PATH=/usr/share/omarchy
+export XDG_RUNTIME_DIR=/run/user/$(id -u)
+unset DOCKER_HOST
+omarchy-pkg-drop podman-docker
+omarchy-pkg-add docker
+sudo systemctl start docker.socket
+sudo docker run -d --name redis --restart unless-stopped \
+  -p 127.0.0.1:6379:6379 -v migration-redis:/data \
+  --health-cmd 'redis-cli ping' --health-interval 1s --health-timeout 1s --health-retries 5 \
+  docker.io/library/redis:7
+sudo docker run -d --name postgres16 --restart unless-stopped \
+  -p 127.0.0.1:5432:5432 -v migration-postgres:/var/lib/postgresql/data \
+  -e POSTGRES_PASSWORD=fixture-only docker.io/library/postgres:16
+for attempt in {1..60}; do
+  sudo docker exec postgres16 pg_isready -U postgres && break
+  sleep 1
+done
+sudo docker exec postgres16 psql -U postgres -c "CREATE TABLE migration_proof (value text); INSERT INTO migration_proof VALUES ('preserved');"
+sudo docker exec redis redis-cli SET migration-proof preserved
+sudo docker exec redis sh -c 'echo writable-layer >/migration-proof'
+sudo docker stop postgres16
+
+volume=$(sudo docker volume inspect migration-postgres --format '{{.Mountpoint}}')
+sudo python3 - "$volume" <<'PY'
+from pathlib import Path
+import os,sys
+p=Path(sys.argv[1]);p.chmod(0o775)
+f=p/'metadata-proof';f.write_bytes(b'preserved metadata\n');f.chmod(0o640)
+os.chown(f,1000,1000);os.setxattr(f,'user.migration',b'preserved')
+os.link(f,p/'hardlink-proof');(p/'symlink-proof').symlink_to('metadata-proof')
+os.utime(f,ns=(1720000000123456789,1720000000123456789))
+PY
+sudo setfacl -m u:1234:r "$volume/metadata-proof"
+# One unsupported workload must reject the entire batch while Redis stays up.
+sudo docker run -d --name custom-project docker.io/library/redis:7 sleep infinity
+if bash -euo pipefail "$OMARCHY_PATH/migrations/1788886195.sh"; then
+  echo 'Unsupported container incorrectly passed migration' >&2; exit 1
+fi
+[[ $(sudo docker inspect redis --format '{{.State.Running}}') == "true" ]]
+! podman container exists redis
+sudo docker rm -f custom-project
+bash -euo pipefail "$OMARCHY_PATH/migrations/1788886195.sh"
+[[ $(pacman -Qq docker) == "podman-docker" ]]
+[[ $(podman exec redis redis-cli GET migration-proof) == "preserved" ]]
+[[ $(podman exec redis cat /migration-proof) == "writable-layer" ]]
+[[ $(podman inspect postgres16 --format '{{.State.Running}}') == "false" ]]
+[[ $(podman inspect redis --format '{{.HostConfig.PidsLimit}}') == "-1" ]]
+for attempt in {1..30}; do
+  [[ $(podman inspect redis --format '{{.State.Health.Status}}') == "healthy" ]] && break
+  sleep 1
+done
+[[ $(podman inspect redis --format '{{.State.Health.Status}}') == "healthy" ]]
+target=$(podman volume inspect omarchy-migrated-migration-postgres --format '{{.Mountpoint}}')
+podman unshare python3 - "$target" <<'PY'
+import os,sys
+from pathlib import Path
+p=Path(sys.argv[1]);f=p/'metadata-proof';s=f.stat()
+assert p.stat().st_mode & 0o777==0o775
+assert s.st_uid==1000 and s.st_gid==1000
+assert s.st_mtime_ns==1720000000123456789
+assert os.getxattr(f,'user.migration')==b'preserved'
+assert os.getxattr(f,'system.posix_acl_access')
+assert s.st_ino==(p/'hardlink-proof').stat().st_ino
+assert (p/'symlink-proof').readlink()==Path('metadata-proof')
+PY
+podman start postgres16
+for attempt in {1..60}; do
+  podman exec postgres16 pg_isready -U postgres && break
+  sleep 1
+done
+[[ $(podman exec postgres16 psql -U postgres -Atc 'SELECT value FROM migration_proof') == "preserved" ]]
+podman stop postgres16
+# Retrying after Docker removal must preserve both destinations and their data.
+bash -euo pipefail "$OMARCHY_PATH/migrations/1788886195.sh"
+sudo test -d /var/lib/docker
+printf 'LIVE MIGRATION VERIFIED\n'
+GUEST
+ssh_guest 'bash /tmp/podman-migration-fixture.sh' >"$RUN_DIR/migration.log" 2>&1 || {
+  cat "$RUN_DIR/migration.log"; capture_console failure-podman-migration; exit 1;
+}
+capture_console success-podman-migration
+old_boot=$(ssh_guest 'cat /proc/sys/kernel/random/boot_id')
+ssh_sudo 'systemctl reboot' || true
+sleep 10
+wait_for_ssh "$BOOT_TIMEOUT"
+check "guest rebooted" ssh_guest "test \"\$(cat /proc/sys/kernel/random/boot_id)\" != '$old_boot'"
+check "running Redis resumed with data" ssh_guest "test \"\$(podman exec redis redis-cli GET migration-proof)\" = preserved"
+check "deliberately stopped PostgreSQL remains stopped" ssh_guest "test \"\$(podman inspect postgres16 --format '{{.State.Running}}')\" = false"
+check "Docker bridge and firewall chains are gone" ssh_sudo '! ip link show docker0 2>/dev/null && ! iptables-save | grep -q DOCKER'
+check "rootless API responds after reboot" ssh_guest 'curl -fsS --max-time 10 --unix-socket "$XDG_RUNTIME_DIR/podman/podman.sock" http://localhost/_ping'
+capture_console success-podman-migration-reboot
+finish

--- a/test/integration.d/podman-migration-test.sh
+++ b/test/integration.d/podman-migration-test.sh
@@ -37,8 +37,7 @@ sudo docker exec redis redis-cli SET migration-proof preserved
 sudo docker exec redis sh -c 'echo writable-layer >/migration-proof'
 sudo docker stop postgres16
 
-# Stock installers rely on the image's anonymous VOLUME. Explicit -v/--mount
-# configuration is deliberately outside automatic migration's accepted scope.
+# Stock installers rely on the image's anonymous VOLUME.
 volume_name=$(sudo docker inspect postgres16 --format '{{range .Mounts}}{{if eq .Destination "/var/lib/postgresql/data"}}{{.Name}}{{end}}{{end}}')
 volume=$(sudo docker volume inspect "$volume_name" --format '{{.Mountpoint}}')
 sudo python3 - "$volume" <<'PY'
@@ -51,15 +50,34 @@ os.link(f,p/'hardlink-proof');(p/'symlink-proof').symlink_to('metadata-proof')
 os.utime(f,ns=(1720000000123456789,1720000000123456789))
 PY
 sudo setfacl -m u:1234:r "$volume/metadata-proof"
-# One unsupported workload must reject the entire batch while Redis stays up.
-sudo docker run -d --name custom-project docker.io/library/redis:7 sleep infinity
-if bash -euo pipefail "$OMARCHY_PATH/migrations/1788886195.sh"; then
+
+# A custom image/name, private named volume, non-root application user and
+# explicit resource/confinement settings should migrate without gaining access.
+sudo docker volume create --label fixture=secure-migration project-state
+sudo docker run --rm -v project-state:/data docker.io/library/alpine:3 \
+  sh -c 'chown 1000:1000 /data; chmod 0750 /data'
+sudo docker run -d --name project-worker --restart unless-stopped \
+  --user 1000:1000 --cap-drop ALL --security-opt no-new-privileges \
+  --cpus 0.5 --memory 128m --memory-swap 256m --pids-limit 64 --shm-size 128m \
+  -e WORKER_MESSAGE=retained -v project-state:/data docker.io/library/alpine:3 \
+  sh -c 'echo preserved >/data/proof; trap "exit 0" TERM; while :; do sleep 1 & wait $!; done'
+
+# Review-required records are never started, even in this disposable fixture.
+# Both must be reported while all ordinary source workloads stay running.
+sudo docker create --name review-required --privileged docker.io/library/alpine:3 sleep infinity
+sudo docker create --name device-required --device /dev/null docker.io/library/alpine:3 sleep infinity
+if bash -euo pipefail "$OMARCHY_PATH/migrations/1788886195.sh" >/tmp/preflight.log 2>&1; then
   echo 'Unsupported container incorrectly passed migration' >&2; exit 1
 fi
+cat /tmp/preflight.log
+grep -q review-required /tmp/preflight.log
+grep -q device-required /tmp/preflight.log
 [[ $(sudo docker inspect redis --format '{{.State.Running}}') == "true" ]]
+[[ $(sudo docker inspect project-worker --format '{{.State.Running}}') == "true" ]]
 ! podman container exists redis
-sudo docker rm -f custom-project
-bash -euo pipefail "$OMARCHY_PATH/migrations/1788886195.sh"
+! podman container exists project-worker
+sudo docker rm review-required device-required
+CONTAINER_HOST=unix:///tmp/do-not-contact-podman.sock bash -euo pipefail "$OMARCHY_PATH/migrations/1788886195.sh"
 [[ $(pacman -Qq docker) == "podman-docker" ]]
 [[ $(podman exec redis redis-cli GET migration-proof) == "preserved" ]]
 [[ $(podman exec redis cat /migration-proof) == "writable-layer" ]]
@@ -70,6 +88,18 @@ for attempt in {1..30}; do
   sleep 1
 done
 [[ $(podman inspect redis --format '{{.State.Health.Status}}') == "healthy" ]]
+[[ $(podman exec project-worker cat /data/proof) == "preserved" ]]
+[[ $(podman exec project-worker printenv WORKER_MESSAGE) == "retained" ]]
+[[ $(podman exec project-worker id -u) == "1000" ]]
+podman exec project-worker sh -c 'grep -Eq "^NoNewPrivs:[[:space:]]+1$" /proc/1/status; grep -Eq "^Seccomp:[[:space:]]+2$" /proc/1/status; grep -Eq "^CapBnd:[[:space:]]+0+$" /proc/1/status'
+[[ $(podman inspect project-worker --format '{{.HostConfig.Privileged}}') == "false" ]]
+[[ $(podman inspect project-worker --format '{{.HostConfig.Memory}}') == "134217728" ]]
+[[ $(podman inspect project-worker --format '{{.HostConfig.PidsLimit}}') == "64" ]]
+[[ $(podman volume inspect project-state --format '{{index .Labels "fixture"}}') == "secure-migration" ]]
+worker_volume=$(podman volume inspect project-state --format '{{.Mountpoint}}')
+[[ $(podman unshare stat -c '%u:%g:%a' "$worker_volume") == "1000:1000:750" ]]
+[[ -z $(sudo podman ps -aq) ]]
+printf 'CUSTOM ROOTLESS CONFINEMENT VERIFIED\n'
 target=$(podman volume inspect "omarchy-migrated-$volume_name" --format '{{.Mountpoint}}')
 podman unshare python3 - "$target" <<'PY'
 import os,sys
@@ -104,8 +134,11 @@ ssh_sudo 'systemctl reboot' || true
 sleep 10
 wait_for_ssh "$BOOT_TIMEOUT"
 check "guest rebooted" ssh_guest "test \"\$(cat /proc/sys/kernel/random/boot_id)\" != '$old_boot'"
-check "running Redis resumed with data" ssh_guest "test \"\$(podman exec redis redis-cli GET migration-proof)\" = preserved"
+# SSH login starts the user manager; its container restart service and Redis
+# readiness can finish later. Wait for the actual data response, with a bound.
+check "running Redis resumed with data" ssh_guest 'for attempt in {1..30}; do [[ $(podman exec redis redis-cli GET migration-proof 2>/dev/null) == preserved ]] && exit 0; sleep 1; done; exit 1'
 check "deliberately stopped PostgreSQL remains stopped" ssh_guest "test \"\$(podman inspect postgres16 --format '{{.State.Running}}')\" = false"
+check "custom worker resumes as its original non-root user" ssh_guest "test \"\$(podman exec project-worker id -u)\" = 1000"
 check "Docker bridge and firewall chains are gone" ssh_sudo '! ip link show docker0 2>/dev/null && ! iptables-save | grep -q DOCKER'
 check "rootless API responds after reboot" ssh_guest 'curl -fsS --max-time 10 --unix-socket "$XDG_RUNTIME_DIR/podman/podman.sock" http://localhost/_ping'
 capture_console success-podman-migration-reboot

--- a/test/integration.d/podman-migration-test.sh
+++ b/test/integration.d/podman-migration-test.sh
@@ -31,6 +31,12 @@ unset DOCKER_HOST
 sudo pacman -Sy --noconfirm
 omarchy-pkg-drop podman-docker
 omarchy-pkg-add docker
+# A Docker-dependent package must survive the engine/shim replacement.
+omarchy-pkg-add once-bin
+if sudo pacman -Rns --noconfirm docker >/tmp/docker-dependency.log 2>&1; then
+  echo 'Docker removal unexpectedly ignored the ONCE dependency' >&2; exit 1
+fi
+grep -q 'required by once-bin' /tmp/docker-dependency.log
 sudo python3 - <<'PY'
 import json
 from pathlib import Path
@@ -133,8 +139,13 @@ podman rm -f Always..Worker
 rm "$HOME/.local/state/omarchy/podman-migration/$retry_source"
 printf 'INTERRUPTED BATCH AND SOURCE RESTART SAFEGUARDS VERIFIED\n'
 
-CONTAINER_HOST=unix:///tmp/do-not-contact-podman.sock bash -euo pipefail "$OMARCHY_PATH/migrations/1788886195.sh"
+# Match sudo-run upgrades, which do not pass the graphical session variables.
+sudo -u "$USER" -H env -u XDG_RUNTIME_DIR -u DBUS_SESSION_BUS_ADDRESS \
+  OMARCHY_PATH="$OMARCHY_PATH" PATH="$PATH" CONTAINER_HOST=unix:///tmp/do-not-contact-podman.sock \
+  bash -euo pipefail "$OMARCHY_PATH/migrations/1788886195.sh"
 [[ $(pacman -Qq docker) == "podman-docker" ]]
+pacman -Q once-bin
+[[ -z $(pacman -T docker) ]]
 sudo python3 - <<'PY'
 import json
 from pathlib import Path


### PR DESCRIPTION
Build Omarchy ISOs with authenticated rootful Podman after Docker is removed. Preserve privileged builder access, source mounts, package caches and cold-build image refresh; qualify the Arch builder image as `docker.io/archlinux/archlinux:latest`.

The installer harness matches the current install/setup greeters and password-confirmation text, and releases QMP keyboard chords before the next shortcut. These matches track existing installer text; they do not change product branding.

Add `test/integration ... podman-migration` to create real legacy Redis/PostgreSQL fixtures and a custom UID-1000 worker in a disposable installed guest. The worker uses a private named volume, explicit CPU/memory/PID/shared-memory limits, capability restrictions and no-new-privileges. Privileged/device container definitions must stop the entire preflight before ordinary workloads change.

The scenario checks SQL/key data, writable layers, volume ownership/modes/ACLs/xattrs/links/timestamps, runtime confinement, health checks, migration retries, and running/stopped state, IPv4/IPv6 firewall cleanup and API access after reboot. Seed both actual legacy ufw-docker blocks from the recorded installed-system manifest, then verify exact backups and removal. It waits for Redis readiness after SSH login starts the user manager. Fixtures refresh the offline installation's package indexes before installing Docker. Install legacy ONCE and verify that its need for an explicit backup/restore migration leaves the generic engine migration pending with Docker and ONCE intact. Remove that disposable package before workload migration. Use a harmless generated Docker-CLI dependency package to verify standalone Docker removal is blocked and that provider replacement preserves the dependency. Run the migration without inherited XDG/DBus session variables to cover sudo-invoked upgrades. An `Always..Worker` fixture also exercises valid container-name grammar, completed-source restart suppression across a Docker daemon restart, unchanged retries, and rejection of a source resumed and then stopped again.

## Validation

- **ONCE fixture correction (`54af21c`):** ISO shell unit suite and all 63 Python tests pass; shell syntax passes and real pacman accepts the generated dependency package metadata. The updated full migration scenario has not been repeated; a fresh ISO with the latest native runtime remains pending Podman TUI publication.
- ISO shell unit suite and all 63 Python tests pass.
- The earlier extended migration scenario passed in a disposable overlay of the earlier installed ISO base with the candidate runtime helper: image naming, restart suppression, stale receipt refusal, Redis/PostgreSQL/custom-worker data and confinement, both legacy firewall families and their backups, ONCE package dependency preservation (not application compatibility), a stripped session environment, and all six reboot assertions. The review follow-up did not build a new ISO.
- Earlier fresh ISO validation used runtime `a128dc1a`, settings `28a30ad` and ISO `4aecb33`: fresh interactive install without a reused base or product overlay, full graphical/API suite in 92 seconds, and the legacy/custom migration scenario in a separately installed guest. The normal console bootstrap retry recovered its first timeout.
- Earlier Podman-built ISO SHA-256: `ad7e653117909231e868b1d5c506dafd3299928e4e15310a2ff3f0d15f23e9df`. All 72 installation/graphical/migration captures were reviewed; existing screenshots remain below.
- Current runtime follow-up additionally verifies a real Docker Compose Windows definition, custom-storage rejection and engine retirement with the disk marker retained. Earlier Windows boot/RDP and deferred-provisioning paths were not repeated for the review fixes.

Companions: https://github.com/omacom/omarchy/pull/11032 and https://github.com/omacom/omarchy-pkgs/pull/369. Earlier Windows/database captures remain on the main PR.

## Screenshots

Installer greeter from the fresh Podman-built ISO:

![Installer greeter from the Podman-built ISO](https://github.com/user-attachments/assets/40af27bd-6a0d-4879-9f96-2eb4f60af8eb)

Installed desktop during the successful graphical acceptance run:

![Installed Omarchy desktop during acceptance](https://github.com/user-attachments/assets/0aa4f9ca-685c-47fe-a03f-c911d2d1550f)

Fresh packaged Podman Desktop during the successful API socket lifecycle check:

![Podman Desktop in the fresh ISO during the successful socket and Docker API lifecycle test](https://github.com/user-attachments/assets/2fc1e24e-f4a3-4145-9745-79a27484cd44)


New rootless ONCE installation and real Writebook lifecycle support are implemented in the companion source/package PRs and tested separately in Omarchy Lab. That does not change this fixture: existing rootful ONCE deployments still require explicit migration, and no new full ISO run is claimed.
