### PR TITLE
Preserve Apple EFI firmware folder across the install

### DIFF
--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/apple_efi.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/apple_efi.py
@@ -1,0 +1,160 @@
+"""Apple's coprocessor firmware folder, carried across a full-disk install.
+
+On 2016/2017 Touch Bar MacBook Pros the T1 coprocessor holds no firmware of
+its own: the Mac loads it from `EFI/APPLE/EMBEDDEDOS` on the EFI System
+Partition at every boot, and the Touch Bar, Touch ID and the FaceTime camera
+are all behind that chip. Recreating the ESP deletes the folder, and nothing
+in Linux puts it back — the machine installs and boots fine, with three pieces
+of hardware permanently dead until macOS is reinstalled to write the folder
+again (basecamp/omarchy#8271).
+
+So the folder is copied into the live system's RAM before the partition table
+is touched, and written back onto the new ESP before the bootloader lands on
+it. Everything here is best-effort by construction: a failure is logged and
+the install carries on, because a machine that boots with a dead Touch Bar is
+today's outcome, while an install aborted over a firmware copy is worse than
+the bug it protects against.
+
+The folder is the whole signal — there is no hardware sniffing. A disk that
+has one gets it preserved, and a disk that has none costs a read-only mount
+of the partitions the installer is about to erase anyway.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from pathlib import Path
+
+from .command import capture, require_text
+from .ui import info
+
+# Relative to the root of the ESP, in the case the firmware itself uses.
+APPLE_DIR = Path("EFI/APPLE")
+FIRMWARE_DIR = "EMBEDDEDOS"
+
+# The real folder is a few MB. These bound what a surprising one may cost the
+# live system, whose RAM the install itself is also spending.
+MAX_STASH_BYTES = 256 * 1024 * 1024
+FREE_SPACE_MARGIN = 256 * 1024 * 1024
+
+
+def preserve(disk: str, stash: Path) -> Path | None:
+    """Copy EFI/APPLE off `disk` into `stash` before the disk is wiped.
+
+    Returns the stash path, or None when there was nothing to preserve or the
+    copy did not work out. Every mount is read-only: the source is never
+    written, only read out of the way.
+    """
+    try:
+        with ExitStack() as mounts:
+            candidates = []
+            for partition in _vfat_partitions(disk):
+                root = mounts.enter_context(_mounted_ro(partition))
+                if root and (root / APPLE_DIR).is_dir():
+                    candidates.append((partition, root / APPLE_DIR))
+
+            if not candidates:
+                info("› no Apple coprocessor firmware on the install disk")
+                return None
+
+            # More than one ESP can carry an EFI/APPLE; the one holding the
+            # firmware itself is the one worth keeping.
+            partition, source = max(
+                candidates, key=lambda found: (found[1] / FIRMWARE_DIR).is_dir()
+            )
+            return _stash(partition, source, stash)
+    except Exception as exc:  # noqa: BLE001 — never abort an install over this
+        info(f"› warning: could not preserve Apple coprocessor firmware: {exc}")
+        return None
+
+
+def restore(esp_root: Path, stash: Path) -> bool:
+    """Write the preserved folder back onto the freshly created ESP.
+
+    `esp_root` is the ESP as the live system sees it (the mount under the
+    install target), not the mountpoint the installed system will use.
+    """
+    if not stash.is_dir():
+        return False
+
+    destination = esp_root / APPLE_DIR
+    try:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(stash, destination, dirs_exist_ok=True)
+        capture(["sync"])
+
+        expected = _tree_size(stash)
+        written = _tree_size(destination)
+        if written != expected:
+            info(
+                f"› warning: Apple coprocessor firmware landed on {destination} "
+                f"as {written[0]} files / {written[1]} bytes, expected "
+                f"{expected[0]} / {expected[1]}"
+            )
+            return False
+    except Exception as exc:  # noqa: BLE001 — never abort an install over this
+        info(f"› warning: could not restore Apple coprocessor firmware: {exc}")
+        return False
+
+    info(
+        f"› restored Apple coprocessor firmware to {destination} "
+        f"({expected[0]} files, {expected[1] // 1024} KiB)"
+    )
+    return True
+
+
+def _stash(partition: str, source: Path, stash: Path) -> Path | None:
+    files, size = _tree_size(source)
+    stash.parent.mkdir(parents=True, exist_ok=True)
+    free = shutil.disk_usage(stash.parent).free
+    if size > MAX_STASH_BYTES or size + FREE_SPACE_MARGIN > free:
+        info(
+            f"› warning: not preserving Apple coprocessor firmware from "
+            f"{partition}: {size} bytes does not fit in the live system's "
+            f"memory ({free} bytes free)"
+        )
+        return None
+
+    if stash.exists():
+        shutil.rmtree(stash)
+    shutil.copytree(source, stash)
+    info(
+        f"› preserved Apple coprocessor firmware from {partition} "
+        f"({files} files, {size // 1024} KiB)"
+    )
+    return stash
+
+
+def _vfat_partitions(disk: str) -> list[str]:
+    """Partitions on `disk` that could be an ESP, in on-disk order."""
+    listing = capture(["lsblk", "-nrpo", "PATH,FSTYPE", disk])
+    partitions = []
+    for line in listing.stdout.splitlines():
+        fields = line.split()
+        if len(fields) == 2 and fields[1] == "vfat" and fields[0] != disk:
+            # This is handed to mount, so a byte lost in decoding it must stop
+            # the copy rather than mount something else.
+            partitions.append(require_text(fields[0], "the ESP device"))
+    return partitions
+
+
+@contextmanager
+def _mounted_ro(partition: str) -> Iterator[Path | None]:
+    """Mount `partition` read-only somewhere temporary, or yield None."""
+    with tempfile.TemporaryDirectory(prefix="omarchy-esp-") as mountpoint:
+        if capture(["mount", "-o", "ro", partition, mountpoint]).returncode != 0:
+            yield None
+            return
+        try:
+            yield Path(mountpoint)
+        finally:
+            capture(["umount", mountpoint])
+
+
+def _tree_size(root: Path) -> tuple[int, int]:
+    """(file count, total bytes) under `root` — what a restore must match."""
+    files = [path for path in root.rglob("*") if path.is_file()]
+    return len(files), sum(path.stat().st_size for path in files)

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -32,6 +32,7 @@ import time
 from dataclasses import replace
 from pathlib import Path
 
+from . import apple_efi
 from . import archinstall_adapter as arch
 from .command import capture, capture_identifier, require_text
 from .context import InstallContext
@@ -181,6 +182,9 @@ def prepare_live(ctx: InstallContext) -> None:
     else:
         disk = _install_disk(ctx)
         if disk:
+            # An Apple ESP carries the T1/T2 coprocessor's firmware, and the
+            # wipe below is the last moment it exists (omarchy#8271).
+            apple_efi.preserve(disk, _apple_efi_stash(ctx))
             info(f"› cleaning up holders on install disk: {disk}")
             subprocess.run(["omarchy-iso-cleanup-disk", disk], check=True)
 
@@ -189,6 +193,13 @@ def prepare_live(ctx: InstallContext) -> None:
         ctx.arch_config_path, ctx.creds_path
     )
     ctx.state["mirror_handler"] = arch.make_mirror_handler(offline=True)
+
+
+def _apple_efi_stash(ctx: InstallContext) -> Path:
+    """Where Apple's coprocessor firmware waits out the wipe: the state
+    directory, which is tmpfs on the live ISO and so survives the disk but
+    not the reboot."""
+    return ctx.state_dir / "apple-efi"
 
 
 def _install_disk(ctx: InstallContext) -> str | None:
@@ -358,9 +369,16 @@ def _install_limine_omarchy(ctx: InstallContext, installer, config) -> None:
         if not efi_partition.mountpoint:
             raise RuntimeError("EFI partition is not mounted")
 
+        esp_mount = str(efi_partition.mountpoint)
+
+        # The ESP is new and empty here; Apple's coprocessor firmware goes
+        # back on before anything else claims the partition. The mountpoint
+        # is the installed system's, so read it through the target.
+        apple_efi.restore(ctx.target / esp_mount.lstrip("/"), _apple_efi_stash(ctx))
+
         _install_limine_efi(
             ctx,
-            esp_mount=str(efi_partition.mountpoint),
+            esp_mount=esp_mount,
             disk=arch.parent_device_path(efi_partition.safe_dev_path),
             part=int(efi_partition.partn),
             removable=bootloader_removable,

--- a/test/unit/test_apple_efi.py
+++ b/test/unit/test_apple_efi.py
@@ -1,0 +1,181 @@
+#!/usr/bin/python
+
+"""Carrying EFI/APPLE across a wipe, without the disk or the mounts.
+
+The mount seam (`_mounted_ro`) is replaced with directories on disk, so these
+exercise the real copy, the real preference rule and the real verification —
+everything except the two commands that need a block device and root.
+"""
+
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "configs/airootfs/usr/share/omarchy-iso"))
+
+from orchestrator import apple_efi  # noqa: E402
+
+# What a Touch Bar Mac's ESP actually holds, small enough to write per test.
+FIRMWARE = {
+    "EFI/APPLE/EMBEDDEDOS/EmbeddedOSFirmware.im4p": b"\x00im4p" * 64,
+    "EFI/APPLE/EMBEDDEDOS/FDRData": b"fdr" * 32,
+    "EFI/APPLE/EXTENSIONS/Firmware.scap": b"scap" * 16,
+}
+OTHER_ESP = {"EFI/BOOT/BOOTX64.EFI": b"MZ", "EFI/Microsoft/Boot/bootmgfw.efi": b"MZ"}
+
+
+def write_tree(root: Path, files: dict) -> Path:
+    for name, contents in files.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(contents)
+    return root
+
+
+def read_tree(root: Path) -> dict:
+    return {
+        str(path.relative_to(root)): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+class AppleEfiTest(unittest.TestCase):
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.tmp = Path(directory.name)
+        self.stash = self.tmp / "state" / "apple-efi"
+
+        self.logged = []
+        self.patch("info", self.logged.append)
+
+    def esp(self, name: str, files: dict) -> Path:
+        """A directory standing in for a mounted ESP."""
+        return write_tree(self.tmp / name, files)
+
+    def fake_disk(self, partitions: dict) -> None:
+        """Make /dev/... names resolve to those directories instead of mounts.
+
+        A None stands for a partition that would not mount.
+        """
+        @contextmanager
+        def mounted(partition):
+            yield partitions[partition]
+
+        self.patch("_vfat_partitions", lambda disk: list(partitions))
+        self.patch("_mounted_ro", mounted)
+
+    def patch(self, name, replacement):
+        patcher = mock.patch.object(apple_efi, name, replacement)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def log(self) -> str:
+        return "\n".join(self.logged)
+
+    def test_the_firmware_folder_is_found_and_copied_off_the_disk(self):
+        self.fake_disk({"/dev/sda1": self.esp("sda1", FIRMWARE)})
+
+        self.assertEqual(apple_efi.preserve("/dev/sda", self.stash), self.stash)
+        self.assertEqual(
+            read_tree(self.stash),
+            {
+                "EMBEDDEDOS/EmbeddedOSFirmware.im4p": FIRMWARE[
+                    "EFI/APPLE/EMBEDDEDOS/EmbeddedOSFirmware.im4p"
+                ],
+                "EMBEDDEDOS/FDRData": FIRMWARE["EFI/APPLE/EMBEDDEDOS/FDRData"],
+                "EXTENSIONS/Firmware.scap": FIRMWARE["EFI/APPLE/EXTENSIONS/Firmware.scap"],
+            },
+        )
+        self.assertIn("preserved Apple coprocessor firmware", self.log())
+
+    def test_a_disk_with_no_apple_folder_is_left_alone(self):
+        self.fake_disk({"/dev/sda1": self.esp("sda1", OTHER_ESP)})
+
+        self.assertIsNone(apple_efi.preserve("/dev/sda", self.stash))
+        self.assertFalse(self.stash.exists())
+        self.assertEqual(len(self.logged), 1)
+        self.assertIn("no Apple coprocessor firmware", self.log())
+
+    def test_the_esp_holding_the_firmware_wins_over_one_that_only_looks_apple(self):
+        # A stale EFI/APPLE left by a macOS install that is no longer the one
+        # the Mac boots its coprocessor from.
+        decoy = self.esp("sda1", {"EFI/APPLE/README": b"stale"})
+        real = self.esp("sda2", FIRMWARE)
+        self.fake_disk({"/dev/sda1": decoy, "/dev/sda2": real})
+
+        apple_efi.preserve("/dev/sda", self.stash)
+
+        self.assertTrue((self.stash / "EMBEDDEDOS/FDRData").is_file())
+        self.assertFalse((self.stash / "README").exists())
+        self.assertIn("/dev/sda2", self.log())
+
+    def test_what_the_wipe_would_have_destroyed_is_on_the_new_esp(self):
+        self.fake_disk({"/dev/sda1": self.esp("sda1", FIRMWARE)})
+        apple_efi.preserve("/dev/sda", self.stash)
+
+        new_esp = self.tmp / "mnt" / "boot"
+        new_esp.mkdir(parents=True)
+
+        self.assertTrue(apple_efi.restore(new_esp, self.stash))
+        self.assertEqual(
+            read_tree(new_esp / "EFI/APPLE"),
+            read_tree(self.tmp / "sda1" / "EFI/APPLE"),
+        )
+        self.assertIn("restored Apple coprocessor firmware", self.log())
+
+    def test_nothing_preserved_means_nothing_written_to_the_new_esp(self):
+        new_esp = self.tmp / "mnt" / "boot"
+        new_esp.mkdir(parents=True)
+
+        self.assertFalse(apple_efi.restore(new_esp, self.stash))
+        self.assertEqual(read_tree(new_esp), {})
+
+    def test_a_short_restore_is_reported_rather_than_claimed(self):
+        self.fake_disk({"/dev/sda1": self.esp("sda1", FIRMWARE)})
+        apple_efi.preserve("/dev/sda", self.stash)
+        new_esp = self.tmp / "mnt" / "boot"
+        new_esp.mkdir(parents=True)
+
+        def half_a_copy(source, destination, dirs_exist_ok=False):
+            Path(destination).mkdir(parents=True, exist_ok=True)
+            (Path(destination) / "FDRData").write_bytes(b"truncated")
+
+        with mock.patch.object(apple_efi.shutil, "copytree", half_a_copy):
+            self.assertFalse(apple_efi.restore(new_esp, self.stash))
+
+        self.assertNotIn("restored Apple coprocessor firmware", self.log())
+        self.assertIn("warning", self.log())
+
+    def test_an_unreadable_source_warns_and_lets_the_install_continue(self):
+        self.fake_disk({"/dev/sda1": self.esp("sda1", FIRMWARE)})
+
+        with mock.patch.object(
+            apple_efi.shutil, "copytree", side_effect=PermissionError("EFI/APPLE")
+        ):
+            self.assertIsNone(apple_efi.preserve("/dev/sda", self.stash))
+
+        self.assertIn("warning: could not preserve", self.log())
+
+    def test_a_folder_too_big_for_the_live_system_is_not_copied(self):
+        self.fake_disk({"/dev/sda1": self.esp("sda1", FIRMWARE)})
+        self.patch("MAX_STASH_BYTES", 8)
+
+        self.assertIsNone(apple_efi.preserve("/dev/sda", self.stash))
+        self.assertFalse(self.stash.exists())
+        self.assertIn("warning: not preserving", self.log())
+
+    def test_a_partition_that_will_not_mount_is_skipped(self):
+        self.fake_disk({"/dev/sda1": None, "/dev/sda2": self.esp("sda2", FIRMWARE)})
+
+        self.assertEqual(apple_efi.preserve("/dev/sda", self.stash), self.stash)
+        self.assertIn("/dev/sda2", self.log())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The problem

On 2016/2017 Touch Bar MacBook Pros the T1 coprocessor holds no firmware of its own: the Mac loads it from `EFI/APPLE/EMBEDDEDOS` on the EFI System Partition at every boot. The Touch Bar, Touch ID and the FaceTime camera are all behind that chip.

A full-disk install recreates the ESP and the folder goes with it. The install succeeds and the machine boots fine, so nothing points at the installer — but those three pieces of hardware are dead until macOS is reinstalled to write the folder back. Reported as basecamp/omarchy#8271, "Installer erases T1/T2 firmware on Apple hardware, permanently disabling Touch Bar / camera / Touch ID". [t1bridge](https://github.com/standardagents/t1bridge) tells users to back the folder up by hand before installing Linux, which only helps the people who read that first.

## What this does

Two hooks around the existing flow, in a new `orchestrator/apple_efi.py`:

- `prepare_live`, before `omarchy-iso-cleanup-disk` touches the install disk: mount each vfat partition on that disk read-only, and copy `EFI/APPLE` into the state directory (tmpfs on the live ISO). Logs `preserved Apple coprocessor firmware`.
- `_install_limine_omarchy`, after the new ESP is mounted under the target and before Limine is installed on it: copy the folder back and check file count and total size against the copy. Logs `restored Apple coprocessor firmware`.

Details worth calling out:

- The folder is the only signal — no DMI model list to keep up to date. A disk that has one gets it preserved; a disk that has none costs one read-only mount of partitions the installer is about to erase, and logs one line.
- More than one ESP on the disk: the one holding `EFI/APPLE/EMBEDDEDOS` wins over one that merely has an `EFI/APPLE`.
- The source is only ever mounted read-only, and the copy lives in RAM because the disk it came from is the one being wiped. Size is checked against free memory first (the real folder is a few MB) and bounded.
- Every failure path — no folder, a partition that will not mount, a copy error, a restore that does not verify — logs and returns. Nothing here can abort an install. A machine that boots with a dead Touch Bar is today's outcome; an install stopped over a firmware copy would be worse than the bug.

## What it does not do

- Protected / pre-mounted installs are untouched: they do not wipe the ESP, so the folder is already safe.
- It preserves only `EFI/APPLE`. Nothing else on the old ESP is kept, and nothing is written to the source.
- It cannot recover a folder already lost to an earlier install — this only helps installs that still have one to copy.
- It does not make the Touch Bar work on Linux; it keeps the firmware the hardware needs from being destroyed.

## Testing

`./test/all` passes: 72 Python tests, including nine new ones in `test/unit/test_apple_efi.py` covering detection on a fake ESP tree, the silent skip when no folder is present, the preserve/restore round trip with content verification, the ESP preference rule, a partition that will not mount, an oversized folder, a short restore, and a copy failure warning without raising. The mount seam is replaced with directories, so the tests run unprivileged.

The QEMU integration scenarios under `test/integration.d/` were not run: they need a built ISO and a VM, which is out of reach here.

This has not been exercised on a real T1 install yet. I will test it on a MacBookPro14,3 and report back with the install log.

## Open questions

- The restore hook writes to `ctx.target / esp_mount.lstrip("/")` because `efi_partition.mountpoint` is the installed system's mountpoint (`/boot`), matching what `_install_limine_efi` and `_write_limine_defaults` already do. Worth a check that this is the right handle on the ESP at that point in the phase.
- The stash lives in `ctx.state_dir`, which is tmpfs on the live ISO but is overridable via `OMARCHY_INSTALL_STATE_DIR`. Happy to hard-code a `/run` path instead if that is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
