### PR TITLE
removes github compression for already compressed iso

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -12,8 +12,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v3
 
       - name: Free Disk Space
         uses: jlumbroso/free-disk-space@v1.3.1
@@ -33,3 +33,4 @@ jobs:
           name: omarchy-iso-${{ github.run_number }}
           path: ./release/*.iso
           retention-days: 1
+          compression-level: 0


### PR DESCRIPTION
Hey @dhh and the Omarchy team,

I was looking for real-world benchmarks for [runs-on](https://runs-on.com/) runners and when I saw the hottest distro in town is being built on GitHub's old & slow `ubuntu-latest` machines, I had to have a go! 

Was able to get the whole nightly build to ~5m w similarly specced runs-on runners (we use EC2 machines) and one of the major saves was from removing github compression in the upload artifact step since the ISO is already p much compressed anyway. 

Wrote more about it [here](https://runs-on.com/blog/speeding-up-omarchy-nightly-build/). See last run [here](https://github.com/sjysngh/omarchy-iso/actions/runs/34452601134/job/102791538315).

You can cut-off a few minutes off your nightly build for free with this basically, especially when the ISO increases in size with subsequent updates!

(also the docker buildx step is unnecessary since there's no docker build happening anywhere in the scripts but thats optional)

Cheers! And long live Omarchy!