### PR TITLE
Skip the offline-mirror prefetch on an autoinstall

### DIFF
--- a/configs/airootfs/root/.automated_script.sh
+++ b/configs/airootfs/root/.automated_script.sh
@@ -86,18 +86,25 @@ warm_offline_mirror() {
   done < <(du -k "$mirror"/*.pkg.tar.zst 2>/dev/null | sort -rn)
 }
 
-warm_offline_mirror &
-warm_pid=$!
-trap 'kill "$warm_pid" 2>/dev/null' EXIT
-
 cd /root
 # Autoinstall: a cidata drive carrying the configurator's own output files
 # stands in for the wizard. omarchy-cidata-load copies them into /root and
 # everything downstream runs the ordinary path against ordinary inputs.
+#
+# The prefetch above pays off because the medium sits idle while the user
+# works through the wizard. An autoinstall has no wizard: the installer starts
+# reading the mirror at once, and a prefetch racing it on the same stick only
+# slows the orchestrator's own start-up (its Python imports come off that
+# stick too) -- seen as a long stay on the splash screen before the
+# dashboard appears. So warm the cache only when there is a wizard to hide
+# it behind.
 if /usr/local/bin/omarchy-cidata-load; then
   echo "Autoinstall configuration found on cidata drive; skipping the configurator."
   export OMARCHY_UI_INTERACTIVE=no
 else
+  warm_offline_mirror &
+  warm_pid=$!
+  trap 'kill "$warm_pid" 2>/dev/null' EXIT
   ./configurator
 fi
 

--- a/configs/airootfs/root/.automated_script.sh
+++ b/configs/airootfs/root/.automated_script.sh
@@ -91,13 +91,9 @@ cd /root
 # stands in for the wizard. omarchy-cidata-load copies them into /root and
 # everything downstream runs the ordinary path against ordinary inputs.
 #
-# The prefetch above pays off because the medium sits idle while the user
-# works through the wizard. An autoinstall has no wizard: the installer starts
-# reading the mirror at once, and a prefetch racing it on the same stick only
-# slows the orchestrator's own start-up (its Python imports come off that
-# stick too) -- seen as a long stay on the splash screen before the
-# dashboard appears. So warm the cache only when there is a wizard to hide
-# it behind.
+# An autoinstall using cidata has no wizard so the time spent in warm_offline_mirror 
+# is seen as a long stay on the splash screen before the dashboard appears. 
+# So warm the cache only when there is a wizard to hide it behind.
 if /usr/local/bin/omarchy-cidata-load; then
   echo "Autoinstall configuration found on cidata drive; skipping the configurator."
   export OMARCHY_UI_INTERACTIVE=no

--- a/configs/airootfs/root/.automated_script.sh
+++ b/configs/airootfs/root/.automated_script.sh
@@ -91,8 +91,8 @@ cd /root
 # stands in for the wizard. omarchy-cidata-load copies them into /root and
 # everything downstream runs the ordinary path against ordinary inputs.
 #
-# An autoinstall using cidata has no wizard so the time spent in warm_offline_mirror 
-# is seen as a long stay on the splash screen before the dashboard appears. 
+# An autoinstall using cidata has no wizard so the time spent in warm_offline_mirror
+# is seen as a long stay on the splash screen before the dashboard appears.
 # So warm the cache only when there is a wizard to hide it behind.
 if /usr/local/bin/omarchy-cidata-load; then
   echo "Autoinstall configuration found on cidata drive; skipping the configurator."


### PR DESCRIPTION
## Problem

`.automated_script.sh` starts `warm_offline_mirror &` before it looks for a cidata drive. The prefetch exists to use bandwidth the medium would otherwise have idle while the user works through the wizard. An autoinstall has no wizard: the installer starts reading the mirror at once, and the prefetch races it on the same stick, so the orchestrator's own start-up (its Python imports come off that stick too) crawls behind it.

Seen on an Intel MacBook Pro 16,2 with the 4.0.3 ISO and the cidata files on the boot stick: a long stay on the splash screen before the dashboard appeared. Not timed -- inferred from the script's ordering and the observed delay, so please verify on your rig.

## Change

Start the prefetch only on the wizard path, after the cidata check; the EXIT trap that reaps it moves with it. On an autoinstall the install reads the mirror once anyway, so the prefetch saves nothing there.

## Testing

`bash -n` and shellcheck pass; the file's existing `SC2155` warnings are unchanged. There is no unit test for `.automated_script.sh` (its coverage is the QEMU integration suite), and I could not build an ISO from this branch here.

Drafted with help from Claude Code; the observation is from a real install.
