### PR TITLE
Offer and install the server edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ For local development, build the ISO from sibling checkouts:
 
 Despite the local folder name, the first argument is the Omarchy source checkout (runtime commands, configs, setup scripts, themes, shell, migrations). The installer itself lives in this ISO repo.
 
+Pass `--label <name>` to tag the filename, which is how you tell two builds of the same channel apart. The label lands after the channel suffix, so `--label server` on a `--local-source` build produces `omarchy-<date>-x86_64-local-server.iso`. It names the build rather than the medium, since one ISO carries both editions and the Configurator asks which to install.
+
 Use `--dev` or `--rc` to build against those package channels. Both `--dev` and `--edge` select the dev packages from the edge mirror.
 
 ## Autoinstall

--- a/README.md
+++ b/README.md
@@ -40,13 +40,15 @@ These are the configurator's own output files, so the way to get a starting set 
 
 | File | Required | Purpose |
 |------|----------|---------|
-| `user_configuration.json` | Yes | archinstall config: disk, hostname, timezone, keyboard |
+| `user_configuration.json` | Yes | archinstall config: disk, hostname, timezone, keyboard, and `omarchy_install.edition` |
 | `user_credentials.json` | Yes | Username and password hash |
 | `user_full_name.txt` | No | Git full name |
 | `user_email_address.txt` | No | Git email |
 | `user_encrypt_installation.txt` | No | `true` when `user_configuration.json` carries a `disk_encryption` block; defaults to false |
 | `authorized_keys` | No | SSH public keys in sshd's own format, one per line |
 | `tailscale_authkey` | No | Tailscale auth key; the machine joins your tailnet on first boot |
+
+Set `omarchy_install.edition` to `"server"` for a headless install: no compositor, no session, SSH as the way in, and the BBS greeting on the console. It defaults to `"desktop"`, so a configuration written before the server edition existed installs exactly what it always did. Anything else is refused rather than assumed.
 
 Both required files must be present or the installer falls back to the configurator. Generate the password hash for `user_credentials.json` with `openssl passwd -6 "yourpassword"`.
 

--- a/bin/omarchy-iso-make
+++ b/bin/omarchy-iso-make
@@ -4,6 +4,7 @@ set -e
 
 NO_CACHE=""
 KEEP_PKG_CACHE=""
+ISO_LABEL=""
 LOCAL_OMARCHY_PATH=""
 LOCAL_PKGS_PATH=""
 while [[ $# -gt 0 ]]; do
@@ -19,6 +20,18 @@ while [[ $# -gt 0 ]]; do
   --no-boot-offer)
     NO_BOOT_OFFER=1
     shift
+    ;;
+  --label)
+    ISO_LABEL="${2:-}"
+    if [[ -z $ISO_LABEL ]]; then
+      echo "Error: --label requires a name" >&2
+      exit 1
+    fi
+    if [[ ! $ISO_LABEL =~ ^[A-Za-z0-9._-]+$ ]]; then
+      echo "Error: --label may only contain letters, digits, dots, dashes and underscores" >&2
+      exit 1
+    fi
+    shift 2
     ;;
   --debug)
     OMARCHY_INSTALL_DEBUG=1
@@ -57,7 +70,7 @@ while [[ $# -gt 0 ]]; do
     ;;
   *)
     echo "Unknown option: $1"
-    echo "Usage: $0 [--no-cache] [--keep-pkg-cache] [--no-boot-offer] [--debug] [--edge] [--dev|--rc] [--local-source <omarchy-checkout> <pkgs-checkout>]"
+    echo "Usage: $0 [--no-cache] [--keep-pkg-cache] [--no-boot-offer] [--debug] [--edge] [--dev|--rc] [--label <name>] [--local-source <omarchy-checkout> <pkgs-checkout>]"
     exit 1
     ;;
   esac
@@ -169,7 +182,10 @@ fi
 "${DOCKER[@]}" run "${DOCKER_ARGS[@]}" archlinux/archlinux:latest /$BUILD_SCRIPT
 
 latest_iso=$(\ls -t "$BUILD_RELEASE_PATH"/*.iso | head -n1)
-iso_ref="${latest_iso%.*}-$OMARCHY_ISO_REF.iso"
+# --label distinguishes builds that share a channel, which every local build
+# does. It names the build, not the medium: one ISO carries both editions and
+# the Configurator asks which to install.
+iso_ref="${latest_iso%.*}-$OMARCHY_ISO_REF${ISO_LABEL:+-$ISO_LABEL}.iso"
 mv -f "$latest_iso" "$iso_ref"
 
 if [[ -z "${NO_BOOT_OFFER:-}" ]]; then

--- a/builder/build-iso.sh
+++ b/builder/build-iso.sh
@@ -140,6 +140,7 @@ sed -i -E '/^(linux|broadcom-wl)$/d' "$build_cache_dir/packages.x86_64"
 # pulls the published omarchy* from the network mirror like any other package.
 if [[ -d /omarchy-source ]]; then
   base_pkg_lists=(/omarchy-source/install/omarchy-base.packages /omarchy-source/install/omarchy-other.packages)
+  server_pkg_list=/omarchy-source/install/omarchy-server.packages
   setup_form=/omarchy-source/install/provisioning/setup-form.sh
 else
   # Pull the same package lists out of the freshly-downloaded Omarchy runtime
@@ -156,6 +157,11 @@ else
   mkdir -p /tmp/omarchy-pkglists
   bsdtar -xf "$omarchy_pkg" -C /tmp/omarchy-pkglists usr/share/omarchy/install/omarchy-base.packages usr/share/omarchy/install/omarchy-other.packages
   base_pkg_lists=(/tmp/omarchy-pkglists/usr/share/omarchy/install/omarchy-base.packages /tmp/omarchy-pkglists/usr/share/omarchy/install/omarchy-other.packages)
+  # Extracted on its own and tolerating a miss, like the setup form below: a
+  # runtime predating the server edition ships no such list, and that is a
+  # desktop-only ISO rather than a build failure.
+  bsdtar -xf "$omarchy_pkg" -C /tmp/omarchy-pkglists usr/share/omarchy/install/omarchy-server.packages 2>/dev/null || true
+  server_pkg_list=/tmp/omarchy-pkglists/usr/share/omarchy/install/omarchy-server.packages
   # Extracted on its own, tolerating a miss: bsdtar exits non-zero for a member
   # it can't find, so asking for this alongside the package lists would abort the
   # build here (set -e) with a bare "Not found in archive" instead of the
@@ -167,6 +173,14 @@ fi
 mkdir -p "$build_cache_dir/airootfs/usr/share/omarchy-iso"
 cp "${base_pkg_lists[0]}" "$build_cache_dir/airootfs/usr/share/omarchy-iso/omarchy-base.packages"
 cp "${base_pkg_lists[1]}" "$build_cache_dir/airootfs/usr/share/omarchy-iso/omarchy-other.packages"
+
+# The installer reads this when the caller chose the server edition. Without it
+# on the medium, a server install has no list to pacstrap.
+if [[ -f $server_pkg_list ]]; then
+  cp "$server_pkg_list" "$build_cache_dir/airootfs/usr/share/omarchy-iso/omarchy-server.packages"
+else
+  echo "WARNING: no omarchy-server.packages in this runtime; the ISO will offer no server edition." >&2
+fi
 
 # The configurator's setup form comes from the runtime this ISO bundles, so the
 # installer and the first-boot setup that finishes a deferred install can never
@@ -193,6 +207,11 @@ mapfile -t all_packages < <(
   {
     cat "$build_cache_dir/packages.x86_64"
     grep -hv '^#\|^$' "${base_pkg_lists[@]}"
+    # Mostly a subset of the base list, but not entirely: openssh, rsync and
+    # lazyjournal are the server edition's own, and the install is offline.
+    if [[ -f $server_pkg_list ]]; then
+      grep -hv '^#\|^$' "$server_pkg_list"
+    fi
     grep -hv '^#\|^$' /builder/archinstall.packages
     # Always include the selected Omarchy packages so the target install can
     # find the runtime and companion packages in the offline mirror.

--- a/builder/build-iso.sh
+++ b/builder/build-iso.sh
@@ -30,7 +30,9 @@ pacman --noconfirm -Sy archlinux-keyring
 # so this container can be months behind the mirror it installs from. A plain
 # -Sy install is then a partial upgrade — new packages linked against a glibc
 # the container doesn't have yet.
-pacman --noconfirm -Syu archiso git sudo base-devel jq grub imagemagick neovim nodejs npm tree-sitter-cli
+# go is for the packages built from source below, which makepkg will not
+# install itself: build-omarchy-packages.sh runs it with --nodeps.
+pacman --noconfirm -Syu archiso git sudo base-devel go jq grub imagemagick neovim nodejs npm tree-sitter-cli
 
 # Pre-import the omarchy signing key (so pacman trusts our [omarchy] repo
 # during the build without keyserver lookups).
@@ -99,9 +101,17 @@ fi
 # When --local-source is in effect, build omarchy* from the mounted source
 # trees and drop them in the offline mirror. Otherwise pacman -Syw below
 # downloads the published versions from the omarchy network mirror.
+: "${OMARCHY_LOCAL_EXTRA_PACKAGES:=lazyjournal}"
+export OMARCHY_LOCAL_EXTRA_PACKAGES
+
 if [[ -d /omarchy-source && -d /omarchy-pkgs ]]; then
   bash /builder/build-omarchy-packages.sh "$offline_mirror_dir"
   LOCAL_OMARCHY_BUILD=1
+  read -r -a local_built_packages <<<"$OMARCHY_LOCAL_EXTRA_PACKAGES"
+  local_built_packages=(
+    "$OMARCHY_RUNTIME_PACKAGE" "$OMARCHY_SETTINGS_PACKAGE" "$OMARCHY_NVIM_PACKAGE"
+    "${local_built_packages[@]}"
+  )
 fi
 
 # Node.js binary for offline mise install.
@@ -233,12 +243,12 @@ mapfile -t all_packages < <(
 # the mirror; strip them from the pacman -Syw list so it doesn't try to fetch
 # the published versions on top.
 if [[ -n ${LOCAL_OMARCHY_BUILD:-} ]]; then
+  exclude_args=()
+  for local_package_name in "${local_built_packages[@]}"; do
+    exclude_args+=(-e "$local_package_name")
+  done
   mapfile -t all_packages < <(
-    printf '%s\n' "${all_packages[@]}" |
-      grep -Fxv \
-        -e "$OMARCHY_RUNTIME_PACKAGE" \
-        -e "$OMARCHY_SETTINGS_PACKAGE" \
-        -e "$OMARCHY_NVIM_PACKAGE" || true
+    printf '%s\n' "${all_packages[@]}" | grep -Fxv "${exclude_args[@]}" || true
   )
 fi
 
@@ -274,8 +284,7 @@ mapfile -t required_package_files <<< "$resolved_package_files"
 # checkouts. Add those exact artifacts back to the keep-set after verifying
 # that the local build left exactly one file for each selected package name.
 if [[ -n ${LOCAL_OMARCHY_BUILD:-} ]]; then
-  for local_package_name in \
-    "$OMARCHY_RUNTIME_PACKAGE" "$OMARCHY_SETTINGS_PACKAGE" "$OMARCHY_NVIM_PACKAGE"; do
+  for local_package_name in "${local_built_packages[@]}"; do
     local_package_file=""
     for candidate in "$offline_mirror_dir/$local_package_name-"*.pkg.tar.*; do
       [[ -f $candidate && $candidate != *.sig ]] || continue

--- a/builder/build-omarchy-packages.sh
+++ b/builder/build-omarchy-packages.sh
@@ -36,11 +36,20 @@ pacman -Sy --noconfirm
 : "${OMARCHY_SETTINGS_PACKAGE:=omarchy-settings-dev}"
 : "${OMARCHY_NVIM_PACKAGE:=omarchy-nvim}"
 
+# The server edition's log door. Built here rather than downloaded because it
+# exists nowhere pacman can reach: the AUR is not a mirror, and the install is
+# offline. Anything else the server list needs and the published mirror lacks
+# belongs on this list too.
+: "${OMARCHY_LOCAL_EXTRA_PACKAGES:=lazyjournal}"
+
 packages=(
   "$OMARCHY_SETTINGS_PACKAGE"
   "$OMARCHY_RUNTIME_PACKAGE"
   "$OMARCHY_NVIM_PACKAGE"
 )
+
+read -r -a extra_packages <<<"$OMARCHY_LOCAL_EXTRA_PACKAGES"
+packages+=("${extra_packages[@]}")
 
 # Local-source packages must replace every cached build of the same package,
 # even when the checkout's generated pkgver sorts below a published build.

--- a/configs/airootfs/root/.automated_script.sh
+++ b/configs/airootfs/root/.automated_script.sh
@@ -111,6 +111,8 @@ if [[ -f /root/defer-provisioning ]] ||
   export OMARCHY_UI_DEFER_PROVISIONING=yes
 fi
 
+export OMARCHY_UI_EDITION="$(jq -r '.omarchy_install.edition // "desktop"' /root/user_configuration.json 2>/dev/null)"
+
 # The foreground dashboard is now the sole visible install UI owner. It starts
 # the actual installer as a non-interactive child, logs child output, waits for
 # completion, then renders the final installed-time/reboot prompt itself.

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -292,6 +292,7 @@ user_step() {
 
     # Add manual padding since gum table -p doesn't respect padding
     echo -e "Field,Value
+Edition,${edition_label:-Desktop}
 Username,$username
 Password,$(printf "%${#password}s" | tr ' ' '*')
 Full name,${full_name:-[Skipped]}
@@ -801,6 +802,7 @@ run_partition_execute() {
     "custom_commands": [],
     "omarchy_install": {
         "mode": "protected",
+        "edition": "$edition",
         "target_mount": "/mnt",
         "boot": {
             "esp_mount": "$esp_mount_in_target",
@@ -946,6 +948,29 @@ install_mode_form() {
   install_mode=$(gum choose --header "Select installation mode on $disk" "${choices[@]}") || abort
 }
 
+# Which Omarchy this machine becomes. Asked once, never toggled afterwards:
+# taking a compositor off an installed machine, or putting one on, is a
+# migration in both directions, so the answer is a reinstall.
+edition_step() {
+  local choice
+
+  step "Let's pick which Omarchy this machine runs..."
+  choice=$(gum choose --header "Select edition" \
+    "Desktop (Hyprland, apps, the full session)" \
+    "Server (headless, SSH, no desktop)") || abort
+
+  case "$choice" in
+    Server*)
+      edition="server"
+      edition_label="Server"
+      ;;
+    *)
+      edition="desktop"
+      edition_label="Desktop"
+      ;;
+  esac
+}
+
 confirm_disk_overwrite() {
   local mode="encrypted"
   local affirmative confirm_status
@@ -1039,14 +1064,21 @@ install_target="full_disk"
 # isn't measured against the transient 80-column boot console.
 wait_for_stable_terminal
 
+# Deferred provisioning never asks, and an autoinstall drive answers in its own
+# configuration file, so the flow needs a default that means "as before".
+edition="desktop"
+
 greeter
 
 keyboard_form
 
 # Normal install: keyboard (loaded above, so the LUKS passphrase is typed under
-# the right layout) → user → disk → install mode. The user step can unwind to
-# the keyboard screen and arm deferral there, hence the second check.
+# the right layout) → edition → user → disk → install mode. The user step can
+# unwind to the keyboard screen and arm deferral there, hence the second check.
 if ! $defer_provisioning; then
+  # Before the account, so the confirmation table at the end of the user step
+  # can show what was chosen.
+  edition_step
   user_step
 fi
 
@@ -1139,6 +1171,7 @@ cat <<-_EOF_ >user_configuration.json
     "custom_commands": [],
     "omarchy_install": {
         "mode": "full_disk",
+        "edition": "$edition",
         "defer_provisioning": $defer_provisioning,
         "target_mount": "/mnt",
         "boot": {

--- a/configs/airootfs/root/configurator
+++ b/configs/airootfs/root/configurator
@@ -281,12 +281,14 @@ user_step() {
   while true; do
     user_form && status=0 || status=$?
     if ((status != 0)); then
-      # Esc unwinds to the start of the form. Ctrl+C has no side channel in the
-      # user step (only the keyboard and disk screens give it a meaning), so it
-      # keeps its long-standing behaviour of ending the install.
+      # Esc unwinds to the start of the flow: keyboard, then edition, then the
+      # form again. Ctrl+C has no side channel in the user step (only the
+      # keyboard and disk screens give it a meaning), so it keeps its
+      # long-standing behaviour of ending the install.
       ((status == OMARCHY_FORM_BACK)) || abort
       keyboard_form
       $defer_provisioning && return 0
+      edition_step
       continue
     fi
 
@@ -308,6 +310,7 @@ Keyboard,$keyboard" |
     else
       keyboard_form
       $defer_provisioning && return 0
+      edition_step
     fi
   done
 }
@@ -948,8 +951,8 @@ install_mode_form() {
   install_mode=$(gum choose --header "Select installation mode on $disk" "${choices[@]}") || abort
 }
 
-# Which Omarchy this machine becomes. Asked once, never toggled afterwards:
-# taking a compositor off an installed machine, or putting one on, is a
+# Which Omarchy this machine becomes. Settled at install, never toggled on an
+# installed machine: taking a compositor off, or putting one on, is a
 # migration in both directions, so the answer is a reinstall.
 edition_step() {
   local choice

--- a/configs/airootfs/usr/local/bin/omarchy-install-dashboard
+++ b/configs/airootfs/usr/local/bin/omarchy-install-dashboard
@@ -24,6 +24,12 @@ INSTALL_CMD=("$@")
 TTY_PATH="${OMARCHY_DASHBOARD_TTY:-/dev/tty}"
 LOGO_PATH="${OMARCHY_PATH:-/usr/share/omarchy}/logo.txt"
 
+if [[ ${OMARCHY_UI_EDITION:-desktop} == "server" ]]; then
+  INSTALL_TITLE="Installing Omarchy Server"
+else
+  INSTALL_TITLE="Installing Omarchy"
+fi
+
 # Autoinstall has no one at the keyboard, and every prompt this dashboard owns
 # reads from the TTY, so each would hang forever. Suppress them here rather than
 # in the scripts they live in: this process is the only owner of the visible UI.
@@ -452,7 +458,7 @@ render_dynamic() {
   LAST_PM=$pm
 
   printf '%s%d;1H' "$CSI" "$DYNAMIC_ROW"
-  center "Installing Omarchy" "$CONTENT_WIDTH"
+  center "$INSTALL_TITLE" "$CONTENT_WIDTH"
   blank_line
   line_at "$CONTENT_WIDTH" $(( (CONTENT_WIDTH - 34) / 2 )) ""
   progress_bar "$pm" 34

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/context.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/context.py
@@ -21,6 +21,7 @@ class InstallContext:
     encrypt: bool
     authorized_keys_path: Path | None
     tailscale_authkey_path: Path | None
+    edition: str
 
     user_configuration: dict
     user_credentials: dict
@@ -57,6 +58,17 @@ class InstallContext:
         defer_provisioning_marker = _optional_path(os.environ.get("OMARCHY_INSTALL_DEFER_PROVISIONING_FILE"))
         defer_provisioning = bool(omarchy_install.get("defer_provisioning")) or defer_provisioning_marker is not None
         omarchy_install["defer_provisioning"] = defer_provisioning
+
+        # Edition: which Omarchy this machine becomes. Chosen in the
+        # configurator, or set in user_configuration.json by an autoinstall
+        # drive. Anything unrecognised is refused rather than assumed, because
+        # the wrong answer installs the wrong operating system.
+        edition = str(omarchy_install.get("edition") or "desktop").strip().lower()
+        if edition not in ("desktop", "server"):
+            raise RuntimeError(
+                f"omarchy_install.edition must be 'desktop' or 'server', not {edition!r}"
+            )
+        omarchy_install["edition"] = edition
 
         if creds_path.exists():
             user_credentials = json.loads(creds_path.read_text())
@@ -109,6 +121,7 @@ class InstallContext:
             encrypt=_read_text(os.environ.get("OMARCHY_INSTALL_ENCRYPT_FILE")).lower() in ("true", "yes", "1"),
             authorized_keys_path=_optional_path(os.environ.get("OMARCHY_INSTALL_AUTHORIZED_KEYS_FILE")),
             tailscale_authkey_path=_optional_path(os.environ.get("OMARCHY_INSTALL_TAILSCALE_AUTHKEY_FILE")),
+            edition=edition,
             user_configuration=user_configuration,
             user_credentials=user_credentials,
             arch_config_path=arch_config_path,
@@ -180,6 +193,7 @@ def _default_omarchy_install(user_configuration: dict) -> dict[str, Any]:
     mode = "protected" if disk_config.get("config_type") == "pre_mounted_config" else "full_disk"
     return {
         "mode": mode,
+        "edition": "desktop",
         "target_mount": disk_config.get("mountpoint") or "/mnt",
         "boot": {
             "esp_mount": "/boot",

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -723,10 +723,19 @@ def _unmask_mkinitcpio_pacman_hooks(
             info(f"warning: failed to restore pacman hook mask for {name}: {exc}")
 
 
+def _edition_package_list_path(ctx: InstallContext) -> Path:
+    """The package list the chosen edition installs. The server list is the
+    base list minus the desktop, so a machine that asked for a server never
+    pacstraps a compositor it would then have to be told to ignore."""
+    if ctx.edition == "server":
+        return Path("/usr/share/omarchy-iso/omarchy-server.packages")
+    return Path("/usr/share/omarchy-iso/omarchy-base.packages")
+
+
 def _runtime_package_list(ctx: InstallContext) -> list[str]:
     """Selected Omarchy runtime package + every package in the ISO-bundled
-    base package list that isn't already installed early."""
-    base_pkgs_file = Path("/usr/share/omarchy-iso/omarchy-base.packages")
+    package list for this edition that isn't already installed early."""
+    base_pkgs_file = _edition_package_list_path(ctx)
     pkgs = [_omarchy_runtime_package()]
     already_installed = set(_early_packages()) | {
         _omarchy_runtime_package(),
@@ -1087,6 +1096,7 @@ def _run_target_setup_command(ctx: InstallContext, cmd: list[str], *, user: str 
     env_extras = [
         "OMARCHY_PATH=/usr/share/omarchy",
         "OMARCHY_INSTALL=/usr/share/omarchy/install",
+        f"OMARCHY_EDITION={ctx.edition}",
         f"OMARCHY_INSTALL_USER={ctx.username}",
         f"OMARCHY_START_TIME={omarchy_start_time}",
         f"OMARCHY_START_EPOCH={omarchy_start_epoch}",
@@ -1129,7 +1139,24 @@ def _run_target_setup_command(ctx: InstallContext, cmd: list[str], *, user: str 
                 pass
 
 
+def _write_edition_marker(ctx: InstallContext) -> None:
+    """Stamp the target with the edition it was installed as.
+
+    Written before omarchy-apply-system runs, because that is the first thing to
+    read it: the install steps that configure a login manager, a lock screen and
+    a printing stack all gate on this file, and the packages behind them are not
+    there on a server.
+    """
+    marker = ctx.target / "etc" / "omarchy-edition"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(f"{ctx.edition}\n")
+    marker.chmod(0o644)
+    info(f"› edition: {ctx.edition}")
+
+
 def run_system_finalizer(ctx: InstallContext) -> None:
+    _write_edition_marker(ctx)
+
     if ctx.defer_provisioning:
         cmd = ["/usr/bin/omarchy-apply-system", "--defer-provisioning", "--first-install"]
     else:
@@ -1401,6 +1428,12 @@ def _read_omarchy_mirror() -> str:
 # ─────────────────────────────────────────────────────────────────────────────
 
 def configure_login(ctx: InstallContext) -> None:
+    # A server has no display manager to theme and no session to autologin into.
+    # It boots to a getty, and the BBS greeting is what meets the caller there.
+    if ctx.edition == "server":
+        info("› server edition: no display manager to configure")
+        return
+
     sddm_dir = ctx.target / "etc" / "sddm.conf.d"
     sddm_dir.mkdir(parents=True, exist_ok=True)
     (sddm_dir / "99-omarchy-login.conf").write_text(

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -1428,10 +1428,21 @@ def _read_omarchy_mirror() -> str:
 # ─────────────────────────────────────────────────────────────────────────────
 
 def configure_login(ctx: InstallContext) -> None:
-    # A server has no display manager to theme and no session to autologin into.
-    # It boots to a getty, and the BBS greeting is what meets the caller there.
+    # A server boots to a getty, so its equivalent of the desktop's encrypted
+    # autologin is an agetty --autologin drop-in on tty1.
     if ctx.edition == "server":
-        info("› server edition: no display manager to configure")
+        autologin = ctx.target / "etc" / "systemd" / "system" / "getty@tty1.service.d" / "autologin.conf"
+        if ctx.encrypt and not ctx.defer_provisioning:
+            info(f"› autologin {ctx.username} on tty1 behind the LUKS prompt")
+            autologin.parent.mkdir(parents=True, exist_ok=True)
+            autologin.write_text(
+                "[Service]\n"
+                "ExecStart=\n"
+                f"ExecStart=-/sbin/agetty -o '-p -f -- \\\\u' --noclear --autologin {ctx.username} %I $TERM\n"
+            )
+        else:
+            info("› server edition: getty login stays the auth screen")
+            autologin.unlink(missing_ok=True)
         return
 
     sddm_dir = ctx.target / "etc" / "sddm.conf.d"

--- a/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
+++ b/configs/airootfs/usr/share/omarchy-iso/orchestrator/phases_impl.py
@@ -1482,12 +1482,14 @@ def configure_login(ctx: InstallContext) -> None:
 # ─────────────────────────────────────────────────────────────────────────────
 
 def configure_ssh_access(ctx: InstallContext) -> None:
-    if ctx.authorized_keys_path is None:
+    # A server without SSH is unreachable, so the door opens even when no keys
+    # were given; password auth over the console-set password remains.
+    if ctx.authorized_keys_path is None and ctx.edition != "server":
         return
 
-    keys = _authorized_keys(ctx.authorized_keys_path)
+    keys = [] if ctx.authorized_keys_path is None else _authorized_keys(ctx.authorized_keys_path)
 
-    if ctx.defer_provisioning:
+    if keys and ctx.defer_provisioning:
         # No user to authorize yet. Stage the keys in provisioning state for
         # omarchy-provision-owner to install once first boot creates the owner, and
         # still open the door (sshd + ufw) below.
@@ -1497,7 +1499,7 @@ def configure_ssh_access(ctx: InstallContext) -> None:
         staged = provisioning_dir / "authorized_keys"
         staged.write_text("".join(f"{key}\n" for key in keys))
         staged.chmod(0o600)
-    else:
+    elif keys:
         info(f"› installing {len(keys)} SSH key(s) for {ctx.username}")
 
         ssh_dir = ctx.target / "home" / ctx.username / ".ssh"

--- a/test/unit/test_configure_ssh_access.py
+++ b/test/unit/test_configure_ssh_access.py
@@ -55,12 +55,12 @@ class ConfigureSshAccessTest(unittest.TestCase):
             return CompletedProcess(cmd, 1)
         return CompletedProcess(cmd, 0)
 
-    def ctx(self, authorized_keys=None):
+    def ctx(self, authorized_keys=None, edition="desktop"):
         authorized_keys_path = None
         if authorized_keys is not None:
             authorized_keys_path = self.target / "authorized_keys"
             authorized_keys_path.write_text(authorized_keys)
-        return types.SimpleNamespace(target=self.target, username="jeff", authorized_keys_path=authorized_keys_path, defer_provisioning=False)
+        return types.SimpleNamespace(target=self.target, username="jeff", authorized_keys_path=authorized_keys_path, defer_provisioning=False, edition=edition)
 
     def configure(self, **kwargs):
         phases_impl.configure_ssh_access(self.ctx(**kwargs))
@@ -74,6 +74,13 @@ class ConfigureSshAccessTest(unittest.TestCase):
     def test_no_authorized_keys_is_a_no_op(self):
         self.configure()
         self.assertEqual(self.calls, [])
+        self.assertFalse((self.target / "home" / "jeff" / ".ssh").exists())
+
+    def test_server_edition_opens_ssh_even_with_no_keys(self):
+        self.configure(edition="server")
+        self.assertEqual(self.chrooted("systemctl"),
+                         [["arch-chroot", str(self.target), "systemctl", "enable", "sshd.service"]])
+        self.assertEqual(len(self.chrooted("ufw")), 1)
         self.assertFalse((self.target / "home" / "jeff" / ".ssh").exists())
 
     def test_installs_keys_one_per_line(self):

--- a/test/unit/test_provisioning_state.py
+++ b/test/unit/test_provisioning_state.py
@@ -168,6 +168,7 @@ def make_ctx(target, **overrides):
         user_credentials={"users": []},
         state_dir=target / "state",
         authorized_keys_path=None,
+        edition="desktop",
     )
     defaults.update(overrides)
     return types.SimpleNamespace(**defaults)

--- a/test/unit/test_provisioning_state.py
+++ b/test/unit/test_provisioning_state.py
@@ -294,6 +294,10 @@ class ConfigureLoginDeferProvisioningTest(unittest.TestCase):
         run_patch.start()
         self.addCleanup(run_patch.stop)
 
+        info_patch = mock.patch.object(phases_impl, "info")
+        info_patch.start()
+        self.addCleanup(info_patch.stop)
+
     def test_deferred_provisioning_login_leaves_user_state_to_first_boot(self):
         ctx = make_ctx(self.target, encrypt=True)
         phases_impl.configure_login(ctx)
@@ -311,6 +315,23 @@ class ConfigureLoginDeferProvisioningTest(unittest.TestCase):
         self.assertIn("User=jeff", autologin)
         state = (self.target / "var/lib/sddm/state.conf").read_text()
         self.assertIn("User=jeff", state)
+
+    def test_encrypted_server_login_autologs_in_on_tty1(self):
+        ctx = make_ctx(self.target, defer_provisioning=False, encrypt=True, username="jeff", edition="server")
+        phases_impl.configure_login(ctx)
+
+        drop_in = (self.target / "etc/systemd/system/getty@tty1.service.d/autologin.conf").read_text()
+        self.assertIn("ExecStart=\n", drop_in)
+        self.assertIn("--autologin jeff", drop_in)
+        self.assertFalse((self.target / "etc/sddm.conf.d").exists())
+        self.assertFalse(any("sddm.service" in cmd for cmd in self.calls))
+
+    def test_unencrypted_server_login_keeps_the_getty_prompt(self):
+        ctx = make_ctx(self.target, defer_provisioning=False, encrypt=False, username="jeff", edition="server")
+        phases_impl.configure_login(ctx)
+
+        self.assertFalse((self.target / "etc/systemd/system/getty@tty1.service.d/autologin.conf").exists())
+        self.assertFalse((self.target / "etc/sddm.conf.d").exists())
 
 
 class ConfigureSshAccessDeferProvisioningTest(unittest.TestCase):


### PR DESCRIPTION
Installer and ISO side of the server edition — companion to omacom/omarchy#11289 (which should land first: this branch installs the edition that PR ships).

## What's in here

**Configurator.** An edition screen — desktop or server — asked once during configuration. Both revise paths re-ask it, so picking the wrong edition no longer means restarting the installer. One ISO carries both editions; `--label` tags build filenames so two builds of the same channel stay distinguishable.

**Install dashboard.** A server install announces itself: "Installing Omarchy Server".

**SSH on from first boot.** `configure_ssh_access` used to no-op entirely when no authorized keys were supplied, leaving sshd disabled and port 22 closed on a machine whose only door is SSH. On the server edition the door now opens regardless — sshd enabled, ufw limit rule written — while key installation stays conditional on keys being given.

**Autologin behind LUKS.** Encrypted server installs get an agetty `--autologin` drop-in on tty1, mirroring the desktop's SDDM rule: the LUKS passphrase is the auth boundary, so login lands straight on the BBS splash. Unencrypted installs keep the getty prompt as their auth screen.

**Offline mirror.** lazyjournal added for the server menu's logs door (packaged in the companion omarchy-pkgs PR).

## Testing

- `./test/all` passes — 66 unit tests, including new coverage for the no-keys SSH path and both server login cases.
- Full QEMU install loops from a locally built ISO: edition revise flow, server banner, first-boot SSH reachability, and LUKS-to-splash autologin all verified.