### PR TITLE
cidata: keep probing for the drive for a bounded time

### DIFF
--- a/configs/airootfs/usr/local/bin/omarchy-cidata-load
+++ b/configs/airootfs/usr/local/bin/omarchy-cidata-load
@@ -31,24 +31,36 @@ mnt=$root/run/cidata
 # Settling once is not enough for a USB stick that the host has not even
 # enumerated yet: some sticks (and some ports, notably on Intel Macs) take
 # several seconds to show up after the ISO's own stick has booted, and then
-# there is nothing in the queue to wait for. So poll for the label, settling
-# each round so a device that appears mid-wait gets its symlink, and give up
-# after OMARCHY_CIDATA_WAIT seconds (default 10). A boot without a cidata
-# drive pays that wait once; a drive that is already there costs nothing.
+# there is nothing in the queue to wait for. So poll for the label and give
+# up after OMARCHY_CIDATA_WAIT whole seconds (default 10). A boot without a
+# cidata drive pays that wait once; a drive that is already there costs
+# nothing.
+#
+# The budget is wall-clock and it includes udev: every settle is capped at
+# what is left of it (a stuck queue would otherwise block for udevadm's own
+# 120 s default), and the loop also stops after the number of 0.5 s steps
+# the budget allows, so it terminates even where the clock is coarse.
 wait_max=${OMARCHY_CIDATA_WAIT:-10}
-wait_step=0.5
-waited=0
+if [[ ! $wait_max =~ ^[0-9]+$ ]]; then
+  echo "omarchy-cidata-load: OMARCHY_CIDATA_WAIT='$wait_max' is not a whole number of seconds; using 10" >&2
+  wait_max=10
+fi
+wait_max=$((10#$wait_max))
+deadline=$((SECONDS + wait_max))
+steps=$((wait_max * 2))
 device=""
-while :; do
-  udevadm settle 2>/dev/null || true
+for ((i = 0; ; i++)); do
+  remaining=$((deadline - SECONDS))
+  by_steps=$(((steps - i) / 2))
+  ((remaining > by_steps)) && remaining=$by_steps
+  ((remaining < 0)) && remaining=0
+  udevadm settle --timeout="$remaining" 2>/dev/null || true
   for label in cidata CIDATA; do
     [[ -e $by_label/$label ]] && { device=$by_label/$label; break; }
   done
   [[ -n $device ]] && break
-  # bash has no float arithmetic; compare in tenths of a second
-  (( ${waited/./} + ${wait_step/./} > ${wait_max/./}0 )) 2>/dev/null && break
-  sleep "$wait_step"
-  waited=$(awk -v a="$waited" -v b="$wait_step" 'BEGIN { printf "%.1f", a + b }')
+  ((i >= steps || SECONDS >= deadline)) && break
+  sleep 0.5
 done
 [[ -n $device ]] || exit 1
 

--- a/configs/airootfs/usr/local/bin/omarchy-cidata-load
+++ b/configs/airootfs/usr/local/bin/omarchy-cidata-load
@@ -31,19 +31,38 @@ mnt=$root/run/cidata
 # Settling once is not enough for a USB stick that the host has not even
 # enumerated yet: some sticks (and some ports, notably on Intel Macs) take
 # several seconds to show up after the ISO's own stick has booted, and then
-# there is nothing in the queue to wait for. So poll for the label and give
-# up after OMARCHY_CIDATA_WAIT whole seconds (default 10). A boot without a
-# cidata drive pays that wait once; a drive that is already there costs
-# nothing.
+# there is nothing in the queue to wait for. So poll for the label for a
+# bounded time. A boot without a cidata drive pays that wait once; a drive
+# that is already there costs nothing.
 #
+# Only a boot from a USB stick can hit that race -- the stick that booted has
+# been enumerated, a second one may not have been -- so only a USB boot pays
+# a default wait, and a short one. A VM boots its ISO from a virtual CD or
+# disk that is there from the start, and the wizard on such a boot must not
+# get slower: its default is 0. OMARCHY_CIDATA_WAIT overrides either, in
+# whole seconds. The boot medium is found the way the configurator finds it
+# to keep it out of the disk picker: findmnt on the archiso mount, then up
+# to the whole disk.
+default_wait=0
+boot_source=$(findmnt -no SOURCE /run/archiso/bootmnt 2>/dev/null || true)
+if [[ -n $boot_source ]]; then
+  boot_dev=$(readlink -f "$boot_source" 2>/dev/null || printf '%s\n' "$boot_source")
+  while true; do
+    parent=$(lsblk -dno PKNAME "$boot_dev" 2>/dev/null | tail -n1)
+    [[ -n $parent ]] || break
+    boot_dev="/dev/$parent"
+  done
+  [[ $(lsblk -dno TRAN "$boot_dev" 2>/dev/null) == usb ]] && default_wait=3
+fi
+
 # The budget is wall-clock and it includes udev: every settle is capped at
 # what is left of it (a stuck queue would otherwise block for udevadm's own
 # 120 s default), and the loop also stops after the number of 0.5 s steps
 # the budget allows, so it terminates even where the clock is coarse.
-wait_max=${OMARCHY_CIDATA_WAIT:-10}
+wait_max=${OMARCHY_CIDATA_WAIT:-$default_wait}
 if [[ ! $wait_max =~ ^[0-9]+$ ]]; then
-  echo "omarchy-cidata-load: OMARCHY_CIDATA_WAIT='$wait_max' is not a whole number of seconds; using 10" >&2
-  wait_max=10
+  echo "omarchy-cidata-load: OMARCHY_CIDATA_WAIT='$wait_max' is not a whole number of seconds; using the default ($default_wait)" >&2
+  wait_max=$default_wait
 fi
 wait_max=$((10#$wait_max))
 deadline=$((SECONDS + wait_max))

--- a/configs/airootfs/usr/local/bin/omarchy-cidata-load
+++ b/configs/airootfs/usr/local/bin/omarchy-cidata-load
@@ -27,11 +27,28 @@ mnt=$root/run/cidata
 # The by-label symlinks come from udev, and on a fast boot this can run before
 # device enumeration has finished. Wait for the queue to drain instead of
 # racing it and silently dropping a headless install into the wizard.
-udevadm settle 2>/dev/null || true
-
+#
+# Settling once is not enough for a USB stick that the host has not even
+# enumerated yet: some sticks (and some ports, notably on Intel Macs) take
+# several seconds to show up after the ISO's own stick has booted, and then
+# there is nothing in the queue to wait for. So poll for the label, settling
+# each round so a device that appears mid-wait gets its symlink, and give up
+# after OMARCHY_CIDATA_WAIT seconds (default 10). A boot without a cidata
+# drive pays that wait once; a drive that is already there costs nothing.
+wait_max=${OMARCHY_CIDATA_WAIT:-10}
+wait_step=0.5
+waited=0
 device=""
-for label in cidata CIDATA; do
-  [[ -e $by_label/$label ]] && { device=$by_label/$label; break; }
+while :; do
+  udevadm settle 2>/dev/null || true
+  for label in cidata CIDATA; do
+    [[ -e $by_label/$label ]] && { device=$by_label/$label; break; }
+  done
+  [[ -n $device ]] && break
+  # bash has no float arithmetic; compare in tenths of a second
+  (( ${waited/./} + ${wait_step/./} > ${wait_max/./}0 )) 2>/dev/null && break
+  sleep "$wait_step"
+  waited=$(awk -v a="$waited" -v b="$wait_step" 'BEGIN { printf "%.1f", a + b }')
 done
 [[ -n $device ]] || exit 1
 

--- a/test/unit/cidata-load-test.sh
+++ b/test/unit/cidata-load-test.sh
@@ -36,7 +36,7 @@ printf 'udevadm %s\n' "$*" >>"$TEST_LOG"
 # slow USB stick enumerates a few seconds after the ISO stick has booted.
 if [[ -n ${LATE_ATTACH:-} ]]; then
   label=${LATE_ATTACH%%:*} nth=${LATE_ATTACH##*:}
-  if (( $(grep -c '^udevadm settle$' "$TEST_LOG") >= nth )) && [[ ! -e $LATE_ATTACH_DIR/$label ]]; then
+  if (( $(grep -c '^udevadm settle' "$TEST_LOG") >= nth )) && [[ ! -e $LATE_ATTACH_DIR/$label ]]; then
     ln -s "$LATE_ATTACH_MEDIA" "$LATE_ATTACH_DIR/$label"
   fi
 fi
@@ -93,7 +93,7 @@ pass "no drive falls back to the wizard"
 
 # The probe must wait for udev to finish enumerating before concluding there
 # is no drive.
-grep -q '^udevadm settle$' "$TEST_LOG" || fail "probe settles udev first"
+grep -q '^udevadm settle' "$TEST_LOG" || fail "probe settles udev first"
 pass "probe settles udev first"
 
 # ... and it must keep looking for a bounded time: a stick that has not been
@@ -115,6 +115,54 @@ LATE_ATTACH=cidata:4 run_load || fail "late drive loads"
 [[ -f $sandbox/root/user_configuration.json ]] || fail "late drive copies the configuration"
 (( $(grep -c '^sleep ' "$TEST_LOG") == 3 )) || fail "late drive stops the wait once found ($(grep -c '^sleep ' "$TEST_LOG") sleeps)"
 pass "a drive that enumerates late is found and the wait stops early"
+
+# Each settle is capped at what is left of the budget: the first one may use
+# all of it, the last one none. Otherwise a stuck udev queue could hold the
+# boot for udevadm's own default of 120 s per settle.
+new_sandbox
+! run_load || fail "no drive exits non-zero"
+first=$(grep -m1 '^udevadm settle' "$TEST_LOG"); last=$(grep '^udevadm settle' "$TEST_LOG" | tail -n1)
+[[ $first == 'udevadm settle --timeout=10' ]] || fail "first settle is capped at the whole budget (got '$first')"
+[[ $last == 'udevadm settle --timeout=0' ]] || fail "last settle is capped at nothing (got '$last')"
+pass "each settle is bounded by the remaining budget"
+
+# The budget is wall-clock, udev time included. With a settle that takes
+# 0.6 s of real time and a 1 s budget the probe must give up in about a
+# second, not after every scheduled step has run its slow settle.
+new_sandbox
+cat >"$stub_dir/udevadm" <<'STUB'
+#!/bin/bash
+printf 'udevadm %s\n' "$*" >>"$TEST_LOG"
+/bin/sleep 0.6
+STUB
+start=$SECONDS
+! OMARCHY_CIDATA_WAIT=1 run_load || fail "slow settle exits non-zero"
+elapsed=$((SECONDS - start))
+((elapsed <= 2)) || fail "1 s budget with 0.6 s settles took ${elapsed}s"
+pass "the budget includes udev time"
+# restore the fast stub for the remaining cases
+cat >"$stub_dir/udevadm" <<'STUB'
+#!/bin/bash
+printf 'udevadm %s\n' "$*" >>"$TEST_LOG"
+if [[ -n ${LATE_ATTACH:-} ]]; then
+  label=${LATE_ATTACH%%:*} nth=${LATE_ATTACH##*:}
+  if (( $(grep -c '^udevadm settle' "$TEST_LOG") >= nth )) && [[ ! -e $LATE_ATTACH_DIR/$label ]]; then
+    ln -s "$LATE_ATTACH_MEDIA" "$LATE_ATTACH_DIR/$label"
+  fi
+fi
+STUB
+
+# The override is whole seconds only. A fraction or garbage falls back to the
+# default with a note, and a leading zero is decimal, not octal -- neither may
+# turn into an endless loop that never reaches the wizard.
+new_sandbox
+! OMARCHY_CIDATA_WAIT=1.5 run_load 2>"$sandbox/stderr" || fail "fractional override exits non-zero"
+(( $(grep -c '^sleep ' "$TEST_LOG") == 20 )) || fail "fractional override falls back to the default"
+grep -q 'not a whole number' "$sandbox/stderr" || fail "fractional override is reported"
+new_sandbox
+! OMARCHY_CIDATA_WAIT=08 run_load 2>/dev/null || fail "leading-zero override exits non-zero"
+(( $(grep -c '^sleep ' "$TEST_LOG") == 16 )) || fail "08 means 8 s, not octal ($(grep -c '^sleep ' "$TEST_LOG") sleeps)"
+pass "the override is validated and read as decimal"
 
 # A drive that is there from the start costs no wait at all.
 new_sandbox

--- a/test/unit/cidata-load-test.sh
+++ b/test/unit/cidata-load-test.sh
@@ -32,6 +32,21 @@ mkdir -p "$stub_dir"
 cat >"$stub_dir/udevadm" <<'STUB'
 #!/bin/bash
 printf 'udevadm %s\n' "$*" >>"$TEST_LOG"
+# LATE_ATTACH=<label>:<n>: the drive "appears" on the n-th settle, the way a
+# slow USB stick enumerates a few seconds after the ISO stick has booted.
+if [[ -n ${LATE_ATTACH:-} ]]; then
+  label=${LATE_ATTACH%%:*} nth=${LATE_ATTACH##*:}
+  if (( $(grep -c '^udevadm settle$' "$TEST_LOG") >= nth )) && [[ ! -e $LATE_ATTACH_DIR/$label ]]; then
+    ln -s "$LATE_ATTACH_MEDIA" "$LATE_ATTACH_DIR/$label"
+  fi
+fi
+STUB
+
+# Real sleeps would make the timeout cases slow; log them instead so a case
+# can assert how long the probe was prepared to wait.
+cat >"$stub_dir/sleep" <<'STUB'
+#!/bin/bash
+printf 'sleep %s\n' "$*" >>"$TEST_LOG"
 STUB
 
 cat >"$stub_dir/mount" <<'STUB'
@@ -61,7 +76,8 @@ attach_drive() {
 }
 
 run_load() {
-  PATH="$stub_dir:$PATH" "$CIDATA_LOAD" "$sandbox"
+  PATH="$stub_dir:$PATH" LATE_ATTACH_DIR="$sandbox/dev/disk/by-label" LATE_ATTACH_MEDIA="$sandbox/media" \
+    "$CIDATA_LOAD" "$sandbox"
 }
 
 write_required_pair() {
@@ -79,6 +95,34 @@ pass "no drive falls back to the wizard"
 # is no drive.
 grep -q '^udevadm settle$' "$TEST_LOG" || fail "probe settles udev first"
 pass "probe settles udev first"
+
+# ... and it must keep looking for a bounded time: a stick that has not been
+# enumerated yet leaves nothing in the udev queue, so one settle proves
+# nothing. With no drive at all the wait is bounded by OMARCHY_CIDATA_WAIT.
+(( $(grep -c '^sleep ' "$TEST_LOG") == 20 )) || fail "no drive waits 10 s in 0.5 s steps by default ($(grep -c '^sleep ' "$TEST_LOG") sleeps)"
+pass "no drive gives up after the default 10 s"
+
+new_sandbox
+! OMARCHY_CIDATA_WAIT=0 run_load || fail "zero wait exits non-zero"
+(( $(grep -c '^sleep ' "$TEST_LOG") == 0 )) || fail "OMARCHY_CIDATA_WAIT=0 never sleeps"
+pass "OMARCHY_CIDATA_WAIT=0 checks exactly once"
+
+# A drive that enumerates late (on the 4th settle) is still picked up, and
+# the probe stops waiting as soon as it appears.
+new_sandbox
+write_required_pair
+LATE_ATTACH=cidata:4 run_load || fail "late drive loads"
+[[ -f $sandbox/root/user_configuration.json ]] || fail "late drive copies the configuration"
+(( $(grep -c '^sleep ' "$TEST_LOG") == 3 )) || fail "late drive stops the wait once found ($(grep -c '^sleep ' "$TEST_LOG") sleeps)"
+pass "a drive that enumerates late is found and the wait stops early"
+
+# A drive that is there from the start costs no wait at all.
+new_sandbox
+attach_drive cidata
+write_required_pair
+run_load || fail "present drive loads"
+! grep -q '^sleep ' "$TEST_LOG" || fail "present drive never sleeps"
+pass "a drive present at the first probe costs no wait"
 
 # A drive with the full file set: everything lands in /root and the drive is
 # unmounted afterwards.

--- a/test/unit/cidata-load-test.sh
+++ b/test/unit/cidata-load-test.sh
@@ -62,6 +62,23 @@ cat >"$stub_dir/umount" <<'STUB'
 printf 'umount %s\n' "$*" >>"$TEST_LOG"
 STUB
 
+# The boot-medium probe: findmnt names the archiso mount's device, lsblk walks
+# it up to the whole disk and reports its transport. boot_from sets both.
+cat >"$stub_dir/findmnt" <<'STUB'
+#!/bin/bash
+printf 'findmnt %s\n' "$*" >>"$TEST_LOG"
+[[ -n ${BOOT_SOURCE:-} ]] && printf '%s\n' "$BOOT_SOURCE"
+STUB
+cat >"$stub_dir/lsblk" <<'STUB'
+#!/bin/bash
+printf 'lsblk %s\n' "$*" >>"$TEST_LOG"
+case "$*" in
+  *PKNAME*) [[ -n ${BOOT_PARENT:-} && $3 != /dev/$BOOT_PARENT ]] && printf '%s\n' "$BOOT_PARENT" ;;
+  *TRAN*)   printf '%s\n' "${BOOT_TRAN:-}" ;;
+esac
+exit 0
+STUB
+
 chmod +x "$stub_dir"/*
 
 new_sandbox() {
@@ -74,6 +91,17 @@ new_sandbox() {
 attach_drive() {
   ln -s "$sandbox/media" "$sandbox/dev/disk/by-label/$1"
 }
+
+# usb: booted from a stick (partition on a USB disk); cdrom: a VM's virtual
+# CD; none: no archiso mount found at all.
+boot_from() {
+  case "$1" in
+    usb)   export BOOT_SOURCE=/dev/sda1 BOOT_PARENT=sda BOOT_TRAN=usb ;;
+    cdrom) export BOOT_SOURCE=/dev/sr0 BOOT_PARENT="" BOOT_TRAN=sata ;;
+    none)  export BOOT_SOURCE="" BOOT_PARENT="" BOOT_TRAN="" ;;
+  esac
+}
+boot_from none
 
 run_load() {
   PATH="$stub_dir:$PATH" LATE_ATTACH_DIR="$sandbox/dev/disk/by-label" LATE_ATTACH_MEDIA="$sandbox/media" \
@@ -96,20 +124,36 @@ pass "no drive falls back to the wizard"
 grep -q '^udevadm settle' "$TEST_LOG" || fail "probe settles udev first"
 pass "probe settles udev first"
 
-# ... and it must keep looking for a bounded time: a stick that has not been
-# enumerated yet leaves nothing in the udev queue, so one settle proves
-# nothing. With no drive at all the wait is bounded by OMARCHY_CIDATA_WAIT.
-(( $(grep -c '^sleep ' "$TEST_LOG") == 20 )) || fail "no drive waits 10 s in 0.5 s steps by default ($(grep -c '^sleep ' "$TEST_LOG") sleeps)"
-pass "no drive gives up after the default 10 s"
+# ... and on a USB boot it must keep looking for a bounded time: a stick
+# that has not been enumerated yet leaves nothing in the udev queue, so one
+# settle proves nothing. The default there is 3 s in 0.5 s steps.
+new_sandbox; boot_from usb
+! run_load || fail "usb boot, no drive exits non-zero"
+(( $(grep -c '^sleep ' "$TEST_LOG") == 6 )) || fail "usb boot waits 3 s by default ($(grep -c '^sleep ' "$TEST_LOG") sleeps)"
+grep -q '^findmnt -no SOURCE /run/archiso/bootmnt$' "$TEST_LOG" || fail "the boot medium is read from the archiso mount"
+grep -q '^lsblk -dno TRAN /dev/sda$' "$TEST_LOG" || fail "the transport is read from the whole disk, not the partition"
+pass "a USB boot without a drive gives up after 3 s"
 
-new_sandbox
+# Anything that is not a USB boot -- a VM's virtual CD, or no archiso mount
+# at all -- keeps the old behaviour: one look, no wait. The wizard on such a
+# boot must not get slower.
+new_sandbox; boot_from cdrom
+! run_load || fail "cdrom boot, no drive exits non-zero"
+! grep -q '^sleep ' "$TEST_LOG" || fail "a non-USB boot never sleeps"
+(( $(grep -c '^udevadm settle' "$TEST_LOG") == 1 )) || fail "a non-USB boot settles once"
+new_sandbox; boot_from none
+! run_load || fail "unknown boot medium, no drive exits non-zero"
+! grep -q '^sleep ' "$TEST_LOG" || fail "an unknown boot medium never sleeps"
+pass "a non-USB or unknown boot medium keeps the single probe"
+
+new_sandbox; boot_from usb
 ! OMARCHY_CIDATA_WAIT=0 run_load || fail "zero wait exits non-zero"
 (( $(grep -c '^sleep ' "$TEST_LOG") == 0 )) || fail "OMARCHY_CIDATA_WAIT=0 never sleeps"
-pass "OMARCHY_CIDATA_WAIT=0 checks exactly once"
+pass "OMARCHY_CIDATA_WAIT=0 checks exactly once even on USB"
 
 # A drive that enumerates late (on the 4th settle) is still picked up, and
 # the probe stops waiting as soon as it appears.
-new_sandbox
+new_sandbox; boot_from usb
 write_required_pair
 LATE_ATTACH=cidata:4 run_load || fail "late drive loads"
 [[ -f $sandbox/root/user_configuration.json ]] || fail "late drive copies the configuration"
@@ -120,7 +164,7 @@ pass "a drive that enumerates late is found and the wait stops early"
 # all of it, the last one none. Otherwise a stuck udev queue could hold the
 # boot for udevadm's own default of 120 s per settle.
 new_sandbox
-! run_load || fail "no drive exits non-zero"
+! OMARCHY_CIDATA_WAIT=10 run_load || fail "no drive exits non-zero"
 first=$(grep -m1 '^udevadm settle' "$TEST_LOG"); last=$(grep '^udevadm settle' "$TEST_LOG" | tail -n1)
 [[ $first == 'udevadm settle --timeout=10' ]] || fail "first settle is capped at the whole budget (got '$first')"
 [[ $last == 'udevadm settle --timeout=0' ]] || fail "last settle is capped at nothing (got '$last')"
@@ -155,17 +199,17 @@ STUB
 # The override is whole seconds only. A fraction or garbage falls back to the
 # default with a note, and a leading zero is decimal, not octal -- neither may
 # turn into an endless loop that never reaches the wizard.
-new_sandbox
+new_sandbox; boot_from usb
 ! OMARCHY_CIDATA_WAIT=1.5 run_load 2>"$sandbox/stderr" || fail "fractional override exits non-zero"
-(( $(grep -c '^sleep ' "$TEST_LOG") == 20 )) || fail "fractional override falls back to the default"
+(( $(grep -c '^sleep ' "$TEST_LOG") == 6 )) || fail "fractional override falls back to the medium's default"
 grep -q 'not a whole number' "$sandbox/stderr" || fail "fractional override is reported"
 new_sandbox
 ! OMARCHY_CIDATA_WAIT=08 run_load 2>/dev/null || fail "leading-zero override exits non-zero"
 (( $(grep -c '^sleep ' "$TEST_LOG") == 16 )) || fail "08 means 8 s, not octal ($(grep -c '^sleep ' "$TEST_LOG") sleeps)"
 pass "the override is validated and read as decimal"
 
-# A drive that is there from the start costs no wait at all.
-new_sandbox
+# A drive that is there from the start costs no wait at all, USB boot or not.
+new_sandbox; boot_from usb
 attach_drive cidata
 write_required_pair
 run_load || fail "present drive loads"


### PR DESCRIPTION
## Problem

`omarchy-cidata-load` settles udev once and looks for the `cidata`/`CIDATA` label once. That only waits for devices the kernel has already seen: a USB stick the host has not enumerated yet leaves nothing in the queue, so the loader concludes there is no drive and drops a headless install into the wizard.

Seen on an Intel MacBook Pro 16,2 booting the 4.0.3 ISO from one stick with the cidata files on a second: the wizard appeared; on a second console `omarchy-cidata-load` returned 0 a moment later, and re-running `/root/.automated_script.sh` completed the unattended install.

## Change

Poll for the label for a bounded time instead of looking once. The bound is wall-clock and includes udev: each `udevadm settle` is capped with `--timeout=` at what is left of the budget (a stuck queue would otherwise block for udevadm's 120 s default), and the loop also stops after the number of 0.5 s steps the budget allows.

Who pays, and how much, was the design question. Only a boot from a USB stick can hit the race, and the ordinary wizard install must not get slower, so:

| Boot medium | Default wait | Why |
|---|---|---|
| USB stick | 3 s | the only case where a second stick can still be enumerating |
| VM virtual CD/disk, or unknown | 0 (one probe, as today) | the cidata disk is virtual and present from the start |
| any, `OMARCHY_CIDATA_WAIT=N` set | N whole seconds | explicit override, validated, decimal |

The medium is found the way the configurator finds it to keep it out of the disk picker: `findmnt -no SOURCE /run/archiso/bootmnt`, `lsblk -dno PKNAME` up to the whole disk, `lsblk -dno TRAN`. A drive that is already present costs nothing on any medium. If 3 s is still too much for a wizard boot from USB, it is one constant.

Complementary to #154 and #155, which add `--cidata-dir` to the VM wrapper and the configurator and do not change the probe.

## Testing

`findmnt` and `lsblk` are stubbed like the other tools; the `udevadm` stub can plant the by-label symlink on the n-th settle, and a `sleep` stub logs instead of sleeping. The cases assert: a USB boot without a drive waits 3 s (6 steps) and reads the transport from the whole disk; a virtual-CD boot and an unknown medium settle once and never sleep; `OMARCHY_CIDATA_WAIT=0` checks exactly once even on USB; a drive that enumerates late (4th settle) is found and the wait stops as soon as it appears; each settle is capped at the remaining budget (first `--timeout=10`, last `--timeout=0`); a 0.6 s settle stub with a 1 s budget gives up within 2 s; `1.5` falls back to the medium's default with a note; `08` means eight seconds, not octal; a drive present from the start never sleeps.

`test/unit/cidata-load-test.sh`: 24 cases pass. `test/unit/install-media-diagnosis-test.sh` fails on macOS on pristine `quattro` as well, so it is unrelated. Hardware boot behaviour of an ISO built from this branch is not verified here.

Drafted with help from Claude Code; the reproduction and the tests were run locally.

