### PR TITLE
Add CODEOWNERS requiring org owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Merges to protected branches need sign-off from an org owner.
+* @dhh @ryanrhughes


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning all paths to @dhh and @ryanrhughes, matching omarchy.

Pairs with the new "Require PR with owner review on quattro" ruleset (PR + 1 approval + code-owner review, org admins bypass). Until this merges, the code-owner requirement is vacuous and any write-level approval satisfies the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)